### PR TITLE
fix(indexer): use git's built-in union merge for .reposkein JSONL

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -119,7 +119,7 @@ The bundled binary lives at:
 ```
 $(npm root -g)/@reposkein/mcp/bin/reposkein-indexer
 ```
-Export `REPOSKEIN_INDEXER_BIN` to that path when you need the indexer directly (Neo4j `load`, see §4.2).
+Export `REPOSKEIN_INDEXER_BIN` to that path when you need the indexer directly (Neo4j `load`, see §4.3).
 
 ### 3.2 Per-repo (no global install, npx-only)
 
@@ -156,7 +156,22 @@ Run §4 once **per git sub-repo**. Don't try to run it in the workspace root if 
 
 Federation is derived at query time: when an MCP server points at one repo and a sibling/nested repo also has `.reposkein/`, passing `federated: true` to `semantic_find` / `get_context_profile` / `impact` stitches them via `FEDERATES_TO` edges (load-time only — never committed).
 
-### 4.2 Neo4j load (only if §1-Q2 = Neo4j)
+### 4.2 Merge behaviour for `.reposkein/*.jsonl`
+
+`init --hooks` writes these `.gitattributes` rules:
+
+```
+.reposkein/nodes.jsonl merge=union
+.reposkein/edges.jsonl merge=union
+```
+
+`union` is a **built-in** git strategy, so forges honour it. A custom merge driver only resolves where its binary and `git config` exist — a developer's machine. GitHub and GitLab merge server-side with neither, cannot resolve the driver name, and fall back to a plain text merge. Since the pre-commit hook rewrites both files on every commit, that made *every* long-lived pull request conflict on them.
+
+Union never conflicts. The merged file is briefly unsorted and may repeat a record both branches touched; that is safe because readers parse line-wise and the next `index` (which the pre-commit hook runs) re-sorts and de-duplicates by id. Structural fields are regenerated from source; summaries survive via the content-hash rule.
+
+**Upgrading an existing repo:** re-run `reposkein-indexer init --hooks .` once. It rewrites any legacy `merge=reposkein-jsonl` lines in place, leaving your other `.gitattributes` rules untouched. Until you do, that repo keeps conflicting on forge-side merges.
+
+### 4.3 Neo4j load (only if §1-Q2 = Neo4j)
 
 After §4 succeeds for a repo:
 

--- a/indexer/crates/cli/src/main.rs
+++ b/indexer/crates/cli/src/main.rs
@@ -778,11 +778,45 @@ fn main() -> Result<()> {
             write_hook("post-checkout", POST_MERGE)?; // same action as post-merge
 
             // .gitattributes (append idempotently).
+            //
+            // `merge=union` — a BUILT-IN git strategy — not the custom
+            // `reposkein-jsonl` driver registered below. A custom driver only
+            // resolves where its binary and `git config` exist, i.e. on a
+            // developer's machine. Forges (GitHub, GitLab) merge server-side
+            // with neither, so naming a custom driver there does not degrade
+            // gracefully: git cannot resolve the name, falls back to the plain
+            // text merge, and every pull request that touches these files
+            // conflicts on them. Because the indexer rewrites both files on
+            // every commit, that is effectively every long-lived PR — for
+            // conflicts that are pure noise, since the graph is regenerated
+            // from source anyway.
+            //
+            // Union takes both sides' lines and never conflicts. The result is
+            // briefly non-canonical (unsorted, and duplicated for records both
+            // sides touched), which is safe here: readers parse line-wise, and
+            // `nodes_to_jsonl` / `edges_to_jsonl` sort and de-duplicate by id
+            // on the next write. The pre-commit hook runs `index`, so the very
+            // next commit restores canonical form. Structural fields are
+            // regenerated from source; summaries survive via the content-hash
+            // rule in `core::merge`.
+            //
+            // The custom driver is still registered, so anyone who prefers a
+            // high-fidelity local merge can point .gitattributes back at it.
             let attrs_path = path.join(".gitattributes");
             let existing = std::fs::read_to_string(&attrs_path).unwrap_or_default();
-            let lines = [
+            // Migrate repos initialised before this change; leaving the old
+            // line in place would keep forge-side merges conflicting.
+            let existing = existing.replace(
                 ".reposkein/nodes.jsonl merge=reposkein-jsonl",
+                ".reposkein/nodes.jsonl merge=union",
+            );
+            let existing = existing.replace(
                 ".reposkein/edges.jsonl merge=reposkein-jsonl",
+                ".reposkein/edges.jsonl merge=union",
+            );
+            let lines = [
+                ".reposkein/nodes.jsonl merge=union",
+                ".reposkein/edges.jsonl merge=union",
             ];
             let mut attrs = existing.clone();
             if !attrs.is_empty() && !attrs.ends_with('\n') {

--- a/indexer/crates/cli/tests/init_hooks_cli.rs
+++ b/indexer/crates/cli/tests/init_hooks_cli.rs
@@ -39,10 +39,13 @@ fn init_hooks_installs_all_artifacts() {
         }
     }
 
-    // .gitattributes has the merge lines.
+    // .gitattributes points at the BUILT-IN union strategy, not the custom
+    // driver: forges merge server-side without our binary or git config, so a
+    // custom driver name there degrades to a plain text merge and conflicts.
     let attrs = fs::read_to_string(root.join(".gitattributes")).unwrap();
-    assert!(attrs.contains(".reposkein/nodes.jsonl merge=reposkein-jsonl"));
-    assert!(attrs.contains(".reposkein/edges.jsonl merge=reposkein-jsonl"));
+    assert!(attrs.contains(".reposkein/nodes.jsonl merge=union"));
+    assert!(attrs.contains(".reposkein/edges.jsonl merge=union"));
+    assert!(!attrs.contains("merge=reposkein-jsonl"));
 
     // git config has the merge driver.
     let out = Proc::new("git")
@@ -60,8 +63,40 @@ fn init_hooks_installs_all_artifacts() {
         .assert()
         .success();
     let attrs2 = fs::read_to_string(root.join(".gitattributes")).unwrap();
-    assert_eq!(
-        attrs2.matches("nodes.jsonl merge=reposkein-jsonl").count(),
-        1
-    );
+    assert_eq!(attrs2.matches("nodes.jsonl merge=union").count(), 1);
+}
+
+/// A repo initialised before the union change still carries the custom-driver
+/// line. Leaving it would keep every forge-side merge conflicting, so `init`
+/// rewrites it in place rather than appending a second, contradictory rule.
+#[test]
+fn init_hooks_migrates_legacy_custom_driver_lines() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    Proc::new("git")
+        .arg("init")
+        .arg("-q")
+        .current_dir(root)
+        .status()
+        .unwrap();
+
+    fs::write(
+        root.join(".gitattributes"),
+        "*.png binary\n.reposkein/nodes.jsonl merge=reposkein-jsonl\n.reposkein/edges.jsonl merge=reposkein-jsonl\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("reposkein-indexer")
+        .unwrap()
+        .args(["init", "--hooks"])
+        .arg(root)
+        .assert()
+        .success();
+
+    let attrs = fs::read_to_string(root.join(".gitattributes")).unwrap();
+    assert!(!attrs.contains("merge=reposkein-jsonl"), "legacy line must be rewritten");
+    assert_eq!(attrs.matches("nodes.jsonl merge=union").count(), 1);
+    assert_eq!(attrs.matches("edges.jsonl merge=union").count(), 1);
+    // Unrelated rules are preserved.
+    assert!(attrs.contains("*.png binary"));
 }

--- a/indexer/crates/cli/tests/init_hooks_cli.rs
+++ b/indexer/crates/cli/tests/init_hooks_cli.rs
@@ -94,7 +94,10 @@ fn init_hooks_migrates_legacy_custom_driver_lines() {
         .success();
 
     let attrs = fs::read_to_string(root.join(".gitattributes")).unwrap();
-    assert!(!attrs.contains("merge=reposkein-jsonl"), "legacy line must be rewritten");
+    assert!(
+        !attrs.contains("merge=reposkein-jsonl"),
+        "legacy line must be rewritten"
+    );
     assert_eq!(attrs.matches("nodes.jsonl merge=union").count(), 1);
     assert_eq!(attrs.matches("edges.jsonl merge=union").count(), 1);
     // Unrelated rules are preserved.


### PR DESCRIPTION
## The bug

`init --hooks` wrote `.gitattributes` naming our custom merge driver:

```
.reposkein/nodes.jsonl merge=reposkein-jsonl
.reposkein/edges.jsonl merge=reposkein-jsonl
```

A custom driver resolves only where **both** its binary and its `git config merge.reposkein-jsonl.driver` entry exist — i.e. a developer's machine. GitHub and GitLab merge server-side with neither. The name does not degrade gracefully: git cannot resolve it, falls back to the plain text merge, and the file conflicts.

Because the pre-commit hook rewrites both JSONL files on **every** commit, that made effectively every long-lived pull request conflict on `.reposkein/*.jsonl` — conflicts that carry no information, since the graph is regenerated from source.

Reproduced in a scratch repo (base + two branches each appending one node):

| `.gitattributes` | result |
| --- | --- |
| `merge=reposkein-jsonl`, driver unconfigured (= a forge) | `CONFLICT (content)` |
| `merge=union` | clean merge, both records present, zero conflict markers |

## The fix

`merge=union` is a **built-in** git strategy, so forges honour it, and it never conflicts.

The merged file is briefly non-canonical — unsorted, and repeating any record both branches touched. That is safe for this data, and the safety comes from code already in the repo:

- readers parse line-wise (`read_nodes` / `read_edges`);
- `nodes_to_jsonl` / `edges_to_jsonl` already `sort_by(id)` then `dedup_by(id)` on write;
- the pre-commit hook runs `index`, so the next commit restores canonical form;
- structural fields are regenerated from source, and summaries survive via the content-hash rule in `core::merge`.

The custom driver stays registered, so a repo that wants high-fidelity local merges can point `.gitattributes` back at it.

## Migration

Repos initialised before this change still carry the old line and would keep conflicting. `init` now **rewrites it in place** rather than appending a second, contradictory rule — appending would leave two rules for the same path and rely on precedence, which is exactly the kind of thing nobody wants to reason about later. Unrelated `.gitattributes` entries are preserved.

Verified end to end against the built binary:

```
# fresh repo
.reposkein/nodes.jsonl merge=union
.reposkein/edges.jsonl merge=union

# repo carrying the legacy lines + an unrelated rule
*.png binary
.reposkein/nodes.jsonl merge=union
.reposkein/edges.jsonl merge=union
```

Existing users need to re-run `reposkein-indexer init --hooks .` once per repo; documented in `docs/INSTALL.md` §4.2.

## Tests

`cargo test -p reposkein-indexer` — 24 passed, 0 failed. The existing `init_hooks_installs_all_artifacts` assertion is updated (it pinned the old driver name), and a new `init_hooks_migrates_legacy_custom_driver_lines` covers the upgrade path, which had none.
