### PR TITLE
fix: stop committing the derived graph, commit summaries instead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ cliff.toml    # git-cliff config (Conventional Commits → CHANGELOG.md)
 - **`serde_json` feature `preserve_order`** — explicitly banned in `indexer/Cargo.toml` (would couple JSONL byte-order to insertion order; breaks determinism).
 - **Making Neo4j or embed-server required.** Zero-infra invariant.
 - **Adding LLMs / time / randomness / unsorted iteration to `indexer/`.** Determinism invariant.
-- **Mutating committed `.reposkein/*.jsonl` from `mcp/` or `viz/`.** Viewer is read-only; mcp only writes `write_semantic_summary` via the indexer's 3-way merge driver.
+- **Mutating `.reposkein/*.jsonl` from `mcp/` or `viz/`.** Viewer is read-only; mcp only writes `write_semantic_summary`, which appends to the `.reposkein/local/` sidecar for the indexer to fold in.
+- **Committing `.reposkein/nodes.jsonl` or `edges.jsonl`.** Derived from the working tree, git-ignored, rebuilt on demand. Only `summaries.jsonl`, `meta.json` and `config.toml` are committed.
 - **Changing the `@arity` qualified-name rule in `core/src/id.rs`** without a `*_frozen` test diff — orphans every existing summary.
 - **`docker compose` as a build dependency** — only optional services (`embed`, `neo4j` profile).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@ Thanks for your interest! Bug fixes, new languages, and docs improvements are al
 
 ## Ground rules (read first)
 
-RepoSkein has **two hard invariants** — please don't break them:
+RepoSkein has **three hard invariants** — please don't break them:
 
-1. **Determinism.** The committed `.reposkein/*.jsonl` must be a **byte-identical** function of the working-tree source — same code → same graph, on any machine. CI enforces this (`determinism_two_runs_byte_identical`, `cache_warm_run_is_byte_identical_to_cold`, the Neo4j `load → export` round-trip). No LLMs, clocks, randomness, or HashMap-iteration-order may influence committed output. Anything derived/non-deterministic (embeddings, git history, cross-repo edges) lives **outside** the committed graph, under `.reposkein/local/` (gitignored).
+1. **Determinism.** `.reposkein/*.jsonl` must be a **byte-identical** function of the working-tree source — same code → same graph, on any machine. CI enforces this (`determinism_two_runs_byte_identical`, `cache_warm_run_is_byte_identical_to_cold`, the Neo4j `load → export` round-trip). No LLMs, clocks, randomness, or HashMap-iteration-order may influence the output. Anything derived/non-deterministic (embeddings, git history, cross-repo edges) lives under `.reposkein/local/` (gitignored).
 2. **Zero-infra by default.** It must work with **no database and no Docker** (the in-memory JSONL store). Don't make Neo4j or any service *required*.
+3. **Derived output stays out of git.** `nodes.jsonl` and `edges.jsonl` are rebuilt from the tree, so they are git-ignored and the MCP server builds them on demand. Only what an agent *authored* is committed: `.reposkein/summaries.jsonl`, alongside `meta.json` and `config.toml`. Determinism still matters for both — a re-index that reorders lines would churn the committed summaries file.
 
 Also: **Conventional Commits** (`feat:`, `fix:`, `docs:`, …), and **keep CI green** (`cargo test && cargo fmt --check && cargo clippy --all-targets -- -D warnings`; `npm test`).
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ It uses [Tree-sitter](https://tree-sitter.github.io/) to build a **deterministic
 
 **Who it's for:** developers using AI coding agents on real, large, or **nested/polyglot** codebases, who are tired of the agent burning its context window on grep; and teams who want that hard-won understanding to persist and be shared rather than re-derived every session.
 
-- ⚡ **Zero-infra** — no database, no Docker. The graph lives in committed `.reposkein/*.jsonl` files.
+- ⚡ **Zero-infra** — no database, no Docker. The graph lives in plain `.reposkein/*.jsonl` files, rebuilt from your working tree in seconds.
 - 🔒 **Deterministic** — same code → byte-identical graph. No LLM in the construction path.
 - 🌐 **7 languages** — Python, TypeScript, JavaScript, Rust, Go, Java, C#.
-- 🧩 **Local-first & git-native** — the graph and its summaries travel with your code.
+- 🧩 **Local-first & git-native** — the summaries your agents write are committed and travel with your code.
 
 | Your agent asks | RepoSkein answers — directly from the graph |
 | --- | --- |
@@ -72,7 +72,7 @@ It uses [Tree-sitter](https://tree-sitter.github.io/) to build a **deterministic
 
 - **Node.js 18+** — to run `npx @reposkein/mcp` (the indexer binary is fetched automatically).
 - **An MCP-capable agent** — [Claude Code](https://claude.com/claude-code), Cursor, Codex, Zed, etc.
-- A **git repository** to index (RepoSkein installs git hooks and commits the graph).
+- A **git repository** to index (RepoSkein installs git hooks and reads git history for `get_temporal_context`).
 - *Optional:* **Docker** (only for the [embeddings server](#optional-semantic-embeddings) or the [Neo4j backend](#optional-neo4j-backend)); **Rust** (only to [build from source](#build-from-source)).
 
 ## Installation
@@ -96,12 +96,12 @@ This downloads the indexer for your platform, installs git hooks + the navigatio
      }
    }
    ```
-2. **Verify and commit the graph** (`init` already built it):
+2. **Verify the graph** (`init` already built it):
    ```sh
    reposkein-mcp doctor .         # ✓ binary  ✓ indexed (N nodes)  ✓ ready
-   git add .reposkein && git commit -m "add RepoSkein code graph"
+   git add .reposkein/meta.json .reposkein/config.toml && git commit -m "add RepoSkein config"
    ```
-   Re-index after big changes with `reposkein-mcp index .` (or the agent's `reindex_file` tool).
+   `nodes.jsonl` and `edges.jsonl` are derived from your working tree and git-ignored — a clone rebuilds them on first use. Re-index after big changes with `reposkein-mcp index .` (or the agent's `reindex_file` tool).
 3. **Ask your agent** *"what calls this function?"* or *"what breaks if I change X?"* — it answers from the graph.
 
 > **Prefer to let your agent set it up?** Install the [skills](#agent-skills) and tell it to **run the `reposkein-setup` skill** — it installs, indexes, and verifies everything:
@@ -127,7 +127,7 @@ You ask in plain language; the bundled **`reposkein-graph-rag`** skill drives th
 2. **Understand it** — `get_context_profile` returns the node's callers + callees as ready-to-read prose (`hops: 2` widens, `federated: true` spans nested repos).
 3. **Before you change it** — `impact` lists transitive callers (what could break) split from the tests that cover it (what to run). → *"what breaks if I change `charge()`?"*
 4. **What moves with it** — `get_temporal_context` surfaces files that historically change together, plus churn and ownership. → *"what usually changes with the auth config?"*
-5. **Record what you learned** — `write_semantic_summary` attaches a 1–3 sentence note to the node, committed to git for the next agent/teammate.
+5. **Record what you learned** — `write_semantic_summary` attaches a 1–3 sentence note to the node, landing in `.reposkein/summaries.jsonl` for you to commit for the next agent/teammate.
 6. **After editing** — `reindex_file` refreshes the graph for the changed file.
 
 <details>
@@ -182,16 +182,18 @@ RepoSkein ships two cross-agent [Agent Skills](https://skills.sh) — `npx skill
                        CLI: init · doctor · index · view
         │ reads
         ▼
- .reposkein/*.jsonl   ← the code graph, committed to git (zero-infra, in-memory store)
+ .reposkein/           ← nodes.jsonl + edges.jsonl: derived, git-ignored, rebuilt on demand
+                       summaries.jsonl: what your agents authored — commit this
         ▲ writes
         │
  reposkein-indexer    Tree-sitter parse → stable IDs → canonical JSONL
-   (Rust)             + git hooks & a 3-way merge driver for conflict-free summaries
+   (Rust)             + git hooks that keep the local graph in step with your tree
 ```
 
 - **Structure is static.** The skeleton comes only from parsing — identical code produces a byte-identical graph (a CI-tested invariant), independent of who runs it.
 - **Meaning is just-in-time.** Summaries are written as the agent visits nodes; they're content-hash-stamped (so they flag stale when code changes) and committed to git.
-- **Local-first.** The committed JSONL is the source of truth; the optional [Neo4j backend](#optional-neo4j-backend) is a reconstructable projection most users never need.
+- **Derived stays out of git.** `nodes.jsonl` and `edges.jsonl` are a pure function of your working tree, so committing them buys nothing a re-index cannot rebuild while making every branch that touches code conflict with every other. Only `summaries.jsonl`, `meta.json` and `config.toml` are committed.
+- **Local-first.** The JSONL on disk is the source of truth; the optional [Neo4j backend](#optional-neo4j-backend) is a reconstructable projection most users never need.
 
 ### Cross-repo federation
 
@@ -203,9 +205,9 @@ Got nested repositories (a monorepo of indexed repos)? RepoSkein discovers them,
 reposkein-mcp view .          # opens http://127.0.0.1:<port> in your browser
 ```
 
-`view` starts a **local, read-only, zero-infra** web app (React + three.js, bound to `127.0.0.1`) that renders the committed `.reposkein` graph as an interactive 3D astronomy-style **constellation**. There's no Neo4j and no external service — it reads the committed JSONL directly and never mutates it. **[Try the live demo →](https://reposkein.github.io/reposkein/)** (RepoSkein viewing its own multi-language graph).
+`view` starts a **local, read-only, zero-infra** web app (React + three.js, bound to `127.0.0.1`) that renders your `.reposkein` graph as an interactive 3D astronomy-style **constellation**. There's no Neo4j and no external service — it reads the JSONL on disk directly and never mutates it. **[Try the live demo →](https://reposkein.github.io/reposkein/)** (RepoSkein viewing its own multi-language graph).
 
-The map is **deterministic**: a seeded force layout means the same graph always lays out the same way (cached in IndexedDB for instant reloads), and the layout is render-time only — it never touches the committed JSONL. Levels of detail map onto an astronomy metaphor — **Repository → Directory → File → Symbol** become **galaxy → constellation → solar-system → star** — so you zoom or click to expand a cluster (a brief supernova animation) and click a star to inspect it. Federation galaxies and agent-written summaries render when present.
+The map is **deterministic**: a seeded force layout means the same graph always lays out the same way (cached in IndexedDB for instant reloads), and the layout is render-time only — it never touches the JSONL. Levels of detail map onto an astronomy metaphor — **Repository → Directory → File → Symbol** become **galaxy → constellation → solar-system → star** — so you zoom or click to expand a cluster (a brief supernova animation) and click a star to inspect it. Federation galaxies and agent-written summaries render when present.
 
 - **Legible** — per-edge-type colors + legend, importance-sized stars, adaptive labels, breadcrumb, per-language galaxy coloring, depth fog / bloom / nebula halos.
 - **Edges encode resolution** — color = edge type (`CALLS`/`IMPORTS`/`INHERITS`/`IMPLEMENTS`/`INSTANTIATES`), opacity = confidence (`exact`/`name_match`/`ambiguous`), and flow particles show call direction.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -33,7 +33,7 @@ Walk the user through these decisions in order. Use the user's answers to pick b
 
 | Backend | Best for | Setup |
 |---|---|---|
-| **JSONL** (default, "zero-infra") | Any size up to ~100k symbols. Committed to git. Works offline. | Nothing — `init` writes it. |
+| **JSONL** (default, "zero-infra") | Any size up to ~100k symbols. Rebuilt from the working tree. Works offline. | Nothing — `init` writes it. |
 | **Neo4j** | Very large graphs (>100k symbols), raw Cypher queries, multi-tenant, query-perf-sensitive workloads. | Docker (`docker compose --profile neo4j up -d` from a checkout of this repo, or any Neo4j 5.x reachable over Bolt). |
 
 If the user is unsure → recommend **JSONL**. Suggest Neo4j only when they explicitly mention scale, multi-repo dashboards, or Cypher.
@@ -73,9 +73,9 @@ Pick all that apply — RepoSkein is MCP-stdio, so it works with any MCP-capable
 
 Templates in §6.
 
-### Q5 — Commit the `.reposkein/` graph to git?
+### Q5 — What in `.reposkein/` goes into git?
 
-**Yes** in 99% of cases. The committed graph is the SOURCE OF TRUTH; it's a deterministic function of source so commits are stable and merges resolve via the 3-way driver. The only reason to skip is in a sandbox / throwaway clone.
+Not a question to ask; `init` sets it up. **Commit** `meta.json`, `config.toml` and `summaries.jsonl` (the summaries your agents author, which nothing can regenerate). **Do not commit** `nodes.jsonl` / `edges.jsonl` — `.reposkein/.gitignore` already excludes them. They are a pure function of the working tree, so every clone rebuilds them in seconds, and committing them would make every branch that touches code conflict with every other one. `local/` is ignored too.
 
 ### Q6 — Install the cross-agent navigation skills?
 
@@ -138,21 +138,24 @@ reposkein-mcp init                    # or: npx @reposkein/mcp init
 
 This:
 1. Verifies/fetches the platform indexer binary.
-2. Installs git hooks (`pre-commit` re-indexes; `post-merge` reloads Neo4j if configured).
+2. Installs git hooks (`pre-commit` re-indexes the local graph, staging nothing; `post-merge` reloads Neo4j if configured).
 3. Installs the `reposkein-graph-rag` skill into `.claude/skills/` (no-op on agents that ignore `.claude/`).
-4. Walks the tree with Tree-sitter → writes deterministic `.reposkein/nodes.jsonl` + `.reposkein/edges.jsonl` + `.reposkein/meta.json`.
+4. Walks the tree with Tree-sitter → writes deterministic `.reposkein/nodes.jsonl` + `.reposkein/edges.jsonl` + `.reposkein/meta.json`, plus a `.reposkein/.gitignore` that keeps the two derived files out of git.
 5. **Prints an MCP config block** for the user to paste into their agent — you (the agent) should pick the right schema (§6) and write it directly.
 
 Verify:
 
 ```sh
 reposkein-mcp doctor .       # ✓ binary  ✓ indexed (N nodes)  ✓ ready
-git add .reposkein && git commit -m "add RepoSkein code graph"
+git add .reposkein/meta.json .reposkein/config.toml .reposkein/.gitignore
+git commit -m "add RepoSkein config"
 ```
+
+`nodes.jsonl` and `edges.jsonl` are deliberately absent from that `git add`: they are derived, git-ignored, and rebuilt on demand. `summaries.jsonl` appears once an agent writes its first summary; commit it then.
 
 ### 4.1 Multi-repo workspaces
 
-Run §4 once **per git sub-repo**. Don't try to run it in the workspace root if the root isn't itself a git repo — RepoSkein needs git for hooks and the merge driver.
+Run §4 once **per git sub-repo**. Don't try to run it in the workspace root if the root isn't itself a git repo — RepoSkein needs git for hooks and for `get_temporal_context`.
 
 Federation is derived at query time: when an MCP server points at one repo and a sibling/nested repo also has `.reposkein/`, passing `federated: true` to `semantic_find` / `get_context_profile` / `impact` stitches them via `FEDERATES_TO` edges (load-time only — never committed).
 
@@ -260,7 +263,7 @@ Write `<repo>/.mcp.json`:
 
 Drop any block whose feature the user didn't enable. `REPOSKEIN_REPO_PATH` is the only required key.
 
-> **Gitignore `.mcp.json` / `opencode.json`.** They hold absolute machine paths and a local `NEO4J_PASSWORD`, so they are per-machine and must not be committed. `reposkein-mcp init` adds them to `.gitignore` for you; if you write them by hand, do the same. Only the `.reposkein/` graph is shared.
+> **Gitignore `.mcp.json` / `opencode.json`.** They hold absolute machine paths and a local `NEO4J_PASSWORD`, so they are per-machine and must not be committed. `reposkein-mcp init` adds them to `.gitignore` for you; if you write them by hand, do the same. What is shared from `.reposkein/` is `meta.json`, `config.toml` and `summaries.jsonl`.
 
 ### 6.2 OpenCode (+ omo)
 
@@ -364,7 +367,7 @@ npm install -g @reposkein/mcp
 cd /path/to/repo
 reposkein-mcp init
 reposkein-mcp doctor .
-git add .reposkein && git commit -m "add RepoSkein code graph"
+git add .reposkein/meta.json .reposkein/config.toml .reposkein/.gitignore && git commit -m "add RepoSkein config"
 
 # 3. (Optional) Neo4j
 docker compose --profile neo4j up -d           # from a reposkein checkout

--- a/docs/migrations/2026-08-06-stop-committing-derived-graph.md
+++ b/docs/migrations/2026-08-06-stop-committing-derived-graph.md
@@ -1,0 +1,217 @@
+# Migration: stop committing the derived RepoSkein graph
+
+Status: plan only. Nothing here has been executed.
+Written: 2026-08-06.
+Applies to: any repository that already has `.reposkein/nodes.jsonl` and
+`.reposkein/edges.jsonl` under version control.
+
+## What changed upstream
+
+`nodes.jsonl` and `edges.jsonl` are now treated as derived output. `reposkein-indexer index`
+writes a `.reposkein/.gitignore` covering them, the `pre-commit` hook no longer stages anything,
+and the MCP server builds the graph on startup when it is missing. Authored semantic summaries
+move to `.reposkein/summaries.jsonl`, which is small, rarely written, and meant to be committed.
+
+Nothing about the graph's content or determinism changed. The same index of the same tree
+produces the same bytes as before.
+
+## Why
+
+Three measured problems, all caused by the files being in git rather than by anything in the
+graph itself.
+
+1. **Phantom merge conflicts.** The pre-commit hook re-indexed and staged on every commit, so
+   every branch modified both files. The moment any pull request merged, every other open one
+   reported `CONFLICTING`. Four separate occurrences were measured in `cellarnode-backend-v2` on
+   2026-08-06; every rebase applied with zero conflict markers, so no human judgement was ever
+   involved.
+
+2. **A merge driver cannot fix it.** Forges compute mergeability in a bare repository, and git
+   does not consult a tree-level `.gitattributes` when there is no worktree. Verified with
+   `git merge-tree --write-tree` against a bare clone: `git check-attr merge` reports `union` in
+   a worktree and `unspecified` in the bare repo, and the merge exits 1 with conflict markers.
+   Injecting the same rule into the bare repo's `info/attributes` makes it apply, which confirms
+   attribute lookup, not driver availability, is the mechanism. This defeats the custom
+   `reposkein-jsonl` driver and the built-in `merge=union` alike.
+
+3. **Union merge corrupts the graph where it does apply.** Union keeps both sides' lines, so a
+   node both branches touched ends up on two lines with the same `id` and different bodies. A
+   reader taking the last match sees a stale node shape. Forty duplicate ids were observed after
+   one rebase in `cellarnode-backend-v2`, invisible to `git diff --name-only` because the
+   pre-commit hook re-snapshots the pre-rebase tree.
+
+Two further findings from the investigation:
+
+4. **The committed graph bought nothing in practice.** Across all 16 CellarNode repositories:
+   29,605 committed nodes, **zero** carrying a `semantic_summary`, 18.1 MB of machine-generated
+   JSONL under version control. The one thing committing was supposed to preserve was never
+   present.
+
+5. **The committed graph was already wrong.** At `cellarnode-backend-v2` HEAD, the committed
+   `nodes.jsonl` held 8,109 lines while a fresh index of the same tree with the same indexer
+   produced 10,257 nodes (edges 13,122 against 17,454). Roughly 21 percent stale, so the hook
+   was not in fact keeping it in sync.
+
+The cost of removing them is small: a cold full index of `cellarnode-backend-v2` (1,896 files,
+10,257 nodes, 17,454 edges) takes **2.04s** wall clock; a warm one 0.37s. Building on first query
+is cheaper than the conflict tax, and the server logs a line explaining the wait.
+
+## Blast radius
+
+Per repository, three tracked paths change:
+
+| Path | Before | After |
+|---|---|---|
+| `.reposkein/nodes.jsonl` | tracked | untracked, git-ignored |
+| `.reposkein/edges.jsonl` | tracked | untracked, git-ignored |
+| `.reposkein/.gitignore` | absent or `local/` only | adds `nodes.jsonl`, `edges.jsonl` |
+| `.gitattributes` | may hold `merge=reposkein-jsonl` or `merge=union` lines | those lines removed |
+| `.reposkein/meta.json`, `config.toml` | tracked | unchanged, still tracked |
+| `.reposkein/summaries.jsonl` | did not exist | tracked once an agent writes a summary |
+
+Nothing outside `.reposkein/` and `.gitattributes` is touched.
+
+## Prerequisites
+
+1. The upstream change is merged and released, and `@reposkein/mcp` is upgraded on every machine
+   that will run an index. A machine still on the old indexer will re-create the tracked files on
+   its next commit and undo the migration for that branch.
+2. Every open pull request in the repository is merged or rebased onto the migrated `main`. A
+   branch that still has the files tracked will conflict with the removal exactly once. This is
+   the last conflict the migration causes and it is unavoidable.
+3. Announce a window. The migration is a one-commit change per repository, but it lands in
+   everyone's working tree at once.
+
+## Per-repository steps
+
+Run inside each repository, on a branch, one pull request per repository.
+
+```sh
+# 1. Refresh .reposkein/ with the new indexer so .gitignore and summaries.jsonl are written.
+reposkein-mcp index .
+
+# 2. Untrack the derived files. --cached keeps them on disk, so nothing needs re-indexing.
+git rm --cached .reposkein/nodes.jsonl .reposkein/edges.jsonl
+
+# 3. Drop any merge declaration for them. `reposkein-mcp init` does this, or by hand:
+#    remove the two `.reposkein/*.jsonl merge=...` lines from .gitattributes,
+#    and delete the file if it held nothing else.
+reposkein-mcp init .
+
+# 4. Stage explicitly. Never `git add -A` here: step 1 may have refreshed a stale graph,
+#    and those changes are exactly what we are trying to stop committing.
+git add .reposkein/.gitignore
+git add .gitattributes 2>/dev/null || true      # only if it still exists
+git add .reposkein/summaries.jsonl 2>/dev/null || true
+
+# 5. Verify before committing. Expect: two deletions, one .gitignore, and nothing else.
+git status --short
+git diff --cached --stat
+
+git commit -m "chore: stop tracking the derived RepoSkein graph"
+```
+
+Expected `git diff --cached --stat`: two deleted `.jsonl` files with a large line count, one
+small `.gitignore`, optionally a small `.gitattributes` and `summaries.jsonl`. Anything else in
+that list means step 4 over-staged; unstage it rather than committing.
+
+### Verification after merge
+
+```sh
+git ls-files .reposkein            # must not list nodes.jsonl or edges.jsonl
+git check-ignore -v .reposkein/nodes.jsonl   # must report .reposkein/.gitignore
+reposkein-mcp doctor .             # must still report ✓ indexed (N nodes)
+```
+
+Then confirm a clone works from nothing:
+
+```sh
+git clone <repo> /tmp/migrate-check && cd /tmp/migrate-check
+reposkein-mcp doctor .             # expect ✗ indexed, since a clone has no derived graph
+reposkein-mcp index .              # expect it to build in seconds
+reposkein-mcp doctor .             # expect ✓ indexed
+```
+
+## What breaks for a contributor who pulls mid-migration
+
+The failure modes are mild and all self-correct, but they should be in the announcement.
+
+**A contributor with local changes to the tracked files.** `git pull` will refuse or conflict,
+because the migration deletes files their working tree has modified. Resolution: accept the
+deletion. The file content is derived, so nothing is lost. Do not resolve by keeping the local
+copy, which re-tracks it.
+
+**A contributor on a branch created before the migration.** Their branch still tracks both files.
+Rebasing onto migrated `main` produces one conflict per file, resolved by taking the deletion:
+
+```sh
+git rebase origin/main
+git rm --cached .reposkein/nodes.jsonl .reposkein/edges.jsonl
+git rebase --continue
+```
+
+**A contributor still running the old indexer.** Their `pre-commit` hook will `git add` the two
+files again, silently re-tracking them on their next commit. This is the one failure that does
+not self-correct, and it is why the version prerequisite is not optional. It shows up as the
+files reappearing in `git status` on someone else's machine. Fix: upgrade, then
+`git rm --cached` them again.
+
+**A contributor whose git config still has the custom merge driver registered.** Harmless. The
+`merge-jsonl` subcommand is deliberately retained upstream, so a stale
+`merge.reposkein-jsonl.driver` entry still resolves to a working binary. `reposkein-mcp init`
+unsets it. Nothing breaks if they never run it.
+
+**An agent session mid-flight when the migration lands.** If an agent wrote summaries that are
+still only in `.reposkein/local/summaries.jsonl`, the next `index` folds them into
+`summaries.jsonl` as normal. Summaries that were already inside a committed `nodes.jsonl` are
+harvested by the first index after the upgrade, so the upgrade itself loses nothing. But once
+`nodes.jsonl` is untracked, a summary that never made it into `summaries.jsonl` exists only on
+that one machine. Ask contributors to run `reposkein-mcp index .` and commit any resulting
+`summaries.jsonl` **before** the migration commit lands.
+
+**CI that reads the committed graph.** Nothing in the CellarNode repositories does this today
+(checked: no workflow references `.reposkein`). If a repository adds such a step later, it needs
+a `reposkein-mcp index .` before whatever consumes the graph.
+
+## The 16 CellarNode repositories
+
+All 16 currently have both files committed. Listed with their committed node counts, largest
+first, since the largest are where the conflict pain was measured and where the migration is
+most worth doing early.
+
+| Repository | Nodes | Edges |
+|---|---:|---:|
+| `cellarnode-backend-v2` | 8109 | 13122 |
+| `ui` | 5602 | 8894 |
+| `cellarnode-admin-dashboard-v2` | 2645 | 3630 |
+| `producer-dashboard` | 2595 | 4136 |
+| `cellarnode-importer-dashboard` | 1234 | 1608 |
+| `cellarnode-public-site` | 1223 | 1447 |
+| `bottle_extractor` | 999 | 1905 |
+| `crossplane-gcloud` | 400 | 408 |
+| `cellarnode-elabel-frontend` | 327 | 455 |
+| `project-match` | 127 | 159 |
+| `beverage-utils` | 115 | 155 |
+| `cellarnode-mobile-app` | 99 | 104 |
+| `cellarnode-auth` | 89 | 127 |
+| `polyglot-i18n` | 80 | 133 |
+| `finance` | 66 | 95 |
+| `cellarnode-i18n` | 54 | 68 |
+
+Suggested order: migrate `cellarnode-backend-v2` and `ui` first. They have the most branches in
+flight and therefore the most conflicts to stop, and they are the two that will prove the
+approach. The remaining 14 can go in a single batch afterwards.
+
+## Documentation that needs a separate change
+
+`/Users/mjnong/REPOS/CellarNode/CLAUDE.md` currently states, in its RepoSkein file map:
+
+> `.reposkein/nodes.jsonl`, `edges.jsonl` | Canonical deterministic graph. Commit these.
+
+That line is the opposite of the new behaviour and will keep agents re-adding the files. The
+same file's "Operational notes" section describes the merge driver setup and tells new
+contributors to run `reposkein-mcp init` to register it, which also needs revising: `init` now
+removes that registration rather than adding it.
+
+Those edits are outside this repository and are not part of this plan. They are flagged here so
+they are not missed.

--- a/indexer/crates/cli/src/main.rs
+++ b/indexer/crates/cli/src/main.rs
@@ -10,19 +10,23 @@ use reposkein_lang_java::JavaExtractor;
 use reposkein_lang_python::PythonExtractor;
 use reposkein_lang_rust::RustExtractor;
 use reposkein_lang_ts::{JavaScriptExtractor, TypeScriptExtractor};
+use serde_json::{Map, Value};
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const PRE_COMMIT: &str = r#"#!/bin/sh
 # reposkein-managed
-# RepoSkein: keep .reposkein JSONL in sync with the working tree on commit.
+# RepoSkein: keep the local .reposkein graph in sync with the working tree.
+# Nothing is staged. nodes.jsonl / edges.jsonl are derived output and are
+# git-ignored; authored summaries land in .reposkein/summaries.jsonl, which you
+# stage yourself like any other edit.
 BIN="${REPOSKEIN_INDEXER_BIN:-reposkein-indexer}"
 if ! command -v "$BIN" >/dev/null 2>&1 && [ ! -x "$BIN" ]; then
-  echo "reposkein: indexer not found; skipping graph export (commit continues)" >&2
+  echo "reposkein: indexer not found; skipping graph refresh (commit continues)" >&2
   exit 0
 fi
-"$BIN" index . >/dev/null 2>&1 || { echo "reposkein: index failed; skipping export" >&2; exit 0; }
-git add .reposkein/nodes.jsonl .reposkein/edges.jsonl >/dev/null 2>&1 || true
+"$BIN" index . >/dev/null 2>&1 || { echo "reposkein: index failed; skipping refresh" >&2; exit 0; }
 exit 0
 "#;
 
@@ -350,42 +354,92 @@ fn run_index(
     let out_dir = path.join(".reposkein");
     std::fs::create_dir_all(&out_dir).context("failed to create .reposkein/")?;
     let nodes_path = out_dir.join("nodes.jsonl");
-    // 1) Preserve summaries already committed in JSONL (hash-validated).
-    let mut nodes = if nodes_path.exists() {
-        let prev = std::fs::read_to_string(&nodes_path).context("read existing nodes.jsonl")?;
-        let existing = reposkein_core::jsonl::read_nodes(&prev)?;
-        reposkein_core::merge::graft_summaries(&graph.nodes, &existing)
-    } else {
-        graph.nodes.clone()
-    };
-    // 2) Overlay the live DB's summaries (PRD §9 Phase 3).
-    if let Some(db_nodes) = db_summary_nodes(&repo) {
-        nodes = reposkein_core::merge::graft_summaries(&nodes, &db_nodes);
+    let summaries_path = out_dir.join("summaries.jsonl");
+
+    // Collect authored summaries from every source, newest last.
+    //
+    // Structure is rebuilt from source on every index, so nodes.jsonl and
+    // edges.jsonl are recoverable at any time. Summaries are not: an agent
+    // wrote them and nothing can regenerate them. They are therefore gathered
+    // separately and persisted to `.reposkein/summaries.jsonl`, the one file in
+    // .reposkein/ worth committing.
+    let mut authored: BTreeMap<String, Map<String, Value>> = BTreeMap::new();
+    // 1) Legacy: summaries inside a previously committed nodes.jsonl, so the
+    //    first index after upgrading harvests them instead of dropping them.
+    //    Best-effort — a corrupt derived file must never abort an index.
+    if let Ok(prev) = std::fs::read_to_string(&nodes_path) {
+        if let Ok(existing) = reposkein_core::jsonl::read_nodes(&prev) {
+            absorb_summaries(&mut authored, &existing);
+        }
     }
-    // 3) Overlay JSONL-mode sidecar summaries. Atomically *claim* the sidecar
-    //    (rename aside) BEFORE reading it: a write_semantic_summary landing
-    //    during this window then writes a FRESH sidecar that survives to the
-    //    next index, instead of being erased by a blind truncate (data loss).
+    // 2) The committed summaries file: what teammates share.
+    if let Ok(text) = std::fs::read_to_string(&summaries_path) {
+        absorb_summaries(
+            &mut authored,
+            &reposkein_core::jsonl::read_sidecar_summaries(&text),
+        );
+    }
+    // 3) The live DB's summaries (PRD §9 Phase 3).
+    if let Some(db_nodes) = db_summary_nodes(&repo) {
+        absorb_summaries(&mut authored, &db_nodes);
+    }
+    // 4) The JSONL-mode sidecar. Atomically *claim* it (rename aside) BEFORE
+    //    reading: a write_semantic_summary landing during this window then
+    //    writes a FRESH sidecar that survives to the next index, instead of
+    //    being erased by a blind truncate (data loss).
     let sidecar_path = out_dir.join("local").join("summaries.jsonl");
     let claimed_path = out_dir.join("local").join("summaries.consuming.jsonl");
     let claimed = std::fs::rename(&sidecar_path, &claimed_path).is_ok();
     if claimed {
         if let Ok(text) = std::fs::read_to_string(&claimed_path) {
-            let sidecar_nodes = reposkein_core::jsonl::read_sidecar_summaries(&text);
-            nodes = reposkein_core::merge::graft_summaries(&nodes, &sidecar_nodes);
+            absorb_summaries(
+                &mut authored,
+                &reposkein_core::jsonl::read_sidecar_summaries(&text),
+            );
         }
     }
+    let authored_nodes: Vec<reposkein_core::model::Node> = authored
+        .into_iter()
+        .map(|(id, props)| reposkein_core::model::Node {
+            id,
+            labels: Vec::new(),
+            props,
+        })
+        .collect();
+
+    // Derived output. Summaries are grafted in only where `summary_of_hash`
+    // still matches the node, so a stale summary never reads as current.
+    let nodes = reposkein_core::merge::graft_summaries(&graph.nodes, &authored_nodes);
     std::fs::write(&nodes_path, jsonl::nodes_to_jsonl(&nodes))
         .context("failed to write nodes.jsonl")?;
-    if claimed {
-        // Grafted summaries are now in committed nodes.jsonl; drop the claim.
-        let _ = std::fs::remove_file(&claimed_path);
-    }
     std::fs::write(
         out_dir.join("edges.jsonl"),
         jsonl::edges_to_jsonl(&graph.edges),
     )
     .context("failed to write edges.jsonl")?;
+
+    // Authored output. Kept verbatim rather than hash-filtered: a summary whose
+    // node changed is *stale*, not wrong, and a reader detects that by comparing
+    // `summary_of_hash` against the node's `content_hash`. Filtering here would
+    // silently delete authored prose on the next unrelated refactor, and churn
+    // a committed file on every edit. Summaries whose node no longer exists are
+    // dropped — that code is gone.
+    let live: HashSet<&str> = graph.nodes.iter().map(|n| n.id.as_str()).collect();
+    let surviving: Vec<reposkein_core::model::Node> = authored_nodes
+        .into_iter()
+        .filter(|n| live.contains(n.id.as_str()))
+        .collect();
+    let summaries = jsonl::summaries_to_jsonl(&surviving);
+    if summaries.is_empty() {
+        // Leave no empty file behind in repos that have no summaries at all.
+        let _ = std::fs::remove_file(&summaries_path);
+    } else {
+        std::fs::write(&summaries_path, summaries).context("failed to write summaries.jsonl")?;
+    }
+    if claimed {
+        // Now persisted in summaries.jsonl; drop the claim.
+        let _ = std::fs::remove_file(&claimed_path);
+    }
 
     write_reposkein_layout(&out_dir, &repo).context("failed to write .reposkein layout")?;
 
@@ -412,6 +466,29 @@ fn index_stats_json(r: &IndexRun) -> String {
     serde_json::to_string(&stats).unwrap()
 }
 
+/// True for a `.gitattributes` line an earlier RepoSkein wrote to point the
+/// derived JSONL at a merge driver (the custom `reposkein-jsonl` one or the
+/// built-in `union`).
+fn is_reposkein_merge_attr(line: &str) -> bool {
+    let l = line.trim();
+    (l.starts_with(".reposkein/nodes.jsonl") || l.starts_with(".reposkein/edges.jsonl"))
+        && l.contains("merge=")
+}
+
+/// Folds any nodes carrying summary props into `authored`, keyed by node id.
+/// Later calls win, so callers should feed sources oldest-first.
+fn absorb_summaries(
+    authored: &mut BTreeMap<String, Map<String, Value>>,
+    records: &[reposkein_core::model::Node],
+) {
+    for n in records {
+        let part = reposkein_core::merge::summary_part(&n.props);
+        if reposkein_core::merge::has_summary(&part) {
+            authored.insert(n.id.clone(), part);
+        }
+    }
+}
+
 /// Writes meta.json, .reposkein/.gitignore, default config.toml (if absent),
 /// and the git-ignored local/ dir.
 fn write_reposkein_layout(out_dir: &Path, repo_id: &str) -> Result<()> {
@@ -419,7 +496,20 @@ fn write_reposkein_layout(out_dir: &Path, repo_id: &str) -> Result<()> {
         out_dir.join("meta.json"),
         reposkein_core::meta::meta_json(repo_id),
     )?;
-    std::fs::write(out_dir.join(".gitignore"), "local/\n")?;
+    // nodes.jsonl / edges.jsonl are derived: a pure function of the working
+    // tree that `index` rebuilds in seconds. Committing them means every branch
+    // that touches code also rewrites two machine-generated files, so every open
+    // pull request conflicts on them the moment any other one merges. A
+    // `.gitattributes merge=union` declaration does not rescue this: forges
+    // compute mergeability in a bare repo, where tree-level .gitattributes is
+    // never consulted, and where union *does* apply it resolves by keeping both
+    // sides' lines, producing duplicate ids for any node both branches touched.
+    // So they stay out of git. Authored summaries live in summaries.jsonl, which
+    // is committed.
+    std::fs::write(
+        out_dir.join(".gitignore"),
+        "local/\nnodes.jsonl\nedges.jsonl\n",
+    )?;
     std::fs::create_dir_all(out_dir.join("local"))?;
     let cfg = out_dir.join("config.toml");
     if !cfg.exists() {
@@ -777,83 +867,46 @@ fn main() -> Result<()> {
             write_hook("post-merge", POST_MERGE)?;
             write_hook("post-checkout", POST_MERGE)?; // same action as post-merge
 
-            // .gitattributes (append idempotently).
+            // .gitattributes: remove any merge declaration an earlier RepoSkein
+            // installed for the derived JSONL.
             //
-            // `merge=union` — a BUILT-IN git strategy — not the custom
-            // `reposkein-jsonl` driver registered below. A custom driver only
-            // resolves where its binary and `git config` exist, i.e. on a
-            // developer's machine. Forges (GitHub, GitLab) merge server-side
-            // with neither, so naming a custom driver there does not degrade
-            // gracefully: git cannot resolve the name, falls back to the plain
-            // text merge, and every pull request that touches these files
-            // conflicts on them. Because the indexer rewrites both files on
-            // every commit, that is effectively every long-lived PR — for
-            // conflicts that are pure noise, since the graph is regenerated
-            // from source anyway.
-            //
-            // Union takes both sides' lines and never conflicts. The result is
-            // briefly non-canonical (unsorted, and duplicated for records both
-            // sides touched), which is safe here: readers parse line-wise, and
-            // `nodes_to_jsonl` / `edges_to_jsonl` sort and de-duplicate by id
-            // on the next write. The pre-commit hook runs `index`, so the very
-            // next commit restores canonical form. Structural fields are
-            // regenerated from source; summaries survive via the content-hash
-            // rule in `core::merge`.
-            //
-            // The custom driver is still registered, so anyone who prefers a
-            // high-fidelity local merge can point .gitattributes back at it.
+            // Those files are no longer committed, so a merge driver has nothing
+            // left to resolve. Leaving the line is worse than useless: the custom
+            // driver only exists on a developer's machine, and a forge computing
+            // mergeability does it in a bare repo, where tree-level .gitattributes
+            // is not consulted at all — so neither the custom driver nor a
+            // built-in `merge=union` ever runs there.
             let attrs_path = path.join(".gitattributes");
-            let existing = std::fs::read_to_string(&attrs_path).unwrap_or_default();
-            // Migrate repos initialised before this change; leaving the old
-            // line in place would keep forge-side merges conflicting.
-            let existing = existing.replace(
-                ".reposkein/nodes.jsonl merge=reposkein-jsonl",
-                ".reposkein/nodes.jsonl merge=union",
-            );
-            let existing = existing.replace(
-                ".reposkein/edges.jsonl merge=reposkein-jsonl",
-                ".reposkein/edges.jsonl merge=union",
-            );
-            let lines = [
-                ".reposkein/nodes.jsonl merge=union",
-                ".reposkein/edges.jsonl merge=union",
-            ];
-            let mut attrs = existing.clone();
-            if !attrs.is_empty() && !attrs.ends_with('\n') {
-                attrs.push('\n');
-            }
-            for l in lines {
-                if !existing.contains(l) {
-                    attrs.push_str(l);
-                    attrs.push('\n');
+            if let Ok(existing) = std::fs::read_to_string(&attrs_path) {
+                let kept: Vec<&str> = existing
+                    .lines()
+                    .filter(|l| !is_reposkein_merge_attr(l))
+                    .collect();
+                if kept.len() != existing.lines().count() {
+                    if kept.iter().all(|l| l.trim().is_empty()) {
+                        // The file only ever held our lines; leave no empty
+                        // artefact behind.
+                        std::fs::remove_file(&attrs_path).context("remove .gitattributes")?;
+                    } else {
+                        let mut out = kept.join("\n");
+                        out.push('\n');
+                        std::fs::write(&attrs_path, out).context("write .gitattributes")?;
+                    }
+                    println!("removed the .reposkein merge declaration from .gitattributes");
                 }
             }
-            std::fs::write(&attrs_path, attrs).context("write .gitattributes")?;
 
-            // Register the merge driver (kind inferred from filename at merge time).
-            let run_cfg = |k: &str, v: &str| {
-                std::process::Command::new("git")
+            // Drop the merge-driver registration an earlier RepoSkein wrote into
+            // .git/config. Best-effort: an absent key is not an error.
+            for key in ["merge.reposkein-jsonl.name", "merge.reposkein-jsonl.driver"] {
+                let _ = std::process::Command::new("git")
                     .arg("-C")
                     .arg(&path)
-                    .args(["config", k, v])
-                    .status()
-            };
-            run_cfg(
-                "merge.reposkein-jsonl.name",
-                "RepoSkein canonical JSONL merge",
-            )?;
-            let exe_path = std::env::current_exe()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|_| "reposkein-indexer".to_string());
-            run_cfg(
-                "merge.reposkein-jsonl.driver",
-                &format!("{exe_path} merge-jsonl --path %P %O %A %B"),
-            )?;
+                    .args(["config", "--unset-all", key])
+                    .status();
+            }
 
-            println!(
-                "installed reposkein git hooks + merge driver in {}",
-                path.display()
-            );
+            println!("installed reposkein git hooks in {}", path.display());
             Ok(())
         }
         Commands::MergeJsonl {

--- a/indexer/crates/cli/tests/init_hooks_cli.rs
+++ b/indexer/crates/cli/tests/init_hooks_cli.rs
@@ -3,26 +3,41 @@ use std::fs;
 use std::process::Command as Proc;
 use tempfile::tempdir;
 
-#[test]
-fn init_hooks_installs_all_artifacts() {
+fn git_repo() -> tempfile::TempDir {
     let dir = tempdir().unwrap();
-    let root = dir.path();
-    // Make it a git repo.
     Proc::new("git")
         .arg("init")
         .arg("-q")
-        .current_dir(root)
+        .current_dir(dir.path())
         .status()
         .unwrap();
+    dir
+}
 
+fn run_init(root: &std::path::Path) {
     Command::cargo_bin("reposkein-indexer")
         .unwrap()
         .args(["init", "--hooks"])
         .arg(root)
         .assert()
         .success();
+}
 
-    // Hooks exist and mention reposkein.
+fn git_config(root: &std::path::Path, key: &str) -> String {
+    let out = Proc::new("git")
+        .args(["config", "--get", key])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[test]
+fn init_hooks_installs_all_artifacts() {
+    let dir = git_repo();
+    let root = dir.path();
+    run_init(root);
+
     for hook in ["pre-commit", "post-merge", "post-checkout"] {
         let p = root.join(".git/hooks").join(hook);
         assert!(p.exists(), "{hook} should exist");
@@ -39,67 +54,122 @@ fn init_hooks_installs_all_artifacts() {
         }
     }
 
-    // .gitattributes points at the BUILT-IN union strategy, not the custom
-    // driver: forges merge server-side without our binary or git config, so a
-    // custom driver name there degrades to a plain text merge and conflicts.
-    let attrs = fs::read_to_string(root.join(".gitattributes")).unwrap();
-    assert!(attrs.contains(".reposkein/nodes.jsonl merge=union"));
-    assert!(attrs.contains(".reposkein/edges.jsonl merge=union"));
-    assert!(!attrs.contains("merge=reposkein-jsonl"));
-
-    // git config has the merge driver.
-    let out = Proc::new("git")
-        .args(["config", "merge.reposkein-jsonl.driver"])
-        .current_dir(root)
-        .output()
-        .unwrap();
-    assert!(String::from_utf8_lossy(&out.stdout).contains("merge-jsonl"));
-
-    // Idempotent: running again succeeds and doesn't duplicate gitattributes.
-    Command::cargo_bin("reposkein-indexer")
-        .unwrap()
-        .args(["init", "--hooks"])
-        .arg(root)
-        .assert()
-        .success();
-    let attrs2 = fs::read_to_string(root.join(".gitattributes")).unwrap();
-    assert_eq!(attrs2.matches("nodes.jsonl merge=union").count(), 1);
+    // Idempotent.
+    run_init(root);
 }
 
-/// A repo initialised before the union change still carries the custom-driver
-/// line. Leaving it would keep every forge-side merge conflicting, so `init`
-/// rewrites it in place rather than appending a second, contradictory rule.
 #[test]
-fn init_hooks_migrates_legacy_custom_driver_lines() {
-    let dir = tempdir().unwrap();
+fn pre_commit_hook_stages_nothing() {
+    let dir = git_repo();
     let root = dir.path();
-    Proc::new("git")
-        .arg("init")
-        .arg("-q")
-        .current_dir(root)
-        .status()
-        .unwrap();
+    run_init(root);
 
+    let body = fs::read_to_string(root.join(".git/hooks/pre-commit")).unwrap();
+    assert!(
+        !body.contains("git add"),
+        "the pre-commit hook must not stage anything: the derived JSONL is \
+         git-ignored, and authored summaries are staged by hand.\n{body}"
+    );
+    assert!(
+        body.contains("index ."),
+        "the hook should still refresh the local graph"
+    );
+}
+
+#[test]
+fn init_does_not_declare_a_merge_driver() {
+    let dir = git_repo();
+    let root = dir.path();
+    run_init(root);
+
+    assert!(
+        !root.join(".gitattributes").exists(),
+        "init must not create .gitattributes: nodes.jsonl / edges.jsonl are no \
+         longer committed, so there is nothing for a merge driver to resolve"
+    );
+    assert_eq!(git_config(root, "merge.reposkein-jsonl.driver"), "");
+    assert_eq!(git_config(root, "merge.reposkein-jsonl.name"), "");
+}
+
+#[test]
+fn init_migrates_away_a_legacy_custom_driver_declaration() {
+    let dir = git_repo();
+    let root = dir.path();
+    // A repo initialised by an older RepoSkein: custom driver in .gitattributes
+    // and registered in .git/config.
     fs::write(
         root.join(".gitattributes"),
-        "*.png binary\n.reposkein/nodes.jsonl merge=reposkein-jsonl\n.reposkein/edges.jsonl merge=reposkein-jsonl\n",
+        "*.png binary\n\
+         .reposkein/nodes.jsonl merge=reposkein-jsonl\n\
+         .reposkein/edges.jsonl merge=reposkein-jsonl\n",
     )
     .unwrap();
+    for (k, v) in [
+        (
+            "merge.reposkein-jsonl.name",
+            "RepoSkein canonical JSONL merge",
+        ),
+        (
+            "merge.reposkein-jsonl.driver",
+            "reposkein-indexer merge-jsonl",
+        ),
+    ] {
+        Proc::new("git")
+            .args(["config", k, v])
+            .current_dir(root)
+            .status()
+            .unwrap();
+    }
 
-    Command::cargo_bin("reposkein-indexer")
-        .unwrap()
-        .args(["init", "--hooks"])
-        .arg(root)
-        .assert()
-        .success();
+    run_init(root);
 
     let attrs = fs::read_to_string(root.join(".gitattributes")).unwrap();
     assert!(
-        !attrs.contains("merge=reposkein-jsonl"),
-        "legacy line must be rewritten"
+        !attrs.contains("reposkein"),
+        "the stale merge declaration should be gone: {attrs}"
     );
-    assert_eq!(attrs.matches("nodes.jsonl merge=union").count(), 1);
-    assert_eq!(attrs.matches("edges.jsonl merge=union").count(), 1);
-    // Unrelated rules are preserved.
-    assert!(attrs.contains("*.png binary"));
+    assert!(
+        attrs.contains("*.png binary"),
+        "unrelated user lines must survive: {attrs}"
+    );
+    assert_eq!(git_config(root, "merge.reposkein-jsonl.driver"), "");
+    assert_eq!(git_config(root, "merge.reposkein-jsonl.name"), "");
+}
+
+#[test]
+fn init_migrates_away_a_union_merge_declaration() {
+    let dir = git_repo();
+    let root = dir.path();
+    // `merge=union` was the interim fix. It does not survive a forge's
+    // mergeability check either (that runs in a bare repo, where tree-level
+    // .gitattributes is never consulted), and where it does apply it keeps both
+    // sides' lines, duplicating any node id both branches touched.
+    fs::write(
+        root.join(".gitattributes"),
+        ".reposkein/nodes.jsonl merge=union\n.reposkein/edges.jsonl merge=union\n",
+    )
+    .unwrap();
+
+    run_init(root);
+
+    assert!(
+        !root.join(".gitattributes").exists(),
+        "a .gitattributes holding only our lines should be removed, not left empty"
+    );
+}
+
+#[test]
+fn init_leaves_a_foreign_gitattributes_byte_identical() {
+    let dir = git_repo();
+    let root = dir.path();
+    let original = "* text=auto\n*.sh eol=lf\n";
+    fs::write(root.join(".gitattributes"), original).unwrap();
+
+    run_init(root);
+
+    assert_eq!(
+        fs::read_to_string(root.join(".gitattributes")).unwrap(),
+        original,
+        "init must not touch a .gitattributes it has no lines in"
+    );
 }

--- a/indexer/crates/cli/tests/summaries_cli.rs
+++ b/indexer/crates/cli/tests/summaries_cli.rs
@@ -1,0 +1,250 @@
+//! The committed-artifact contract: `.reposkein/nodes.jsonl` and `edges.jsonl`
+//! are derived and git-ignored; `.reposkein/summaries.jsonl` holds the authored
+//! half and is the only part of the directory meant to be committed.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn index(root: &Path) {
+    Command::cargo_bin("reposkein-indexer")
+        .unwrap()
+        .args(["index", "--repo-id", "r", "--name", "d"])
+        .arg(root)
+        .assert()
+        .success();
+}
+
+fn seed(root: &Path) {
+    fs::write(root.join("m.py"), b"def f():\n    return 1\n").unwrap();
+}
+
+const FUNC_ID: &str = "rs1:r:func:m.py#f@0";
+
+fn content_hash(root: &Path, id: &str) -> String {
+    let text = fs::read_to_string(root.join(".reposkein/nodes.jsonl")).unwrap();
+    text.lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v| v["id"] == id)
+        .and_then(|v| v["content_hash"].as_str().map(String::from))
+        .expect("content_hash for the seeded function")
+}
+
+/// Writes a sidecar summary the way `write_semantic_summary` does in JSONL mode.
+fn write_sidecar(root: &Path, id: &str, summary: &str, hash: &str) {
+    let sidecar = root.join(".reposkein/local/summaries.jsonl");
+    fs::create_dir_all(sidecar.parent().unwrap()).unwrap();
+    fs::write(
+        &sidecar,
+        format!(
+            "{{\"id\":\"{id}\",\"semantic_summary\":\"{summary}\",\"summary_of_hash\":\"{hash}\"}}\n"
+        ),
+    )
+    .unwrap();
+}
+
+fn summaries(root: &Path) -> Option<String> {
+    fs::read_to_string(root.join(".reposkein/summaries.jsonl")).ok()
+}
+
+#[test]
+fn derived_jsonl_is_gitignored() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    seed(root);
+    index(root);
+
+    let ignore = fs::read_to_string(root.join(".reposkein/.gitignore")).unwrap();
+    for entry in ["local/", "nodes.jsonl", "edges.jsonl"] {
+        assert!(
+            ignore.lines().any(|l| l.trim() == entry),
+            "`{entry}` should be git-ignored, got:\n{ignore}"
+        );
+    }
+    assert!(
+        !ignore.lines().any(|l| l.trim() == "summaries.jsonl"),
+        "summaries.jsonl is authored and must stay committable:\n{ignore}"
+    );
+}
+
+#[test]
+fn a_repo_with_no_summaries_gets_no_summaries_file() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    seed(root);
+    index(root);
+
+    assert!(
+        summaries(root).is_none(),
+        "nothing authored yet, so nothing to commit"
+    );
+}
+
+#[test]
+fn sidecar_summary_is_persisted_for_committing() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    seed(root);
+    index(root);
+    let hash = content_hash(root, FUNC_ID);
+    write_sidecar(root, FUNC_ID, "returns one", &hash);
+
+    index(root);
+
+    let s = summaries(root).expect("summaries.jsonl should exist once one is written");
+    assert!(s.contains(FUNC_ID), "should key by node id: {s}");
+    assert!(s.contains("returns one"), "should carry the prose: {s}");
+    // Authored fields only: no structural payload rides along, which is what
+    // keeps this file small and conflict-free.
+    for structural in ["content_hash", "labels", "\"path\"", "start_line"] {
+        assert!(
+            !s.contains(structural),
+            "summaries.jsonl must hold no derived fields, found {structural}: {s}"
+        );
+    }
+}
+
+#[test]
+fn summaries_file_is_deterministic_across_runs() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    seed(root);
+    index(root);
+    let hash = content_hash(root, FUNC_ID);
+    write_sidecar(root, FUNC_ID, "returns one", &hash);
+
+    index(root);
+    let first = summaries(root).unwrap();
+    index(root);
+    let second = summaries(root).unwrap();
+
+    assert_eq!(first, second, "repeated indexes must be byte-identical");
+}
+
+#[test]
+fn a_summary_survives_the_source_changing_under_it() {
+    // The point of splitting authored from derived. `nodes.jsonl` drops a
+    // summary whose hash no longer matches, so a stale summary never reads as
+    // current. The committed file keeps it: it is stale, not wrong, and
+    // deleting it would silently destroy authored prose on the next unrelated
+    // refactor (and churn a committed file on every edit).
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    seed(root);
+    index(root);
+    let hash = content_hash(root, FUNC_ID);
+    write_sidecar(root, FUNC_ID, "returns one", &hash);
+    index(root);
+
+    fs::write(root.join("m.py"), b"def f():\n    return 2\n").unwrap();
+    index(root);
+
+    let nodes = fs::read_to_string(root.join(".reposkein/nodes.jsonl")).unwrap();
+    assert!(
+        !nodes.contains("returns one"),
+        "a stale summary must not be served as current"
+    );
+    let s = summaries(root).expect("the authored summary must be retained");
+    assert!(
+        s.contains("returns one"),
+        "authored prose must survive a source edit: {s}"
+    );
+}
+
+#[test]
+fn a_fresh_clone_rebuilds_the_graph_from_the_committed_summaries_alone() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    seed(root);
+    index(root);
+    let hash = content_hash(root, FUNC_ID);
+    write_sidecar(root, FUNC_ID, "returns one", &hash);
+    index(root);
+
+    // What a teammate actually checks out: source + the committed summaries,
+    // with no derived JSONL and no sidecar.
+    fs::remove_file(root.join(".reposkein/nodes.jsonl")).unwrap();
+    fs::remove_file(root.join(".reposkein/edges.jsonl")).unwrap();
+    assert!(!root.join(".reposkein/local/summaries.jsonl").exists());
+
+    index(root);
+
+    let nodes = fs::read_to_string(root.join(".reposkein/nodes.jsonl")).unwrap();
+    assert!(
+        nodes.contains("returns one"),
+        "the committed summaries file alone must restore the summary: {nodes}"
+    );
+}
+
+#[test]
+fn a_summary_for_deleted_code_is_dropped() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    seed(root);
+    index(root);
+    let hash = content_hash(root, FUNC_ID);
+    write_sidecar(root, FUNC_ID, "returns one", &hash);
+    index(root);
+    assert!(summaries(root).is_some());
+
+    fs::remove_file(root.join("m.py")).unwrap();
+    index(root);
+
+    assert!(
+        summaries(root).is_none(),
+        "the node is gone, so its summary should go with it"
+    );
+}
+
+#[test]
+fn summaries_in_a_legacy_committed_nodes_jsonl_are_harvested() {
+    // Migration: repos indexed by an older RepoSkein carry their summaries
+    // inside a committed nodes.jsonl. The first index after upgrading must move
+    // them into summaries.jsonl rather than stranding them in an ignored file.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    seed(root);
+    index(root);
+
+    let nodes_path = root.join(".reposkein/nodes.jsonl");
+    let text = fs::read_to_string(&nodes_path).unwrap();
+    let mut lines: Vec<String> = Vec::new();
+    for line in text.lines() {
+        let mut v: serde_json::Value = serde_json::from_str(line).unwrap();
+        if v["id"] == FUNC_ID {
+            let hash = v["content_hash"].as_str().unwrap().to_string();
+            v["semantic_summary"] = serde_json::json!("legacy prose");
+            v["summary_of_hash"] = serde_json::json!(hash);
+        }
+        lines.push(serde_json::to_string(&v).unwrap());
+    }
+    fs::write(&nodes_path, lines.join("\n") + "\n").unwrap();
+
+    index(root);
+
+    let s = summaries(root).expect("legacy summaries must be harvested");
+    assert!(
+        s.contains("legacy prose"),
+        "a summary living only in nodes.jsonl must be migrated: {s}"
+    );
+}
+
+#[test]
+fn a_corrupt_derived_nodes_file_does_not_abort_the_index() {
+    // nodes.jsonl is derived and git-ignored, so a truncated or half-merged one
+    // is a normal state to recover from, never a reason to fail.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    seed(root);
+    index(root);
+    fs::write(root.join(".reposkein/nodes.jsonl"), b"{not json at all\n").unwrap();
+
+    index(root);
+
+    let nodes = fs::read_to_string(root.join(".reposkein/nodes.jsonl")).unwrap();
+    assert!(
+        nodes.contains(FUNC_ID),
+        "the graph should be rebuilt: {nodes}"
+    );
+}

--- a/indexer/crates/core/src/jsonl.rs
+++ b/indexer/crates/core/src/jsonl.rs
@@ -197,11 +197,42 @@ pub fn read_edges(text: &str) -> Result<Vec<Edge>> {
     Ok(out)
 }
 
-/// Parses a summaries sidecar (`.reposkein/local/summaries.jsonl`) into Nodes
-/// carrying only `id` + summary props (labels empty). Feeds `graft_summaries`
-/// so JSONL-mode agent summaries reach committed `nodes.jsonl`. Best-effort:
-/// malformed lines are skipped (the sidecar is regenerable and must never abort
-/// an index).
+/// Serializes the *authored* half of the graph: one line per node carrying a
+/// semantic summary, holding its `id` plus summary props and nothing else.
+///
+/// This is the only part of `.reposkein/` worth committing. `nodes.jsonl` and
+/// `edges.jsonl` are a pure function of the working tree, so committing them
+/// buys nothing a re-index cannot rebuild, while costing a merge conflict on
+/// every branch that touches code. Summaries are the opposite: an agent wrote
+/// them, and no re-index can recover them once lost.
+///
+/// Deterministic: sorted by id, deduped, each object canonicalised with `id`
+/// first, LF-terminated. Nodes with no summary are skipped, so the file stays
+/// empty until someone actually writes one.
+pub fn summaries_to_jsonl(nodes: &[Node]) -> String {
+    let mut sorted: Vec<&Node> = nodes.iter().collect();
+    sorted.sort_by(|a, b| a.id.cmp(&b.id));
+    sorted.dedup_by(|a, b| a.id == b.id);
+    let mut out = String::new();
+    for n in sorted {
+        let mut obj = crate::merge::summary_part(&n.props);
+        if !crate::merge::has_summary(&obj) {
+            continue;
+        }
+        obj.insert("id".to_string(), Value::String(n.id.clone()));
+        out.push_str(&canonical_object(&obj, &["id"]));
+        out.push('\n');
+    }
+    out
+}
+
+/// Parses a summaries file into Nodes carrying only `id` + summary props
+/// (labels empty), ready to feed `graft_summaries`.
+///
+/// Reads both the committed `.reposkein/summaries.jsonl` and the local
+/// `.reposkein/local/summaries.jsonl` sidecar that `write_semantic_summary`
+/// appends to between indexes; the two share this line format. Best-effort:
+/// malformed lines are skipped (a summaries file must never abort an index).
 pub fn read_sidecar_summaries(text: &str) -> Vec<Node> {
     let mut out = Vec::new();
     for line in text.lines() {

--- a/indexer/crates/core/src/merge.rs
+++ b/indexer/crates/core/src/merge.rs
@@ -6,7 +6,10 @@ use crate::model::{Edge, Node};
 use serde_json::{Map, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
-const SUMMARY_FIELDS: &[&str] = &[
+/// Node props that are *authored* rather than derived from source. Every other
+/// field is a pure function of the working tree and can be regenerated, so these
+/// are the only ones worth committing (see `jsonl::summaries_to_jsonl`).
+pub const SUMMARY_FIELDS: &[&str] = &[
     "semantic_summary",
     "purpose_summary",
     "summary_of_hash",
@@ -15,7 +18,7 @@ const SUMMARY_FIELDS: &[&str] = &[
     "summary_by",
 ];
 
-fn is_summary_field(k: &str) -> bool {
+pub fn is_summary_field(k: &str) -> bool {
     SUMMARY_FIELDS.contains(&k)
 }
 
@@ -27,7 +30,7 @@ fn structural(props: &Map<String, Value>) -> Map<String, Value> {
         .collect()
 }
 
-fn summary_part(props: &Map<String, Value>) -> Map<String, Value> {
+pub fn summary_part(props: &Map<String, Value>) -> Map<String, Value> {
     props
         .iter()
         .filter(|(k, _)| is_summary_field(k))
@@ -35,7 +38,7 @@ fn summary_part(props: &Map<String, Value>) -> Map<String, Value> {
         .collect()
 }
 
-fn has_summary(s: &Map<String, Value>) -> bool {
+pub fn has_summary(s: &Map<String, Value>) -> bool {
     s.contains_key("semantic_summary") || s.contains_key("purpose_summary")
 }
 

--- a/mcp/src/cli/init.ts
+++ b/mcp/src/cli/init.ts
@@ -44,8 +44,9 @@ export function ensureLocalConfigGitignored(repoPath: string): void {
   const leadingNewline = current.length > 0 && !current.endsWith("\n") ? "\n" : "";
   const block =
     `${leadingNewline}\n# RepoSkein per-machine MCP config (absolute paths + a local backend\n` +
-    "# password); regenerated per machine by `reposkein-mcp init`. Only the\n" +
-    `# .reposkein/ graph is meant to be committed.\n${missing.join("\n")}\n`;
+    "# password); regenerated per machine by `reposkein-mcp init`. The derived\n" +
+    "# graph is ignored separately by .reposkein/.gitignore.\n" +
+    `${missing.join("\n")}\n`;
   appendFileSync(gitignorePath, block);
   console.error(`reposkein: gitignored ${missing.join(", ")} (per-machine config, never commit)`);
 }
@@ -63,14 +64,15 @@ export async function runIndex(repoPath = "."): Promise<number> {
   return r.code;
 }
 
-/** `reposkein-mcp init [path] [--no-index]`: ensure the indexer, install hooks +
- *  merge driver, build the initial graph, install the navigation skill, and print
- *  the MCP config + next steps. Pass `index: false` to skip the initial index. */
+/** `reposkein-mcp init [path] [--no-index]`: ensure the indexer, install git hooks,
+ *  build the initial graph, install the navigation skill, and print the MCP config +
+ *  next steps. Pass `index: false` to skip the initial index. */
 export async function runInit(repoPath = ".", opts: { index?: boolean } = {}): Promise<number> {
   // 1) Indexer binary (fetches it if needed).
   const bin = await ensureIndexerBinary();
 
-  // 2) Git hooks + JSONL merge driver (needs a git repo).
+  // 2) Git hooks (needs a git repo). Also strips any merge declaration an older
+  //    RepoSkein left behind for the derived JSONL, which is no longer committed.
   const r = await spawnIndexer(bin, ["init", "--hooks", repoPath]);
   if (r.code !== 0) {
     console.error(`reposkein: indexer init failed: ${r.stderr || r.stdout}`);
@@ -107,7 +109,9 @@ export async function runInit(repoPath = ".", opts: { index?: boolean } = {}): P
   console.error("\nreposkein: ready. Add this MCP server to your client config:\n");
   console.error(mcpConfigSnippet(repoPath));
   console.error(
-    "\nCommit the generated .reposkein/ directory so the graph + summaries are shared with your team." +
+    "\nCommit .reposkein/meta.json, config.toml and summaries.jsonl. nodes.jsonl and edges.jsonl are " +
+      "derived from your working tree and git-ignored: every clone rebuilds them in seconds, and committing " +
+      "them would conflict on every branch that touches code." +
       "\nVerify anytime with `reposkein-mcp doctor`; re-index after big changes with `reposkein-mcp index` " +
       "(or the agent's reindex_file / init_cpg_skeleton tools)."
   );

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -20,6 +20,7 @@ import { makeSemanticFind } from "./tools/semanticFind.js";
 import { makeTemporalContext } from "./tools/temporalContext.js";
 import { makeImpact } from "./tools/impact.js";
 import { resolveRepoId } from "./store/repoId.js";
+import { ensureGraph } from "./indexer/ensureGraph.js";
 
 /** Selects the store backend.
  *  REPOSKEIN_STORE = "jsonl" | "neo4j" | "auto" (default "auto").
@@ -70,6 +71,13 @@ export const getContextProfileInputSchema = {
 export async function main(): Promise<void> {
   const repoPath = process.env.REPOSKEIN_REPO_PATH;
   const repoId = resolveRepoId(repoPath, process.env.REPOSKEIN_REPO_ID);
+  // Build the graph if the repo has none yet. Derived JSONL is git-ignored, so a
+  // fresh clone arrives without it; without this the first query would fail on a
+  // repo that indexes fine in a couple of seconds.
+  await ensureGraph(repoPath, repoId, {
+    mode: (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase(),
+    neo4jConfigured: !!process.env.NEO4J_PASSWORD,
+  });
   const store = buildStore(repoPath, repoId);
 
   const server = new McpServer({ name: "@reposkein/mcp", version: "0.0.0" });

--- a/mcp/src/indexer/ensureGraph.ts
+++ b/mcp/src/indexer/ensureGraph.ts
@@ -1,0 +1,86 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnIndexer, parseJsonStats } from "./runIndexer.js";
+import { ensureIndexerBinary } from "./fetchBinary.js";
+
+export type EnsureOutcome = "present" | "built" | "failed" | "skipped";
+
+export type BuildResult =
+  | { ok: true; nodes: number; edges: number }
+  | { ok: false; error: string };
+
+export interface EnsureDeps {
+  exists: (path: string) => boolean;
+  build: (repoId: string, repoPath: string) => Promise<BuildResult>;
+  /** Where progress goes. MUST NOT be stdout: that is the MCP stdio transport. */
+  log: (message: string) => void;
+  now: () => number;
+}
+
+export interface EnsureOpts {
+  /** REPOSKEIN_STORE, lowercased. */
+  mode: string;
+  /** Whether a Neo4j password is present in the environment. */
+  neo4jConfigured: boolean;
+}
+
+async function defaultBuild(repoId: string, path: string): Promise<BuildResult> {
+  try {
+    const bin = await ensureIndexerBinary();
+    const r = await spawnIndexer(bin, ["index", "--json", "--repo-id", repoId, path]);
+    if (r.code !== 0) return { ok: false, error: r.stderr.trim() || r.stdout.trim() || `exit ${r.code}` };
+    const stats = parseJsonStats(r.stdout);
+    if (!stats) return { ok: false, error: `index --json returned unparseable output: ${r.stdout}` };
+    return { ok: true, nodes: stats.nodes, edges: stats.edges };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Builds the JSONL graph if it is missing, so a fresh clone works on the first query.
+ *
+ *  `.reposkein/nodes.jsonl` and `edges.jsonl` are derived from the working tree and
+ *  git-ignored, so a clone never carries them. Without this the server would fall
+ *  through to `UnconfiguredStore` and every tool would fail on a repo that is
+ *  perfectly indexable. A full index is seconds even on a large repo, so building it
+ *  here is cheaper than making the user discover a setup step.
+ *
+ *  Skipped when Neo4j is the store: the DB already holds the graph, and building
+ *  JSONL would silently switch the backend out from under a configured user.
+ *
+ *  Never throws and never fails startup: a repo that cannot be indexed should still
+ *  bring the server up, with the error explained on stderr. */
+export async function ensureGraph(
+  repoPath: string | undefined,
+  repoId: string | undefined,
+  opts: EnsureOpts,
+  deps?: Partial<EnsureDeps>
+): Promise<EnsureOutcome> {
+  const exists = deps?.exists ?? existsSync;
+  const build = deps?.build ?? defaultBuild;
+  const log = deps?.log ?? ((m: string) => void process.stderr.write(`${m}\n`));
+  const now = deps?.now ?? Date.now;
+
+  if (!repoPath || !repoId) return "skipped";
+  if (opts.mode === "neo4j") return "skipped";
+  if (opts.mode === "auto" && opts.neo4jConfigured) return "skipped";
+  if (exists(join(repoPath, ".reposkein", "nodes.jsonl"))) return "present";
+
+  log(
+    `reposkein: no graph in ${join(repoPath, ".reposkein")}; building it now. ` +
+      "nodes.jsonl and edges.jsonl are derived from your working tree and git-ignored, " +
+      "so a fresh clone builds them once. This usually takes a few seconds."
+  );
+  const started = now();
+  const r = await build(repoId, repoPath);
+  const secs = ((now() - started) / 1000).toFixed(1);
+  if (!r.ok) {
+    log(
+      `reposkein: graph build failed after ${secs}s: ${r.error}. ` +
+        `Tools will report no graph until this succeeds. Run \`reposkein-mcp index ${repoPath}\` to see the full output.`
+    );
+    return "failed";
+  }
+  log(`reposkein: graph built in ${secs}s (${r.nodes} nodes, ${r.edges} edges).`);
+  return "built";
+}

--- a/mcp/src/store/AGENTS.md
+++ b/mcp/src/store/AGENTS.md
@@ -7,7 +7,7 @@ The `GraphStore` abstraction. Every MCP tool reads through this interface; backe
 | File | Role |
 |---|---|
 | `GraphStore.ts` | The interface contract. **Source of truth for row shapes.** |
-| `JsonlGraphStore.ts` | Reads committed `.reposkein/*.jsonl` into memory. **Default** when `nodes.jsonl` exists. |
+| `JsonlGraphStore.ts` | Reads `.reposkein/*.jsonl` into memory. **Default** when `nodes.jsonl` exists (built on startup by `indexer/ensureGraph.ts` when it does not). |
 | `Neo4jGraphStore.ts` | Optional Cypher backend (via `neo4j-driver`). Used for very large graphs. |
 | `UnconfiguredStore.ts` | Every method returns an instructive error. Selected when no backend is reachable. |
 | `federation.ts` | Discovers nested `.reposkein/` dirs → derives `FEDERATES_TO` + cross-repo edges at load. |
@@ -24,10 +24,15 @@ REPOSKEIN_STORE = auto (default) | jsonl | neo4j
   neo4j : Neo4j if NEO4J_* env set, else Unconfigured
 ```
 
+`main()` calls `ensureGraph` before `buildStore`: nodes.jsonl / edges.jsonl are derived and
+git-ignored, so a fresh clone has none and the server builds them once (seconds) rather than
+failing every tool. It skips when Neo4j is the store, so building JSONL can never switch the
+backend out from under a configured user.
+
 ## CONVENTIONS
 
 - **Every backend MUST pass `test/storeConformance.ts`** — the canonical parity fixture. Add a method → add a conformance case.
-- **No backend may mutate `.reposkein/*.jsonl` directly.** Only `writeSemanticSummary` writes, and only via the indexer's 3-way merge.
+- **No backend may mutate `.reposkein/*.jsonl` directly.** Only `writeSemanticSummary` writes, and only by appending to the `.reposkein/local/` sidecar the indexer folds in on its next run.
 - Federation is **load-time only** — `FEDERATES_TO` + cross-repo edges are NEVER committed (they live in `.reposkein/local/`).
 - `repoId.ts` resolution is `path → blake3(canonical_path)` — keep stable for sidecar invariance.
 

--- a/mcp/src/store/UnconfiguredStore.ts
+++ b/mcp/src/store/UnconfiguredStore.ts
@@ -7,8 +7,16 @@ import type {
 } from "./GraphStore.js";
 import type { TargetRow } from "../profile/types.js";
 
+// Reached when no backend resolved. The common cause is a missing
+// REPOSKEIN_REPO_PATH, not a missing database: `.reposkein/nodes.jsonl` is
+// derived and git-ignored, and the server builds it on startup when it can, so
+// pointing the user straight at Neo4j would send them to set up infrastructure
+// they do not need.
 const MSG =
-  "Neo4j not configured: set NEO4J_PASSWORD and run `docker compose up` in indexer/";
+  "RepoSkein has no graph for this repository. Set REPOSKEIN_REPO_PATH to the repository root: " +
+  "nodes.jsonl and edges.jsonl are derived and git-ignored, so they are built on first use. " +
+  "To build one by hand, run `reposkein-mcp index <repo>`. " +
+  "To query a Neo4j-backed graph instead, set NEO4J_PASSWORD.";
 
 /** A no-op store used when NEO4J_PASSWORD is absent.
  *  All operations reject with an instructive error. */

--- a/mcp/test/ensureGraph.test.ts
+++ b/mcp/test/ensureGraph.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { ensureGraph, type EnsureDeps, type BuildResult } from "../src/indexer/ensureGraph.js";
+
+/** Records what ensureGraph did, so a test can assert on the build and the log. */
+function harness(
+  opts: { hasGraph?: boolean; build?: BuildResult } = {}
+): { deps: Partial<EnsureDeps>; builds: string[][]; logs: string[] } {
+  const builds: string[][] = [];
+  const logs: string[] = [];
+  let clock = 0;
+  return {
+    builds,
+    logs,
+    deps: {
+      exists: () => opts.hasGraph ?? false,
+      build: async (repoId, repoPath) => {
+        builds.push([repoId, repoPath]);
+        return opts.build ?? { ok: true, nodes: 10257, edges: 17454 };
+      },
+      log: (m) => void logs.push(m),
+      // 2.0s per call pair: first call 0, second 2000.
+      now: () => (clock += 2000) - 2000,
+    },
+  };
+}
+
+const ZERO_INFRA = { mode: "auto", neo4jConfigured: false };
+
+describe("ensureGraph", () => {
+  it("builds the graph when a fresh clone has none", async () => {
+    const h = harness();
+    const outcome = await ensureGraph("/repo", "r", ZERO_INFRA, h.deps);
+
+    expect(outcome).toBe("built");
+    expect(h.builds).toEqual([["r", "/repo"]]);
+  });
+
+  it("explains the delay before building and reports the result after", async () => {
+    // A user watching stderr should understand why the first query is slow,
+    // rather than concluding the server hung.
+    const h = harness();
+    await ensureGraph("/repo", "r", ZERO_INFRA, h.deps);
+
+    expect(h.logs[0]).toMatch(/building it now/);
+    expect(h.logs[0]).toMatch(/git-ignored/);
+    expect(h.logs[1]).toMatch(/built in 2\.0s/);
+    expect(h.logs[1]).toMatch(/10257 nodes, 17454 edges/);
+  });
+
+  it("does nothing when the graph is already there", async () => {
+    const h = harness({ hasGraph: true });
+    const outcome = await ensureGraph("/repo", "r", ZERO_INFRA, h.deps);
+
+    expect(outcome).toBe("present");
+    expect(h.builds).toEqual([]);
+    expect(h.logs).toEqual([]);
+  });
+
+  it("leaves an explicit neo4j store alone", async () => {
+    const h = harness();
+    const outcome = await ensureGraph("/repo", "r", { mode: "neo4j", neo4jConfigured: true }, h.deps);
+
+    expect(outcome).toBe("skipped");
+    expect(h.builds).toEqual([]);
+  });
+
+  it("does not switch a configured neo4j user onto JSONL in auto mode", async () => {
+    // auto prefers JSONL when it exists, so building it here would silently
+    // change which backend answers every query.
+    const h = harness();
+    const outcome = await ensureGraph("/repo", "r", { mode: "auto", neo4jConfigured: true }, h.deps);
+
+    expect(outcome).toBe("skipped");
+    expect(h.builds).toEqual([]);
+  });
+
+  it("builds in explicit jsonl mode even with a database around", async () => {
+    const h = harness();
+    const outcome = await ensureGraph("/repo", "r", { mode: "jsonl", neo4jConfigured: true }, h.deps);
+
+    expect(outcome).toBe("built");
+  });
+
+  it("skips when there is no repo to index", async () => {
+    const h = harness();
+    expect(await ensureGraph(undefined, "r", ZERO_INFRA, h.deps)).toBe("skipped");
+    expect(await ensureGraph("/repo", undefined, ZERO_INFRA, h.deps)).toBe("skipped");
+    expect(h.builds).toEqual([]);
+  });
+
+  it("survives a failed build and says how to see the real error", async () => {
+    // Startup must not die on an unindexable repo: the server still comes up and
+    // every tool reports the missing graph.
+    const h = harness({ build: { ok: false, error: "parse error in a.ts" } });
+    const outcome = await ensureGraph("/repo", "r", ZERO_INFRA, h.deps);
+
+    expect(outcome).toBe("failed");
+    expect(h.logs[1]).toMatch(/parse error in a\.ts/);
+    expect(h.logs[1]).toMatch(/reposkein-mcp index \/repo/);
+  });
+});

--- a/mcp/test/gracefulStartup.test.ts
+++ b/mcp/test/gracefulStartup.test.ts
@@ -11,6 +11,16 @@ describe("graceful startup without NEO4J_PASSWORD", () => {
     await expect(store.runRead("MATCH (n) RETURN n")).rejects.toThrow(/Neo4j/i);
   });
 
+  it("points at the repo path first, not at standing up a database", async () => {
+    // The usual cause of an unconfigured store is a missing REPOSKEIN_REPO_PATH.
+    // Leading with Neo4j sends a zero-infra user off to install infrastructure
+    // they do not need to answer a single query.
+    const store = new UnconfiguredStore();
+    await expect(store.runRead("MATCH (n) RETURN n")).rejects.toThrow(/REPOSKEIN_REPO_PATH/);
+    await expect(store.runRead("MATCH (n) RETURN n")).rejects.toThrow(/reposkein-mcp index/);
+    await expect(store.runRead("MATCH (n) RETURN n")).rejects.toThrow(/git-ignored/);
+  });
+
   it("UnconfiguredStore.writeSummary rejects with a Neo4j configuration message", async () => {
     const store = new UnconfiguredStore();
     await expect(

--- a/mcp/test/indexerTools.int.test.ts
+++ b/mcp/test/indexerTools.int.test.ts
@@ -1,13 +1,19 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import neo4j, { type Driver } from "neo4j-driver";
 import { makeInitCpgSkeleton } from "../src/tools/indexerTools.js";
 
-const INDEXER = "/Users/mjnong/repos/reposkein/indexer/target/debug/reposkein-indexer";
+/** The locally built indexer, resolved from this file rather than an absolute
+ *  path: a hardcoded home directory only ever worked on one machine. */
+const INDEXER =
+  process.env.REPOSKEIN_INDEXER_BIN ??
+  fileURLToPath(new URL("../../indexer/target/debug/reposkein-indexer", import.meta.url));
 const REPO = "inittest";
-const gated = process.env.NEO4J_PASSWORD ? describe : describe.skip;
+// Needs both a database and a built indexer; either one absent means skip.
+const gated = process.env.NEO4J_PASSWORD && existsSync(INDEXER) ? describe : describe.skip;
 
 gated("init_cpg_skeleton (integration)", () => {
   let dir: string;

--- a/skills/reposkein-setup/SKILL.md
+++ b/skills/reposkein-setup/SKILL.md
@@ -10,7 +10,7 @@ description: >
 # RepoSkein Setup & Health Check
 
 Goal: get RepoSkein actually serving in THIS repo, then confirm it before relying
-on it. RepoSkein has three moving parts — the **indexer binary**, the committed
+on it. RepoSkein has three moving parts — the **indexer binary**, the
 **`.reposkein/` graph**, and the **MCP server** registered in your agent. This
 skill walks all three and verifies each.
 
@@ -30,8 +30,15 @@ If both pass, skip to step 4 (verify the server). Otherwise continue.
 ```bash
 npx -y @reposkein/mcp init .       # fetches the indexer, installs git hooks + the navigation skill
 reposkein-indexer index .          # builds .reposkein/ (or ask the agent to call init_cpg_skeleton)
-git add .reposkein && git commit -m "chore: add RepoSkein graph"
+git add .reposkein/meta.json .reposkein/config.toml .reposkein/.gitignore
+git commit -m "chore: add RepoSkein config"
 ```
+
+`nodes.jsonl` and `edges.jsonl` stay out of git: they are derived from the working
+tree, so every clone rebuilds them in seconds (the MCP server does it on startup
+when they are missing), and committing them would conflict on every branch that
+touches code. `summaries.jsonl` appears once an agent writes its first summary —
+commit that one, since nothing can regenerate it.
 
 Re-run `npx -y @reposkein/mcp doctor .` until the binary + index checks are `✓`.
 
@@ -51,7 +58,8 @@ differently. Add the RepoSkein server with `REPOSKEIN_REPO_PATH` set to this rep
 > **Gitignore these files.** `.mcp.json` / `opencode.json` hold absolute machine
 > paths and a local backend password, so they are per-machine and must not be
 > committed. `reposkein-mcp init` adds them to `.gitignore` for you; if you wrote
-> them by hand, add them yourself. Only the `.reposkein/` graph gets committed.
+> them by hand, add them yourself. From `.reposkein/`, what gets committed is
+> `meta.json`, `config.toml` and `summaries.jsonl`.
 
 Then **restart / reload the agent** so it picks up the new server.
 


### PR DESCRIPTION
## The problem

`nodes.jsonl` and `edges.jsonl` are a pure function of the working tree, but they were tracked and the `pre-commit` hook re-staged them on every commit. Every branch therefore modified both files, so every merge made every other open pull request report `CONFLICTING`.

## A merge driver cannot fix this

Forges compute mergeability in a **bare** repository, and git does not consult a tree-level `.gitattributes` when there is no worktree. Verified against a bare clone:

- `git check-attr merge .reposkein/nodes.jsonl` reports the declared rule in a worktree and `unspecified` in the bare repo.
- `git merge-tree --write-tree` exits 1 with conflict markers.
- Injecting the same rule into the bare repo's `info/attributes` makes it apply, which confirms attribute lookup, not driver availability, is the mechanism.

This defeats the custom `reposkein-jsonl` driver and the built-in `merge=union` alike, so **#32 is superseded by this PR** and should be closed.

Where union *does* apply it makes things worse: it keeps both sides' lines, so a node both branches touched lands twice with the same `id` and different bodies. A reader taking the last match sees a stale node shape. Forty duplicate ids were observed after one rebase in a consumer repo, invisible to `git diff --name-only` because the hook re-snapshots the pre-rebase tree.

## What committing actually bought

Nothing measurable. Across all 16 CellarNode repositories: **29,605 committed nodes, zero carrying a `semantic_summary`, 18.1 MB** of machine-generated JSONL under version control. The one thing committing was supposed to preserve was never present.

The committed graph was also already wrong. At `cellarnode-backend-v2` HEAD the committed `nodes.jsonl` held 8,109 lines while a fresh index of the same tree with the same indexer produced 10,257 nodes (edges 13,122 against 17,454). Roughly 21 percent stale, so the hook was not in fact keeping it in sync.

Worth noting: this repository never dogfooded its own advice. Its `.gitignore` line 5 is `.reposkein/`.

## The cost of removing them, measured

A cold full index of `cellarnode-backend-v2` (1,896 files, 10,257 nodes, 17,454 edges) takes **2.04s** wall clock; warm, 0.37s. Building on first use is far cheaper than the conflict tax, so on-demand is viable and the "too slow" escape hatch does not apply.

## What changed

**Indexer**

- `index` writes `.reposkein/.gitignore` covering `nodes.jsonl` and `edges.jsonl`.
- Authored summaries move to a small committed `.reposkein/summaries.jsonl`. It shares the sidecar line format, so `read_sidecar_summaries` parses both.
- The summaries file is written **verbatim, filtered only by live node id, never by content hash**. `graft_summaries` drops a summary the moment its node's `content_hash` changes, so hash-filtering would silently delete authored prose on an unrelated refactor and churn a committed file on every edit. Staleness becomes a read-time signal instead. Only summaries whose node id no longer exists are dropped.
- `index` gathers authored summaries from four sources oldest-first: a legacy committed `nodes.jsonl`, the committed `summaries.jsonl`, the database, and the atomically-claimed local sidecar. An existing repo loses nothing on its first run after upgrading.
- The `pre-commit` hook no longer stages anything.
- `init` strips `merge=reposkein-jsonl` and `merge=union` declarations from `.gitattributes` (removing the file if it held nothing else) and unsets both git config keys. A foreign `.gitattributes` is left byte-identical.
- `merge-jsonl` is deliberately retained so a stale local driver registration still resolves to a working binary mid-migration.

**MCP server**

- New `mcp/src/indexer/ensureGraph.ts`. `main()` calls it before `buildStore`: if the derived JSONL is absent it builds it, logging to **stderr** (stdout is the stdio transport) what it is doing, why the wait is happening, and how long it took. It never throws, so startup survives an unindexable repo, and it skips when Neo4j is the store so it can never switch a configured user's backend out from under them.
- `UnconfiguredStore` now points at `REPOSKEIN_REPO_PATH` and `reposkein-mcp index` rather than at standing up a database, which was the wrong first suggestion for the common cause.

**No `.gitattributes`, no merge driver, at all.** A genuine conflict in `summaries.jsonl` is semantically meaningful and deserves a human.

## Design note: two departures from the obvious version

1. A bare gitignore would have **silently discarded summaries**, because `index` consumes the local sidecar after grafting into `nodes.jsonl`. Hence the committed `summaries.jsonl`.
2. Filtering that file by content hash looks correct and is not, for the reason above.

## Tests

New `indexer/crates/cli/tests/summaries_cli.rs` (9 tests): derived JSONL is gitignored and `summaries.jsonl` is not; a repo with no summaries gets no file; a sidecar summary is persisted with no `content_hash` / `labels` / `path` / `start_line` leakage; the file is deterministic across runs; a summary survives the source changing under it (dropped from `nodes.jsonl`, retained in `summaries.jsonl`); a fresh clone rebuilds from the committed summaries alone; a summary for deleted code is dropped; summaries in a legacy committed `nodes.jsonl` are harvested; a corrupt derived `nodes.jsonl` does not abort the index.

`indexer/crates/cli/tests/init_hooks_cli.rs` rewritten (6 tests): the hook stages nothing; `init` declares no merge driver; it migrates away both a legacy custom driver declaration and a union declaration; it leaves a foreign `.gitattributes` byte-identical.

New `mcp/test/ensureGraph.test.ts` (8 tests) covering the build-on-fresh-clone path, the explain-before / report-after logging, the three skip conditions, and the failure path.

Also fixes a pre-existing integration test in `mcp/test/indexerTools.int.test.ts` that spawned the indexer from a hardcoded personal absolute path, which only ever worked on one machine. Now resolved from `import.meta.url`, overridable via `REPOSKEIN_INDEXER_BIN`, and gated on the binary existing.

### Exit codes

```
cargo test --all                               0
cargo fmt --all -- --check                     0
cargo clippy --all-targets -- -D warnings      0
npm run typecheck                              0
npm test                                       0   (37/37 files, 325 passed | 1 skipped)
```

## Migration

`docs/migrations/2026-08-06-stop-committing-derived-graph.md`. Plan only, nothing executed. Covers the per-repository steps (`index` then `git rm --cached` then `init` then explicit-path staging), verification including a fresh-clone check, and what breaks for a contributor who pulls mid-migration. The one failure mode that does not self-correct is a contributor still on the old indexer, whose hook re-stages the files and undoes the migration for that branch, which is why the version prerequisite is not optional.

## Docs

`README.md`, `docs/INSTALL.md`, `AGENTS.md`, `mcp/src/store/AGENTS.md`, `CONTRIBUTING.md` and `skills/reposkein-setup/SKILL.md` updated. CONTRIBUTING gains a third hard invariant: derived output stays out of git.
