### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ All notable changes to RepoSkein. Format roughly follows
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-20
+
+### Added
+
+- **Architecture Decision Records: the graph now remembers *why*.** Agents record
+  significant design decisions with the new `record_decision` MCP tool, anchored to
+  the graph nodes and paths they govern; recall them with `list_decisions` /
+  `get_decision`, ratify or retire them with `set_decision_status`, and re-stamp a
+  still-correct decision after code changes with `reaffirm_decision`. Records land
+  as `proposed` (a human ratifies), bodies are immutable (`body_hash`-checked), and
+  nothing is ever machine-deleted — a decision about deleted code is still history.
+  (#42)
+
+  - **Storage that survives teams.** One committed JSON file per decision at
+    `.reposkein/decisions/<date>-<slug>.json` — parallel branches appending records
+    never merge-conflict on forges (the lesson from #35). Ids are portable
+    `adr:<date>-<slug>` (no repo_id, so forks and no-remote clones resolve them);
+    anchors keep full `rs1:` node ids, matched tolerantly by suffix, with
+    content-hash recovery when anchored code is renamed.
+  - **Decisions surface where agents already look.** `get_context_profile` returns
+    `target.decisions` plus `decisions_needing_review` for accepted decisions whose
+    code drifted; `impact` returns `governing_decisions` over the target and its
+    impacted callers; `semantic_find` ranks decisions in the corpus, so "why don't
+    we X?" queries answer from recorded rationale (kind: `"Decision"` filters to it).
+  - **Mechanical drift detection.** The indexer diffs the previous graph against the
+    fresh one (`graph_delta` in `--json` stats — content-hash based, so line shifts
+    and summary edits never fire it) and persists the delta to
+    `.reposkein/local/last_delta.json`; hook-driven indexes discard stdout, and
+    post-merge is exactly when teammate changes invalidate decisions, so the next
+    `reindex_file` / `init_cpg_skeleton` call surfaces `decisions_affected` — the
+    skill instructs the agent to conform, supersede, or reaffirm.
+  - **Interop + hygiene.** `reposkein-mcp adr export` renders the log to
+    `docs/adr/NNNN-slug.md` (Nygard sections; a derived view — JSON stays the system
+    of record) and `adr import` brings an existing markdown ADR log in, idempotently.
+    `reposkein-mcp doctor` validates the log: parse failures, duplicate ids,
+    body-hash tampering, dangling/cyclic supersession, and a ~100-active-record
+    budget warning.
+  - The `reposkein-graph-rag` skill gains when-to-record guidance (significance
+    test + anti-triggers) and the rule: check `list_decisions` before modifying
+    governed code — never silently violate a decision. RepoSkein's own repo ships
+    three seeded decisions recorded through these tools.
+
 ## [0.2.7] - 2026-08-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ All notable changes to RepoSkein. Format roughly follows
     governed code — never silently violate a decision. RepoSkein's own repo ships
     three seeded decisions recorded through these tools.
 
+### Security
+
+- **All nine open Dependabot alerts resolved** (lockfile-only; no API changes).
+  The one runtime exposure in the shipped package — `body-parser` < 2.3.0 (DoS
+  when an invalid `limit` silently disables size enforcement, low severity, via
+  `@modelcontextprotocol/sdk` → `express`) — is bumped to 2.3.0. The remaining
+  eight were development-scope build tooling in the mcp and viz dependency
+  trees: `postcss` → 8.5.26 (source-map path traversal + its incomplete fix),
+  `js-yaml` → 4.3.1 (quadratic CPU in `!!omap` and merge-key chains), and
+  `brace-expansion` → 1.1.18 / 5.0.9 (exponential-time expansion DoS).
+
 ## [0.2.7] - 2026-08-07
 
 ### Changed

--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -1083,7 +1083,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reposkein-core"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-indexer"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-common"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "reposkein-core",
  "tree-sitter",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-csharp"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-go"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-java"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-python"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-rust"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-ts"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-neo4j-io"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "neo4rs",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/lang-common", "crates/cli", "crates/lang-python", "crates/lang-ts", "crates/lang-rust", "crates/lang-go", "crates/lang-java", "crates/neo4j-io", "crates/lang-csharp"]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/reposkein/reposkein"

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -671,21 +671,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1706,9 +1719,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1885,9 +1898,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1905,7 +1918,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reposkein/mcp",
-      "version": "0.2.7",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "Deterministic code-graph (GraphRAG) MCP server — give your AI agent callers/callees, change-impact, and semantic search over your repo instead of grep. 7 languages, zero-infra, git-native.",
   "keywords": [
     "mcp",

--- a/viz/pnpm-lock.yaml
+++ b/viz/pnpm-lock.yaml
@@ -853,12 +853,12 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1157,8 +1157,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1246,8 +1246,8 @@ packages:
       postprocessing: '>=6.30.0'
       three: '>=0.137'
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1300,8 +1300,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postprocessing@6.39.1:
@@ -1905,7 +1905,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2439,12 +2439,12 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2738,7 +2738,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2803,11 +2803,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   ms@2.1.3: {}
 
@@ -2816,7 +2816,7 @@ snapshots:
       postprocessing: 6.39.1(three@0.169.0)
       three: 0.169.0
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -2857,9 +2857,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3119,7 +3119,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.26
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
Cuts the release carrying #42 — **Architecture Decision Records** — plus resolution of all nine open Dependabot alerts.

- Bumps the Rust workspace and `@reposkein/mcp` to **0.3.0** in lockstep (the npm postinstall fetches the indexer binary for its own version, so the versions must match; the `version-lockstep` CI job guards this).
- Adds the 0.3.0 changelog entry (Added: ADRs; Security: dependency bumps).
- Dependency fixes are lockfile-only: `body-parser` → 2.3.0 (the one runtime exposure, via `@modelcontextprotocol/sdk` → `express`), `postcss` → 8.5.26, `js-yaml` → 4.3.1, `brace-expansion` → 1.1.18 / 5.0.9 (dev-scope build tooling in mcp/viz).

After merge: tag `v0.3.0` on main → `.github/workflows/release.yml` builds the four prebuilt indexer binaries, attaches them to the GitHub Release, and publishes `@reposkein/mcp@0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)