### PR TITLE
chore(release): 0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to RepoSkein. Format roughly follows
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-08-07
+
+### Changed
+
+- **The derived graph is no longer committed; summaries are.** `.reposkein/nodes.jsonl`
+  and `edges.jsonl` are regenerated artefacts, and committing them cost more than it
+  bought. `reposkein-mcp init` now gitignores them, `ensureGraph` builds them on demand
+  when they are absent, and the merge-driver declaration they required is removed from
+  `.gitattributes` (the cleanup matches any `merge=` on those two paths, so both the
+  `reposkein-jsonl` and `union` variants go). Semantic summaries, which are authored
+  rather than derived, are what a repo shares. (#35)
+
+  Two problems this removes, both measured in the CellarNode workspace:
+
+  - **Context exhaustion in coding agents.** The pre-commit hook rewrote both files on
+    every commit, so they landed in `git diff` output. In one consumer repo the tracked
+    pair reached **7.2 MB, roughly 1.9x a 1M-token context window**, which repeatedly
+    killed agents mid-task with autocompact thrashing.
+  - **Silent duplicate node ids after a rebase.** Replaying a commit that touched the
+    graph could leave duplicate ids that `git diff --name-only` does not surface, since
+    the file is listed as changed either way. Observed at 26, 19, 4 and 40 duplicates
+    on separate rebases, each requiring a re-index to clear.
+
+  **Migrating an existing repo:** run `reposkein-mcp init` to pick up the new
+  `.gitignore` and `.gitattributes`, then `git rm --cached .reposkein/nodes.jsonl
+  .reposkein/edges.jsonl` and commit. The graph rebuilds locally on next use.
+
 ## [0.2.6] - 2026-07-06
 
 ### Added

--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -1083,7 +1083,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reposkein-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-indexer"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-common"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "reposkein-core",
  "tree-sitter",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-csharp"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-go"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-java"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-python"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-rust"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-ts"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-neo4j-io"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "neo4rs",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/lang-common", "crates/cli", "crates/lang-python", "crates/lang-ts", "crates/lang-rust", "crates/lang-go", "crates/lang-java", "crates/neo4j-io", "crates/lang-csharp"]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/reposkein/reposkein"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Deterministic code-graph (GraphRAG) MCP server — give your AI agent callers/callees, change-impact, and semantic search over your repo instead of grep. 7 languages, zero-infra, git-native.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Cuts the release that makes #35 available to consumers.

## Why this is needed now

#35 merged, but **nothing downstream has it.** The installed `@reposkein/mcp` is `0.2.6`, so `reposkein-mcp init` still writes the old `.gitignore` and `.gitattributes`, and all 16 CellarNode repos keep tracking the derived graph.

## What #35 fixes, measured

Both problems were observed in the CellarNode workspace, not hypothesised:

**Context exhaustion in coding agents.** The pre-commit hook rewrites `nodes.jsonl` and `edges.jsonl` on every commit, so they land in `git diff` output. Tracked sizes:

| repo | tracked | ~tokens if fully diffed |
|---|--:|--:|
| `cellarnode-backend-v2` | **7.2 MB** | **~1890k** |
| `ui` | **3.9 MB** | **~1030k** |
| `producer-dashboard` | 2.3 MB | ~600k |
| `cellarnode-elabel-frontend` | 0.6 MB | ~156k |

A 1M-token window holds roughly 4 MB of text, so backend-v2's tracked graph alone is about 1.9x a full window. **Five agents died to autocompact thrashing in exactly the two repos at the top of that table**, and none in the ones at the bottom.

**Silent duplicate node ids after a rebase.** Replaying a commit that touched the graph can leave duplicate ids that `git diff --name-only` does not surface, because the file is listed as changed either way. Observed at 26, 19, 4 and 40 duplicates on separate rebases, each needing a re-index to clear. A reviewer looking at a clean-looking diff has no signal.

Note `.reposkein/local/` is separately 101 MB in backend-v2, but it is gitignored and never reaches git output. The tracked JSONL is the problem.

## Contents

| File | Change |
| -- | -- |
| `mcp/package.json` | `0.2.6` -> `0.2.7` |
| `CHANGELOG.md` | 0.2.7 entry with the migration steps |

No code changes. #35 is already on `main`.

## Releasing

Per `.github/workflows/release.yml`, the tag drives it and the published version must match `mcp/package.json`:

```
git tag v0.2.7 && git push origin v0.2.7
```

That builds the four prebuilt `reposkein-indexer` binaries (darwin-arm64, linux-x64, linux-arm64, win32-x64), attaches them to the GitHub Release, then publishes `@reposkein/mcp`. Needs the `NPM_TOKEN` repo secret; the publish job is skipped without it.

## Consumer migration, after publishing

Per repo: `reposkein-mcp init` to pick up the new `.gitignore` and `.gitattributes`, then `git rm --cached .reposkein/nodes.jsonl .reposkein/edges.jsonl` and commit. The graph rebuilds locally on next use.