### PR TITLE
ci: reattach the pnpm version to action-setup in the viz job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,8 @@ jobs:
       run:
         working-directory: viz
     steps:
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           # Explicit version: action-setup runs at the repo root (working-directory
           # applies only to `run:` steps), where there is no package.json with a


### PR DESCRIPTION
`viz` has failed on `main` since #16 merged. Every other job is green, which is why it reads as a viz problem rather than a config one.

## What happened

The pnpm/action-setup v4 → v6 bump (#16) landed next to the checkout v5 → v7 bump (#17). Between them the two steps got reordered, and the `with:` block stayed behind on the wrong one:

```yaml
- uses: pnpm/action-setup@0ebf4713… # v6.0.9     # <- no `with:` at all
- uses: actions/checkout@9c091bb2…  # v7.0.0
  with:
    # Explicit version: action-setup runs at the repo root …
    version: "10.15.0"                            # <- landed on checkout
```

`action-setup` therefore ran with defaults and failed:

```
Error: No pnpm version is specified.
Please specify it by one of the following ways:
  - in the GitHub Action config with the key "version"
```

The logged step inputs confirm it received none. `actions/checkout` meanwhile silently ignored a `version` input it does not accept.

The explanatory comment travelled with the orphaned block, which is what makes the mistake read as intentional on a skim.

## The fix

Restore the original order and reattach the block. `version` still exists in v6 — the action's own error lists it first — so nothing about the bump itself was wrong, only where its neighbour's config ended up.

Root `package.json` does not exist in this repo, and `defaults.run.working-directory` applies only to `run:` steps, so auto-detection from `viz/package.json` cannot work here. The explicit `version` is load-bearing, which the original comment already said.

## Verification

Parsed every workflow looking for two symptoms: an `action-setup` with no version, and a `checkout` given one. Against unfixed `main`:

```
NO VERSION  ci.yml :: viz step0 -> pnpm/action-setup has no version
MANGLED     ci.yml :: viz step1 -> checkout got version='10.15.0'
```

Against this branch: clean. `release.yml` was untouched by the same bumps and is unaffected. `actionlint` reports nothing on `ci.yml`.

## Note

Found while investigating why CI failed on #27, which only touches Rust in `indexer/crates/cli`. That PR's `indexer` job passes; it is blocked purely by this. Worth a dependabot grouping rule for adjacent `uses:` bumps, since this failure mode is invisible in each individual bump's diff.