### PR TITLE
fix(mcp): make get_context_profile hops schema Gemini-compatible

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -55,6 +55,18 @@ const REPO_REQUIRED_MSG =
   "REPOSKEIN_REPO_PATH (or REPOSKEIN_REPO_ID) must be set to use this tool. " +
   "Set REPOSKEIN_REPO_PATH to the root of the repository you want to work with.";
 
+// Exported for the regression test. `hops` MUST stay a bounded integer: a literal union
+// (z.union([z.literal(1), z.literal(2)])) serialises to JSON-Schema `anyOf:[{const:1},{const:2}]`,
+// which Gemini's tool-schema validator 400-rejects — and one bad tool declaration fails the
+// whole request, breaking every Gemini model whenever a reposkein tool is in the payload.
+export const getContextProfileInputSchema = {
+  node_id: z.string().optional(),
+  file_path: z.string().optional(),
+  name: z.string().optional(),
+  hops: z.number().int().min(1).max(2).optional(),
+  federated: z.boolean().optional(),
+};
+
 export async function main(): Promise<void> {
   const repoPath = process.env.REPOSKEIN_REPO_PATH;
   const repoId = resolveRepoId(repoPath, process.env.REPOSKEIN_REPO_ID);
@@ -87,13 +99,7 @@ export async function main(): Promise<void> {
       title: "Get context profile",
       description:
         "Resolve a function/class (by node_id, file_path+name, or name) and return its caller/callee neighborhood (hops 1-2) with inlined prose and an enrichment_needed list. Never guesses — returns candidates if a name is ambiguous. Pass federated:true to resolve and traverse across nested repos.",
-      inputSchema: {
-        node_id: z.string().optional(),
-        file_path: z.string().optional(),
-        name: z.string().optional(),
-        hops: z.union([z.literal(1), z.literal(2)]).optional(),
-        federated: z.boolean().optional(),
-      },
+      inputSchema: getContextProfileInputSchema,
     },
     async (args) => {
       if (!getContextProfile) {

--- a/mcp/test/getContextProfileSchema.test.ts
+++ b/mcp/test/getContextProfileSchema.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { getContextProfileInputSchema } from "../src/index.js";
+
+function findKey(node: unknown, key: string): unknown[] {
+  const hits: unknown[] = [];
+  const walk = (n: unknown): void => {
+    if (Array.isArray(n)) {
+      for (const v of n) walk(v);
+    } else if (n && typeof n === "object") {
+      for (const [k, v] of Object.entries(n)) {
+        if (k === key) hits.push(v);
+        walk(v);
+      }
+    }
+  };
+  walk(node);
+  return hits;
+}
+
+describe("get_context_profile input schema (Gemini tool-schema safety)", () => {
+  const jsonSchema = z.toJSONSchema(z.object(getContextProfileInputSchema));
+
+  it("serialises with no anyOf or oneOf", () => {
+    expect(findKey(jsonSchema, "anyOf")).toEqual([]);
+    expect(findKey(jsonSchema, "oneOf")).toEqual([]);
+  });
+
+  it("exposes hops as a bounded integer (1..2)", () => {
+    const hops = (
+      jsonSchema as {
+        properties: Record<string, { type?: string; minimum?: number; maximum?: number }>;
+      }
+    ).properties.hops;
+    expect(["integer", "number"]).toContain(hops.type);
+    expect(hops.minimum).toBe(1);
+    expect(hops.maximum).toBe(2);
+  });
+
+  it("accepts hops 1, 2, and omitted; rejects 0, 3, 1.5, and non-numbers", () => {
+    const schema = z.object(getContextProfileInputSchema);
+    expect(schema.safeParse({ hops: 1 }).success).toBe(true);
+    expect(schema.safeParse({ hops: 2 }).success).toBe(true);
+    expect(schema.safeParse({}).success).toBe(true);
+    expect(schema.safeParse({ hops: 0 }).success).toBe(false);
+    expect(schema.safeParse({ hops: 3 }).success).toBe(false);
+    expect(schema.safeParse({ hops: 1.5 }).success).toBe(false);
+    expect(schema.safeParse({ hops: "1" }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`get_context_profile`'s `hops` parameter was declared as `z.union([z.literal(1), z.literal(2)])`, which serialises to JSON Schema:

```json
"hops": { "anyOf": [{ "const": 1 }, { "const": 2 }] }
```

Gemini's function-declaration validator is far stricter than Anthropic's / OpenAI's: it rejects the numeric `const`/enum as a `TYPE_STRING` mismatch and returns **HTTP 400 on the entire request**. Because one malformed tool declaration fails the whole `tools` array, this single field broke **every Gemini model** (`gemini-3-flash` and `gemini-3.1-pro` alike) for any agent that had a reposkein tool in its payload. Anthropic and OpenAI silently tolerate the loose schema, so the breakage was Gemini-only — which made it look like a provider problem rather than a schema problem.

Observed error (opencode + the antigravity Gemini provider, inside a reposkein-loaded project):

```
Status: 400   Effective Model: gemini-3.1-pro-low
Invalid value at 'request.tools[0].function_declarations[N].parameters.properties[3].value.any_of[0].enum[0]' (TYPE_STRING), 1
Invalid value at '...any_of[1].enum[0]' (TYPE_STRING), 2
```

## Fix

Replace the literal union with a bounded integer, mirroring the `impact` tool's existing `depth` field:

```ts
hops: z.number().int().min(1).max(2).optional(),  // → { type: "integer", minimum: 1, maximum: 2 }
```

The handler is already typed `hops?: number` and coerces (`const hops = args.hops === 2 ? 2 : 1`), so runtime behaviour is unchanged.

The schema is extracted to an exported `getContextProfileInputSchema` so the regression test asserts the **actual** registered schema (not a drifting copy).

## Tests

New `test/getContextProfileSchema.test.ts`:
- serialised JSON Schema contains **no `anyOf`/`oneOf`**
- `hops` is a bounded integer (`type: integer`, `1..2`)
- runtime parsing accepts `1`, `2`, and omitted; rejects `0`, `3`, `1.5`, `"1"`

## Verification

- `npm run typecheck` ✓ · `npm run build` ✓ · regression test 3/3 ✓
- Protocol-level (`tools/list` from the built bin): `hops = {"type":"integer","minimum":1,"maximum":2}`, and **no tool emits `anyOf`** anymore
- End-to-end: `gemini-3.1-pro` and `gemini-3-flash` now complete requests in a reposkein-loaded project (previously 400'd on every call)
- Full mcp suite: **298 passed**, 17 skipped. The only failures were 2 macOS temp-dir teardown races (`ENOTEMPTY` in `temporal.test.ts`'s `afterEach`) — unrelated to this change and green in isolation (6/6).
