### PR TITLE
fix: zero-config repo resolution — walk-up/walk-down discovery, list_repos/select_repo session tools (REP-23)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -57,6 +57,8 @@ Then ask your agent *"what calls this function?"* or *"what breaks if I change X
 
 | Tool | What it does |
 | --- | --- |
+| `list_repos` | enumerate the repos discovered by resolution — path, name, cheap node/edge counts. One entry in single-repo mode; workspace mode lists every sibling repo found |
+| `select_repo` | set the session-active repo (by `path` or `name` from `list_repos`) for every repo-scoped tool below — how workspace mode resolves ambiguity, and how you switch repos without restarting the server |
 | `get_context_profile` | resolve a function/class → its caller/callee neighborhood as ready-to-read prose |
 | `semantic_find` | find where to start — rank functions/classes by meaning (lexical BM25F; optional pluggable embeddings), seeding `get_context_profile` |
 | `impact` | transitive callers of a function/class — split into impacted code vs covering tests — with counts and truncated flag |
@@ -97,20 +99,29 @@ npx skills add reposkein/reposkein --all
 ### Repo resolution (zero-config)
 
 `REPOSKEIN_REPO_PATH` is optional — the server resolves the target repo from
-the process's working directory, in this order:
+the process's working directory. Full precedence:
 
-1. `REPOSKEIN_REPO_PATH`, if set.
-2. **Walk up:** the nearest ancestor of the cwd containing `.reposkein/`.
-3. **Walk down** (workspace mode, only tried when no ancestor has one): scans
+1. **`select_repo`** — an MCP tool call that sets the session-active repo
+   (by `path` or `name` from `list_repos`) for every repo-scoped tool call
+   made afterward, for the rest of the connection. The only one of these
+   that's mutable at runtime — everything below it is fixed at server start.
+2. `REPOSKEIN_REPO_PATH`, if set.
+3. **Walk up:** the nearest ancestor of the cwd containing `.reposkein/`.
+4. **Walk down** (workspace mode, only tried when no ancestor has one): scans
    the cwd's children and grandchildren (skipping `node_modules`, `.git`,
    `target`, `dist`, `.worktrees`, `.claude`) for `.reposkein/` dirs. One hit
-   is used automatically; two or more leave the repo unresolved.
+   is used automatically; two or more leave the repo unresolved until a
+   `select_repo` call picks one — `list_repos` always enumerates every repo
+   the walk finds (plus a `REPOSKEIN_REPO_PATH` pin, if one is set and not
+   already among them), regardless of which one is currently active.
 
-If nothing resolves — or step 3 finds more than one repo — repo-scoped tools
-don't fail silently at startup: each call returns a structured error telling
-you what to run (`reposkein-mcp init`) or which `REPOSKEIN_REPO_PATH` to set
-(naming the candidates when ambiguous). `reposkein-mcp doctor` and `--help`
-never require a resolved repo. See `mcp/src/store/resolveRepoPath.ts`.
+If nothing resolves — or step 4 finds more than one repo and none has been
+`select_repo`'d — repo-scoped tools don't fail silently at startup: each call
+returns a structured error telling you what to run (`reposkein-mcp init`,
+`list_repos`/`select_repo`, or which `REPOSKEIN_REPO_PATH` to set — naming the
+candidates when ambiguous). `reposkein-mcp doctor` and `--help` never require
+a resolved repo. See `mcp/src/store/resolveRepoPath.ts` and
+`mcp/src/store/repoSession.ts`.
 
 | Env var | Purpose |
 | --- | --- |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -94,9 +94,27 @@ npx skills add reposkein/reposkein --all
 
 ## Configuration
 
+### Repo resolution (zero-config)
+
+`REPOSKEIN_REPO_PATH` is optional — the server resolves the target repo from
+the process's working directory, in this order:
+
+1. `REPOSKEIN_REPO_PATH`, if set.
+2. **Walk up:** the nearest ancestor of the cwd containing `.reposkein/`.
+3. **Walk down** (workspace mode, only tried when no ancestor has one): scans
+   the cwd's children and grandchildren (skipping `node_modules`, `.git`,
+   `target`, `dist`, `.worktrees`, `.claude`) for `.reposkein/` dirs. One hit
+   is used automatically; two or more leave the repo unresolved.
+
+If nothing resolves — or step 3 finds more than one repo — repo-scoped tools
+don't fail silently at startup: each call returns a structured error telling
+you what to run (`reposkein-mcp init`) or which `REPOSKEIN_REPO_PATH` to set
+(naming the candidates when ambiguous). `reposkein-mcp doctor` and `--help`
+never require a resolved repo. See `mcp/src/store/resolveRepoPath.ts`.
+
 | Env var | Purpose |
 | --- | --- |
-| `REPOSKEIN_REPO_PATH` | the repository the server operates on (required for repo-scoped tools) |
+| `REPOSKEIN_REPO_PATH` | pins the repository the server operates on — optional, see repo resolution above |
 | `REPOSKEIN_STORE` | `auto` (default) · `jsonl` (zero-infra) · `neo4j` |
 | `REPOSKEIN_INDEXER_BIN` | override the `reposkein-indexer` binary path (unsupported platforms) |
 | `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD` | optional Neo4j backend (large graphs / Cypher at scale) |

--- a/mcp/src/cli/doctor.ts
+++ b/mcp/src/cli/doctor.ts
@@ -3,7 +3,38 @@ import { join } from "node:path";
 import { ensureIndexerBinary } from "../indexer/fetchBinary.js";
 import { spawnIndexer } from "../indexer/runIndexer.js";
 import { resolveRepoId } from "../store/repoId.js";
+import { resolveRepoPath } from "../store/resolveRepoPath.js";
 import { decisionChecks } from "./doctorDecisions.js";
+
+export interface DoctorPathResolution {
+  path: string;
+  /** Set when walk-down found 2+ candidate repos and neither an explicit
+   *  path nor REPOSKEIN_REPO_PATH picked one — `path` falls back to `cwd`
+   *  in this case so the caller can still print a real (failing) report. */
+  error?: string;
+}
+
+/** Resolves the repo path for `reposkein-mcp doctor [path]`: explicit arg >
+ *  REPOSKEIN_REPO_PATH > walk-up (nearest ancestor with .reposkein/) >
+ *  walk-down (workspace mode). Verifies doctor works from a subdirectory
+ *  cwd — the common case of running it somewhere other than the repo root. */
+export function resolveDoctorRepoPath(
+  explicitPath: string | undefined,
+  cwd: string,
+  envRepoPath: string | undefined
+): DoctorPathResolution {
+  const resolution = resolveRepoPath({ cwd, envRepoPath, explicit: explicitPath });
+  if (resolution.repoPath) return { path: resolution.repoPath };
+  if (resolution.candidates && resolution.candidates.length > 0) {
+    return {
+      path: cwd,
+      error:
+        `multiple RepoSkein repos found under ${cwd}: ${resolution.candidates.join(", ")}. ` +
+        "Pass one explicitly: `reposkein-mcp doctor <path>` (or set REPOSKEIN_REPO_PATH).",
+    };
+  }
+  return { path: cwd };
+}
 
 export interface Check {
   id: string;

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -14,6 +14,7 @@ import { UnconfiguredStore } from "./store/UnconfiguredStore.js";
 import type { GraphStore } from "./store/GraphStore.js";
 import { JsonlGraphStore } from "./store/JsonlGraphStore.js";
 import { makeReadCypher } from "./tools/readCypher.js";
+import type { ToolResult } from "./tools/readCypher.js";
 import { makeGetContextProfile } from "./tools/getContextProfile.js";
 import { makeWriteSemanticSummary } from "./tools/writeSemanticSummary.js";
 import { makeInitCpgSkeleton, makeReindexFile } from "./tools/indexerTools.js";
@@ -26,7 +27,8 @@ import { makeReaffirmDecision } from "./tools/reaffirmDecision.js";
 import { makeListDecisions } from "./tools/listDecisions.js";
 import { makeGetDecision } from "./tools/getDecision.js";
 import { resolveRepoId } from "./store/repoId.js";
-import { resolveRepoPath, type RepoResolution } from "./store/resolveRepoPath.js";
+import type { RepoResolution } from "./store/resolveRepoPath.js";
+import { RepoSession } from "./store/repoSession.js";
 import { ensureGraph } from "./indexer/ensureGraph.js";
 import { ensureIndexerBinary, packageVersion } from "./indexer/fetchBinary.js";
 import { spawnIndexer } from "./indexer/runIndexer.js";
@@ -86,20 +88,25 @@ Docs: https://github.com/reposkein/reposkein/tree/main/mcp#readme`;
 
 /** Structured, actionable message for repo-scoped tool calls when no repo
  *  resolved (see `resolveRepoPath`). Names the discovered candidates when
- *  resolution failed due to workspace-mode ambiguity, so the agent can pick
- *  one instead of abandoning the tools. */
-function repoRequiredMessage(resolution: RepoResolution): string {
+ *  resolution failed due to workspace-mode ambiguity, and points at
+ *  `list_repos` / `select_repo` so the agent can pick one instead of
+ *  abandoning the tools. */
+// Exported for the regression test below (repoRequiredMessage.test.ts) — it
+// must keep pointing agents at list_repos/select_repo, not just the env var.
+export function repoRequiredMessage(resolution: RepoResolution): string {
   if (resolution.candidates && resolution.candidates.length > 0) {
     return (
       `Multiple RepoSkein repos were found under ${process.cwd()} and none is selected: ` +
       resolution.candidates.join(", ") +
-      `. Set REPOSKEIN_REPO_PATH to one of them to use this tool.`
+      ". Call list_repos to see them, then select_repo with one of its `path` or `name` " +
+      "values (or set REPOSKEIN_REPO_PATH) to use this tool."
     );
   }
   return (
     "No RepoSkein repo found (checked the current directory, its ancestors, and its " +
     "immediate subdirectories for .reposkein/). Run `reposkein-mcp init` in the repository " +
-    "you want to work with, or set REPOSKEIN_REPO_PATH to its root."
+    "you want to work with, call list_repos to check what was discovered, or set " +
+    "REPOSKEIN_REPO_PATH to its root."
   );
 }
 
@@ -153,24 +160,93 @@ export async function main(): Promise<void> {
   // Zero-config repo resolution: explicit arg (n/a here) > REPOSKEIN_REPO_PATH >
   // walk-up (nearest ancestor with .reposkein/) > walk-down (workspace mode).
   // See store/resolveRepoPath.ts for the full precedence + ambiguity rules.
-  const resolution = resolveRepoPath({
+  // Session-scoped resolution: `select_repo` (below) can override this for
+  // the rest of the connection. Precedence: select_repo > REPOSKEIN_REPO_PATH
+  // > walk-up > walk-down. See store/repoSession.ts.
+  const session = new RepoSession({
     cwd: process.cwd(),
     envRepoPath: process.env.REPOSKEIN_REPO_PATH,
   });
-  const repoPath = resolution.repoPath;
-  const repoId = resolveRepoId(repoPath, process.env.REPOSKEIN_REPO_ID);
-  const REPO_REQUIRED_MSG = repoRequiredMessage(resolution);
-  // Build the graph if the repo has none yet. Derived JSONL is git-ignored, so a
-  // fresh clone arrives without it; without this the first query would fail on a
-  // repo that indexes fine in a couple of seconds.
-  await ensureGraph(repoPath, repoId, {
-    mode: (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase(),
-    neo4jConfigured: !!process.env.NEO4J_PASSWORD,
-  });
-  const store = buildStore(repoPath, repoId);
+
+  // Per-repoPath {repoId, store} cache. Constructing a JsonlGraphStore is
+  // cheap (it lazily loads/re-parses its graph per call, keyed by file
+  // mtime) but re-running resolveRepoId/ensureGraph/buildStore on every tool
+  // call would still be wasted work for the common single-repo case, and
+  // rebuilding the store object would also throw away that per-instance
+  // mtime cache — so one context is built per repoPath and reused, letting
+  // `select_repo` switch back and forth cheaply too.
+  const repoContexts = new Map<string, { repoId: string | undefined; store: GraphStore }>();
+  async function getRepoContext(path: string): Promise<{ repoId: string | undefined; store: GraphStore }> {
+    const cached = repoContexts.get(path);
+    if (cached) return cached;
+    const id = resolveRepoId(path, process.env.REPOSKEIN_REPO_ID);
+    // Build the graph if the repo has none yet. Derived JSONL is git-ignored,
+    // so a fresh clone arrives without it; without this the first query on a
+    // newly selected repo would fail on one that indexes fine in seconds.
+    await ensureGraph(path, id, {
+      mode: (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase(),
+      neo4jConfigured: !!process.env.NEO4J_PASSWORD,
+    });
+    const ctx = { repoId: id, store: buildStore(path, id) };
+    repoContexts.set(path, ctx);
+    return ctx;
+  }
+
+  type ActiveRepo =
+    | { ok: true; repoPath: string; repoId: string; store: GraphStore }
+    | { ok: false; message: string };
+  /** Resolves the session's current repo for a repo-scoped tool call.
+   *  Re-evaluated on every call (not once at startup) so `select_repo`
+   *  actually takes effect for calls made after it. */
+  async function resolveActiveRepo(): Promise<ActiveRepo> {
+    const resolution = session.resolve();
+    if (!resolution.repoPath) return { ok: false, message: repoRequiredMessage(resolution) };
+    const ctx = await getRepoContext(resolution.repoPath);
+    if (!ctx.repoId) return { ok: false, message: repoRequiredMessage(resolution) };
+    return { ok: true, repoPath: resolution.repoPath, repoId: ctx.repoId, store: ctx.store };
+  }
+  const errResult = (message: string): ToolResult => ({ content: [{ type: "text", text: message }], isError: true });
 
   const server = new McpServer({ name: "@reposkein/mcp", version: "0.0.0" });
-  const readCypher = makeReadCypher(store, repoId);
+
+  server.registerTool(
+    "list_repos",
+    {
+      title: "List discovered repos",
+      description:
+        "Enumerate the RepoSkein repos discovered from the server's working directory (walk-up: the nearest ancestor with .reposkein/; walk-down/workspace mode: subdirectories, when no ancestor has one). Single-repo setups return exactly one entry. In workspace mode (multiple sibling repos, no default selected), use this to see the candidates, then `select_repo` one before calling other repo-scoped tools.",
+      inputSchema: {},
+    },
+    async () => {
+      const repos = session.list();
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              mode: repos.length > 1 ? "workspace" : "single",
+              repos,
+            }),
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerTool(
+    "select_repo",
+    {
+      title: "Select the active repo",
+      description:
+        "Set the session-active repo for all subsequent repo-scoped tool calls (get_context_profile, semantic_find, impact, decisions, etc.) — the fix for workspace-mode ambiguity (list_repos returned more than one candidate). Pass a `repo` value from list_repos: its `path` or its `name`. Overrides REPOSKEIN_REPO_PATH and any earlier select_repo call for the rest of this connection; stays in effect until called again.",
+      inputSchema: { repo: z.string() },
+    },
+    async (args) => {
+      const result = session.select(args.repo);
+      if (!result.ok) return errResult(result.error);
+      return { content: [{ type: "text", text: JSON.stringify({ ok: true, selected: result.repo }) }] };
+    }
+  );
 
   server.registerTool(
     "read_cypher",
@@ -184,12 +260,18 @@ export async function main(): Promise<void> {
         federated: z.boolean().optional(),
       },
     },
-    async (args) => readCypher(args)
+    async (args) => {
+      // read_cypher tolerates an unresolved repo (falls back to whatever
+      // buildStore(undefined, undefined) picks — Neo4j if configured, else
+      // UnconfiguredStore — matching its pre-existing, non-gated behavior).
+      const resolution = session.resolve();
+      const ctx = resolution.repoPath
+        ? await getRepoContext(resolution.repoPath)
+        : { repoId: undefined, store: buildStore(undefined, undefined) };
+      return makeReadCypher(ctx.store, ctx.repoId)(args);
+    }
   );
 
-  // Repo-scoped tools are always registered; they check repoId at call time.
-  // Handlers are constructed with a real repoId only if it's available.
-  const getContextProfile = repoId ? makeGetContextProfile(store, repoId, repoPath) : null;
   server.registerTool(
     "get_context_profile",
     {
@@ -199,14 +281,12 @@ export async function main(): Promise<void> {
       inputSchema: getContextProfileInputSchema,
     },
     async (args) => {
-      if (!getContextProfile) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return getContextProfile(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeGetContextProfile(active.store, active.repoId, active.repoPath)(args);
     }
   );
 
-  const writeSummary = repoId ? makeWriteSemanticSummary(store, repoId) : null;
   server.registerTool(
     "write_semantic_summary",
     {
@@ -220,14 +300,12 @@ export async function main(): Promise<void> {
       },
     },
     async (args) => {
-      if (!writeSummary) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return writeSummary(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeWriteSemanticSummary(active.store, active.repoId)(args);
     }
   );
 
-  const initSkeleton = repoId ? makeInitCpgSkeleton(repoId) : null;
   server.registerTool(
     "init_cpg_skeleton",
     {
@@ -240,14 +318,14 @@ export async function main(): Promise<void> {
       },
     },
     async (args) => {
-      if (!initSkeleton) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return initSkeleton(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      // Default to the active repo's path (not the indexer's own cwd-based
+      // fallback) so a selected/discovered repo is what actually gets indexed.
+      return makeInitCpgSkeleton(active.repoId)({ ...args, path: args?.path ?? active.repoPath });
     }
   );
 
-  const reindexFile = repoId ? makeReindexFile(repoId) : null;
   server.registerTool(
     "reindex_file",
     {
@@ -257,16 +335,12 @@ export async function main(): Promise<void> {
       inputSchema: { path: z.string() },
     },
     async (args) => {
-      if (!reindexFile) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return reindexFile(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeReindexFile(active.repoId)(args);
     }
   );
 
-  const semanticFind = repoId
-    ? makeSemanticFind(store, repoId, repoPath ?? ".", undefined, { decisions: !!repoPath })
-    : null;
   server.registerTool(
     "semantic_find",
     {
@@ -281,15 +355,12 @@ export async function main(): Promise<void> {
       },
     },
     async (args) => {
-      if (!semanticFind) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return semanticFind(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeSemanticFind(active.store, active.repoId, active.repoPath, undefined, { decisions: true })(args);
     }
   );
 
-  // get_temporal_context is gated on repoPath (not the store — it reads from .git directly).
-  const temporalContext = repoPath ? makeTemporalContext(repoPath) : null;
   server.registerTool(
     "get_temporal_context",
     {
@@ -299,14 +370,13 @@ export async function main(): Promise<void> {
       inputSchema: { path: z.string() },
     },
     async (args) => {
-      if (!temporalContext) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return temporalContext(args);
+      // Gated on repoPath only (not repoId/store) — it reads from .git directly.
+      const resolution = session.resolve();
+      if (!resolution.repoPath) return errResult(repoRequiredMessage(resolution));
+      return makeTemporalContext(resolution.repoPath)(args);
     }
   );
 
-  const impact = repoId ? makeImpact(store, repoId, repoPath) : null;
   server.registerTool(
     "impact",
     {
@@ -322,26 +392,16 @@ export async function main(): Promise<void> {
       },
     },
     async (args) => {
-      if (!impact) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return impact(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeImpact(active.store, active.repoId, active.repoPath)(args);
     }
   );
 
   // Decision tools are gated on repoPath + repoId: records live as committed
   // files under <repoPath>/.reposkein/decisions/, the graph is used only for
   // anchor resolution and hash stamping (Phase 1 — no GraphStore changes).
-  const decisionsReady = !!repoPath && !!repoId;
-  // Best-effort reindex before stamping anchors so a decision recorded right
-  // after an edit reflects the working tree, not the last index snapshot.
-  const decisionRefresh = async (): Promise<void> => {
-    const bin = await ensureIndexerBinary();
-    await spawnIndexer(bin, ["index", "--json", "--repo-id", repoId!, repoPath!]);
-  };
-  const recordDecision = decisionsReady
-    ? makeRecordDecision(store, repoId!, repoPath!, { refresh: decisionRefresh })
-    : null;
+  // `resolveActiveRepo` already requires both, so it doubles as the gate.
   server.registerTool(
     "record_decision",
     {
@@ -351,14 +411,18 @@ export async function main(): Promise<void> {
       inputSchema: recordDecisionInputSchema,
     },
     async (args) => {
-      if (!recordDecision) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return recordDecision(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      // Best-effort reindex before stamping anchors so a decision recorded
+      // right after an edit reflects the working tree, not the last index.
+      const decisionRefresh = async (): Promise<void> => {
+        const bin = await ensureIndexerBinary();
+        await spawnIndexer(bin, ["index", "--json", "--repo-id", active.repoId, active.repoPath]);
+      };
+      return makeRecordDecision(active.store, active.repoId, active.repoPath, { refresh: decisionRefresh })(args);
     }
   );
 
-  const setDecisionStatus = decisionsReady ? makeSetDecisionStatus(repoPath!) : null;
   server.registerTool(
     "set_decision_status",
     {
@@ -368,14 +432,12 @@ export async function main(): Promise<void> {
       inputSchema: setDecisionStatusInputSchema,
     },
     async (args) => {
-      if (!setDecisionStatus) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return setDecisionStatus(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeSetDecisionStatus(active.repoPath)(args);
     }
   );
 
-  const reaffirmDecision = decisionsReady ? makeReaffirmDecision(store, repoId!, repoPath!) : null;
   server.registerTool(
     "reaffirm_decision",
     {
@@ -385,14 +447,12 @@ export async function main(): Promise<void> {
       inputSchema: reaffirmDecisionInputSchema,
     },
     async (args) => {
-      if (!reaffirmDecision) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return reaffirmDecision(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeReaffirmDecision(active.store, active.repoId, active.repoPath)(args);
     }
   );
 
-  const listDecisions = decisionsReady ? makeListDecisions(store, repoId!, repoPath!) : null;
   server.registerTool(
     "list_decisions",
     {
@@ -402,14 +462,12 @@ export async function main(): Promise<void> {
       inputSchema: listDecisionsInputSchema,
     },
     async (args) => {
-      if (!listDecisions) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return listDecisions(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeListDecisions(active.store, active.repoId, active.repoPath)(args);
     }
   );
 
-  const getDecision = decisionsReady ? makeGetDecision(store, repoId!, repoPath!) : null;
   server.registerTool(
     "get_decision",
     {
@@ -419,16 +477,16 @@ export async function main(): Promise<void> {
       inputSchema: getDecisionInputSchema,
     },
     async (args) => {
-      if (!getDecision) {
-        return { content: [{ type: "text", text: REPO_REQUIRED_MSG }], isError: true };
-      }
-      return getDecision(args);
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeGetDecision(active.store, active.repoId, active.repoPath)(args);
     }
   );
 
-  // No passive startup warning here: an unresolved repo is surfaced per-call,
-  // as a structured, actionable tool error (REPO_REQUIRED_MSG above) — not a
-  // stderr line an agent can miss and route around by grepping the repo.
+  // No passive startup warning here: an unresolved (or ambiguous) repo is
+  // surfaced per-call, as a structured, actionable tool error pointing at
+  // list_repos/select_repo (repoRequiredMessage above) — not a stderr line
+  // an agent can miss and route around by grepping the repo.
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { pathToFileURL } from "node:url";
 import { runInit, runIndex } from "./cli/init.js";
-import { runDoctor } from "./cli/doctor.js";
+import { runDoctor, resolveDoctorRepoPath } from "./cli/doctor.js";
 import { runAdr } from "./cli/adr.js";
 import { runView, runExport, parseViewArgs } from "./cli/view.js";
 import { existsSync, realpathSync } from "node:fs";
@@ -26,8 +26,9 @@ import { makeReaffirmDecision } from "./tools/reaffirmDecision.js";
 import { makeListDecisions } from "./tools/listDecisions.js";
 import { makeGetDecision } from "./tools/getDecision.js";
 import { resolveRepoId } from "./store/repoId.js";
+import { resolveRepoPath, type RepoResolution } from "./store/resolveRepoPath.js";
 import { ensureGraph } from "./indexer/ensureGraph.js";
-import { ensureIndexerBinary } from "./indexer/fetchBinary.js";
+import { ensureIndexerBinary, packageVersion } from "./indexer/fetchBinary.js";
 import { spawnIndexer } from "./indexer/runIndexer.js";
 
 /** Selects the store backend.
@@ -60,9 +61,47 @@ function buildStore(repoPath: string | undefined, repoId: string | undefined): G
   return neo4j();
 }
 
-const REPO_REQUIRED_MSG =
-  "REPOSKEIN_REPO_PATH (or REPOSKEIN_REPO_ID) must be set to use this tool. " +
-  "Set REPOSKEIN_REPO_PATH to the root of the repository you want to work with.";
+const HELP_TEXT = `reposkein-mcp — deterministic code-graph MCP server
+
+Usage:
+  reposkein-mcp                 start the MCP server (stdio transport)
+  reposkein-mcp init [path]     set up a repo (indexer, git hooks, skill, graph)
+  reposkein-mcp index [path]    (re)build the committed graph
+  reposkein-mcp doctor [path]   health check (indexer binary, index, repo id)
+  reposkein-mcp adr <sub> ...   decision-log utilities
+  reposkein-mcp view [path]     open the constellation viewer (--export <dir> for a static site)
+  reposkein-mcp --help          show this help
+  reposkein-mcp --version       print the package version
+
+Repo resolution (used by the server and by [path]-less CLI commands):
+  1. an explicit path argument, if given
+  2. REPOSKEIN_REPO_PATH, if set
+  3. the nearest ancestor of the current directory containing .reposkein/
+  4. a single .reposkein/ found while scanning subdirectories (2 levels deep,
+     skipping node_modules/.git/target/dist/.worktrees/.claude)
+  If step 4 finds more than one .reposkein/, resolution fails with an error
+  naming the candidates — set REPOSKEIN_REPO_PATH (or pass a path) to pick one.
+
+Docs: https://github.com/reposkein/reposkein/tree/main/mcp#readme`;
+
+/** Structured, actionable message for repo-scoped tool calls when no repo
+ *  resolved (see `resolveRepoPath`). Names the discovered candidates when
+ *  resolution failed due to workspace-mode ambiguity, so the agent can pick
+ *  one instead of abandoning the tools. */
+function repoRequiredMessage(resolution: RepoResolution): string {
+  if (resolution.candidates && resolution.candidates.length > 0) {
+    return (
+      `Multiple RepoSkein repos were found under ${process.cwd()} and none is selected: ` +
+      resolution.candidates.join(", ") +
+      `. Set REPOSKEIN_REPO_PATH to one of them to use this tool.`
+    );
+  }
+  return (
+    "No RepoSkein repo found (checked the current directory, its ancestors, and its " +
+    "immediate subdirectories for .reposkein/). Run `reposkein-mcp init` in the repository " +
+    "you want to work with, or set REPOSKEIN_REPO_PATH to its root."
+  );
+}
 
 // Exported for the regression test. `hops` MUST stay a bounded integer: a literal union
 // (z.union([z.literal(1), z.literal(2)])) serialises to JSON-Schema `anyOf:[{const:1},{const:2}]`,
@@ -111,8 +150,16 @@ export const getDecisionInputSchema = {
 };
 
 export async function main(): Promise<void> {
-  const repoPath = process.env.REPOSKEIN_REPO_PATH;
+  // Zero-config repo resolution: explicit arg (n/a here) > REPOSKEIN_REPO_PATH >
+  // walk-up (nearest ancestor with .reposkein/) > walk-down (workspace mode).
+  // See store/resolveRepoPath.ts for the full precedence + ambiguity rules.
+  const resolution = resolveRepoPath({
+    cwd: process.cwd(),
+    envRepoPath: process.env.REPOSKEIN_REPO_PATH,
+  });
+  const repoPath = resolution.repoPath;
   const repoId = resolveRepoId(repoPath, process.env.REPOSKEIN_REPO_ID);
+  const REPO_REQUIRED_MSG = repoRequiredMessage(resolution);
   // Build the graph if the repo has none yet. Derived JSONL is git-ignored, so a
   // fresh clone arrives without it; without this the first query would fail on a
   // repo that indexes fine in a couple of seconds.
@@ -379,11 +426,9 @@ export async function main(): Promise<void> {
     }
   );
 
-  if (!repoId) {
-    console.error(
-      "[reposkein-mcp] REPOSKEIN_REPO_PATH not set; repo-scoped tools will return an error until it is configured"
-    );
-  }
+  // No passive startup warning here: an unresolved repo is surfaced per-call,
+  // as a structured, actionable tool error (REPO_REQUIRED_MSG above) — not a
+  // stderr line an agent can miss and route around by grepping the repo.
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
@@ -405,7 +450,14 @@ function invokedAsBin(): boolean {
 }
 if (invokedAsBin()) {
   const sub = process.argv[2];
-  if (sub === "init") {
+  if (sub === "--help" || sub === "-h" || sub === "help") {
+    // No repo resolution, no config warnings — just usage, per requirement #3.
+    console.log(HELP_TEXT);
+    process.exit(0);
+  } else if (sub === "--version" || sub === "-v") {
+    console.log(packageVersion());
+    process.exit(0);
+  } else if (sub === "init") {
     const rest = process.argv.slice(3);
     const noIndex = rest.includes("--no-index");
     const path = rest.find((a) => !a.startsWith("-")) ?? ".";
@@ -420,7 +472,12 @@ if (invokedAsBin()) {
   } else if (sub === "doctor") {
     const rest = process.argv.slice(3);
     const json = rest.includes("--json");
-    const path = rest.find((a) => !a.startsWith("-")) ?? process.env.REPOSKEIN_REPO_PATH ?? ".";
+    const explicitPath = rest.find((a) => !a.startsWith("-"));
+    const { path, error } = resolveDoctorRepoPath(explicitPath, process.cwd(), process.env.REPOSKEIN_REPO_PATH);
+    if (error) {
+      console.error(`reposkein doctor: ${error}`);
+      process.exit(1);
+    }
     runDoctor(path, json)
       .then((code) => process.exit(code))
       .catch((err) => { console.error(err); process.exit(1); });

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -29,6 +29,7 @@ import { makeGetDecision } from "./tools/getDecision.js";
 import { resolveRepoId } from "./store/repoId.js";
 import type { RepoResolution } from "./store/resolveRepoPath.js";
 import { RepoSession } from "./store/repoSession.js";
+import { makeCache } from "./store/repoContextCache.js";
 import { ensureGraph } from "./indexer/ensureGraph.js";
 import { ensureIndexerBinary, packageVersion } from "./indexer/fetchBinary.js";
 import { spawnIndexer } from "./indexer/runIndexer.js";
@@ -110,6 +111,24 @@ export function repoRequiredMessage(resolution: RepoResolution): string {
   );
 }
 
+// Exported for the regression test below (repoRequiredMessage.test.ts) — it
+// must name the found path and the fix (`reposkein-mcp index`), not repeat
+// the generic "no repo found" message: a repo WAS found here, it's just not
+// indexed yet (or, if `.reposkein/` isn't actually there, misconfigured).
+export function repoUnindexedMessage(repoPath: string): string {
+  if (existsSync(join(repoPath, ".reposkein"))) {
+    return (
+      `Found .reposkein/ at ${repoPath}, but it has no meta.json (not indexed yet). ` +
+      `Run \`reposkein-mcp index ${repoPath}\` (or the init_cpg_skeleton tool) to build it, ` +
+      "then retry this call."
+    );
+  }
+  return (
+    `${repoPath} has no .reposkein/ directory. Run \`reposkein-mcp init ${repoPath}\` there, ` +
+    "or point REPOSKEIN_REPO_PATH / select_repo at a repo that already has one."
+  );
+}
+
 // Exported for the regression test. `hops` MUST stay a bounded integer: a literal union
 // (z.union([z.literal(1), z.literal(2)])) serialises to JSON-Schema `anyOf:[{const:1},{const:2}]`,
 // which Gemini's tool-schema validator 400-rejects — and one bad tool declaration fails the
@@ -175,22 +194,29 @@ export async function main(): Promise<void> {
   // rebuilding the store object would also throw away that per-instance
   // mtime cache — so one context is built per repoPath and reused, letting
   // `select_repo` switch back and forth cheaply too.
-  const repoContexts = new Map<string, { repoId: string | undefined; store: GraphStore }>();
-  async function getRepoContext(path: string): Promise<{ repoId: string | undefined; store: GraphStore }> {
-    const cached = repoContexts.get(path);
-    if (cached) return cached;
-    const id = resolveRepoId(path, process.env.REPOSKEIN_REPO_ID);
-    // Build the graph if the repo has none yet. Derived JSONL is git-ignored,
-    // so a fresh clone arrives without it; without this the first query on a
-    // newly selected repo would fail on one that indexes fine in seconds.
-    await ensureGraph(path, id, {
-      mode: (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase(),
-      neo4jConfigured: !!process.env.NEO4J_PASSWORD,
-    });
-    const ctx = { repoId: id, store: buildStore(path, id) };
-    repoContexts.set(path, ctx);
-    return ctx;
-  }
+  //
+  // Only a SUCCESSFUL resolution (repoId defined) is cached — see
+  // store/repoContextCache.ts. A repo whose `.reposkein/` exists but isn't
+  // indexed yet (no meta.json) is a transient, fixable state: an agent might
+  // run `reposkein-mcp index` (or init_cpg_skeleton) out-of-band and expect
+  // the very next call in this same session to pick it up. Caching that
+  // failure would freeze the session on a stale "not found" forever,
+  // undercutting select_repo's whole no-restart-needed point.
+  const getRepoContext = makeCache(
+    async (path: string): Promise<{ repoId: string | undefined; store: GraphStore }> => {
+      const id = resolveRepoId(path, process.env.REPOSKEIN_REPO_ID);
+      // Build the graph if the repo has none yet. Derived JSONL is
+      // git-ignored, so a fresh clone arrives without it; without this the
+      // first query on a newly selected repo would fail on one that indexes
+      // fine in seconds.
+      await ensureGraph(path, id, {
+        mode: (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase(),
+        neo4jConfigured: !!process.env.NEO4J_PASSWORD,
+      });
+      return { repoId: id, store: buildStore(path, id) };
+    },
+    (ctx) => !!ctx.repoId
+  );
 
   type ActiveRepo =
     | { ok: true; repoPath: string; repoId: string; store: GraphStore }
@@ -202,7 +228,10 @@ export async function main(): Promise<void> {
     const resolution = session.resolve();
     if (!resolution.repoPath) return { ok: false, message: repoRequiredMessage(resolution) };
     const ctx = await getRepoContext(resolution.repoPath);
-    if (!ctx.repoId) return { ok: false, message: repoRequiredMessage(resolution) };
+    // Distinct from repoRequiredMessage: a repo path WAS resolved here — the
+    // problem is it isn't indexed (or doesn't actually have .reposkein/),
+    // not that none could be found at all. See repoUnindexedMessage.
+    if (!ctx.repoId) return { ok: false, message: repoUnindexedMessage(resolution.repoPath) };
     return { ok: true, repoPath: resolution.repoPath, repoId: ctx.repoId, store: ctx.store };
   }
   const errResult = (message: string): ToolResult => ({ content: [{ type: "text", text: message }], isError: true });

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -320,9 +320,10 @@ export async function main(): Promise<void> {
     async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
-      // Default to the active repo's path (not the indexer's own cwd-based
-      // fallback) so a selected/discovered repo is what actually gets indexed.
-      return makeInitCpgSkeleton(active.repoId)({ ...args, path: args?.path ?? active.repoPath });
+      // repoPath is threaded through explicitly (see indexerTools.ts) so this
+      // always targets the resolved active repo, not a cwd/env-based guess —
+      // an explicit args.path still wins inside makeInitCpgSkeleton itself.
+      return makeInitCpgSkeleton(active.repoId, active.repoPath)(args);
     }
   );
 
@@ -337,7 +338,10 @@ export async function main(): Promise<void> {
     async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
-      return makeReindexFile(active.repoId)(args);
+      // repoPath threaded explicitly — reindex_file has no path override of
+      // its own, so without this it would silently reindex whatever
+      // REPOSKEIN_REPO_PATH/cwd points at instead of the selected repo.
+      return makeReindexFile(active.repoId, active.repoPath)(args);
     }
   );
 

--- a/mcp/src/indexer/runIndexer.ts
+++ b/mcp/src/indexer/runIndexer.ts
@@ -23,10 +23,14 @@ export interface SpawnResult {
   stderr: string;
 }
 
-/** Repo root the indexer operates on: REPOSKEIN_REPO_PATH or cwd. */
-export function repoPath(): string {
-  return process.env.REPOSKEIN_REPO_PATH ?? process.cwd();
-}
+// NOTE: there used to be a `repoPath()` here (REPOSKEIN_REPO_PATH ?? cwd),
+// an independent repo-path resolver `tools/indexerTools.ts` called instead
+// of using its caller's already-resolved active repo. That let init/reindex
+// bypass session.select_repo entirely and index the wrong repo in workspace
+// mode — removed; every caller now takes an explicit `repoPath` param
+// sourced from mcp/src/store/repoSession.ts. Don't reintroduce an
+// env/cwd-based resolver here — see mcp/src/store/resolveRepoPath.ts for the
+// one central resolution algorithm.
 
 export function spawnIndexer(bin: string, args: string[]): Promise<SpawnResult> {
   return new Promise((resolve, reject) => {

--- a/mcp/src/store/repoContextCache.ts
+++ b/mcp/src/store/repoContextCache.ts
@@ -1,0 +1,26 @@
+/** A minimal memoizing cache with a caching decision left to the caller —
+ *  extracted so "never cache a failed/partial result" is one small, directly
+ *  testable primitive rather than inline logic in mcp/src/index.ts.
+ *
+ *  Context: index.ts's per-repoPath {repoId, store} cache used to cache
+ *  every resolution unconditionally, including a repo whose `.reposkein/`
+ *  exists but isn't indexed yet (no meta.json — `repoId` resolves to
+ *  `undefined`). That froze a session on the failure forever: an agent that
+ *  fixed the repo out-of-band (ran `reposkein-mcp index` in another
+ *  terminal) stayed stuck until the server restarted, which defeats
+ *  `select_repo`'s whole "no restart needed" point. `shouldCache` lets the
+ *  caller keep re-attempting `compute` for exactly the states worth
+ *  retrying, while still caching (and not repeatedly re-doing) real work
+ *  for a successful resolution. */
+export function makeCache<T>(
+  compute: (key: string) => Promise<T>,
+  shouldCache: (value: T) => boolean
+): (key: string) => Promise<T> {
+  const cache = new Map<string, T>();
+  return async (key: string): Promise<T> => {
+    if (cache.has(key)) return cache.get(key) as T;
+    const value = await compute(key);
+    if (shouldCache(value)) cache.set(key, value);
+    return value;
+  };
+}

--- a/mcp/src/store/repoSession.ts
+++ b/mcp/src/store/repoSession.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { resolveRepoPath, walkUp, walkDown, type RepoResolution } from "./resolveRepoPath.js";
+
+export interface RepoInfo {
+  path: string;
+  /** From <path>/.reposkein/meta.json, when present. */
+  repo_id?: string;
+  /** Display name: repo_id if meta.json resolved one, else the directory's
+   *  basename — always present so `select_repo` has something to match on
+   *  even before the repo has been indexed (no meta.json yet). */
+  name: string;
+  /** Cheap line counts (not full parses) — omitted where the file is absent. */
+  nodes?: number;
+  edges?: number;
+}
+
+function countLines(text: string): number {
+  let n = 0;
+  for (const line of text.split("\n")) if (line.trim()) n++;
+  return n;
+}
+
+function readMetaRepoId(path: string): string | undefined {
+  try {
+    const meta = JSON.parse(readFileSync(join(path, ".reposkein", "meta.json"), "utf8"));
+    return typeof meta.repo_id === "string" ? meta.repo_id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Line counts for nodes.jsonl / edges.jsonl if they exist — the same cheap
+ *  "count non-empty lines" approach `cli/doctor.ts` uses, not a full parse. */
+function cheapCounts(path: string): { nodes?: number; edges?: number } {
+  const out: { nodes?: number; edges?: number } = {};
+  const nodesFile = join(path, ".reposkein", "nodes.jsonl");
+  const edgesFile = join(path, ".reposkein", "edges.jsonl");
+  try {
+    if (existsSync(nodesFile)) out.nodes = countLines(readFileSync(nodesFile, "utf8"));
+  } catch {
+    /* unreadable — omit rather than fail list_repos over one repo */
+  }
+  try {
+    if (existsSync(edgesFile)) out.edges = countLines(readFileSync(edgesFile, "utf8"));
+  } catch {
+    /* unreadable — omit */
+  }
+  return out;
+}
+
+export function describeRepo(path: string): RepoInfo {
+  const repo_id = readMetaRepoId(path);
+  return {
+    path,
+    ...(repo_id ? { repo_id } : {}),
+    name: repo_id ?? basename(path),
+    ...cheapCounts(path),
+  };
+}
+
+/** Every repo `list_repos` should report. Deliberately broader than
+ *  `resolveRepoPath`'s own short-circuiting precedence: discovery always
+ *  walks the filesystem (nearest ancestor with `.reposkein/`, else
+ *  subdirectories) so a workspace's sibling repos are visible — and thus
+ *  selectable via `select_repo` — even in a session where REPOSKEIN_REPO_PATH
+ *  happens to pin one of them. That env pin is unioned in (deduped) so it's
+ *  never missing from the list, but it does not suppress the others; only
+ *  `resolveRepoPath`'s actual *default* pick (used by `resolve()` below)
+ *  gives it priority over the walk. Sorted for deterministic output. */
+export function discoverRepoPaths(opts: { cwd: string; envRepoPath?: string }): string[] {
+  const up = walkUp(opts.cwd);
+  const physical = up ? [up] : walkDown(opts.cwd);
+  if (opts.envRepoPath && !physical.includes(opts.envRepoPath)) {
+    return [...physical, opts.envRepoPath].sort();
+  }
+  return physical;
+}
+
+/** Tracks the MCP session's active repo across tool calls.
+ *
+ *  Resolution precedence: `select_repo` (session-only; sticky for the rest of
+ *  the connection) > REPOSKEIN_REPO_PATH > walk-up > walk-down. `select_repo`
+ *  is deliberately allowed to override REPOSKEIN_REPO_PATH once called — it's
+ *  the more specific, more recent signal, and it's how a workspace-mode
+ *  session (multiple sibling repos, walk-down ambiguous) picks one to work
+ *  with instead of restarting the server with a different env var. */
+export class RepoSession {
+  private readonly cwd: string;
+  private readonly envRepoPath: string | undefined;
+  private selectedPath: string | undefined;
+
+  constructor(opts: { cwd: string; envRepoPath: string | undefined }) {
+    this.cwd = opts.cwd;
+    this.envRepoPath = opts.envRepoPath;
+  }
+
+  /** Current resolution, honoring an active `select_repo` pick first. */
+  resolve(): RepoResolution {
+    if (this.selectedPath) return { repoPath: this.selectedPath, source: "explicit" };
+    return resolveRepoPath({ cwd: this.cwd, envRepoPath: this.envRepoPath });
+  }
+
+  /** Every candidate repo for this session — see `discoverRepoPaths`. Each
+   *  entry is flagged `selected` for whichever one `resolve()` currently
+   *  returns, so an agent can see the effect of a prior `select_repo` call. */
+  list(): (RepoInfo & { selected: boolean })[] {
+    const active = this.resolve().repoPath;
+    return discoverRepoPaths({ cwd: this.cwd, envRepoPath: this.envRepoPath }).map((path) => ({
+      ...describeRepo(path),
+      selected: path === active,
+    }));
+  }
+
+  /** Sets the session-active repo by path, by its meta.json `repo_id`, or by
+   *  display `name` (as returned by `list()`/`list_repos`) — never an
+   *  arbitrary filesystem path, so this can't be used to point outside what
+   *  resolution actually discovered. */
+  select(pathOrName: string): { ok: true; repo: RepoInfo } | { ok: false; error: string } {
+    const candidates = discoverRepoPaths({ cwd: this.cwd, envRepoPath: this.envRepoPath }).map(describeRepo);
+    const hit =
+      candidates.find((c) => c.path === pathOrName) ??
+      candidates.find((c) => c.repo_id === pathOrName) ??
+      candidates.find((c) => c.name === pathOrName);
+    if (!hit) {
+      return {
+        ok: false,
+        error:
+          `No repo matching "${pathOrName}" among the discovered candidates` +
+          (candidates.length > 0
+            ? `: ${candidates.map((c) => c.path).join(", ")}.`
+            : " (none found).") +
+          " Call list_repos first and pass one of its `path` or `name` values.",
+      };
+    }
+    this.selectedPath = hit.path;
+    return { ok: true, repo: hit };
+  }
+}

--- a/mcp/src/store/resolveRepoPath.ts
+++ b/mcp/src/store/resolveRepoPath.ts
@@ -1,0 +1,97 @@
+import { readdirSync, statSync, type Dirent } from "node:fs";
+import { dirname, join, resolve as resolvePath } from "node:path";
+
+const REPOSKEIN_DIR = ".reposkein";
+
+/** Directories never treated as repo candidates while walking down: build
+ *  output, VCS internals, other worktrees/tool state — never real repo roots. */
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git", "target", "dist", ".worktrees", ".claude"]);
+
+export type RepoResolutionSource = "explicit" | "env" | "walk-up" | "walk-down" | "none";
+
+export interface RepoResolution {
+  /** Resolved repo root, or undefined if none could be determined. */
+  repoPath: string | undefined;
+  /** How repoPath was determined ("none" when nothing resolved). */
+  source: RepoResolutionSource;
+  /** Populated only when source is "none" because walk-down found 2+ hits
+   *  (workspace mode, ambiguous) — name them so the caller can pick one. */
+  candidates?: string[];
+}
+
+function hasReposkeinDir(dir: string): boolean {
+  try {
+    return statSync(join(dir, REPOSKEIN_DIR)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Nearest ancestor of `cwd` (inclusive) containing `.reposkein/`. */
+export function walkUp(cwd: string): string | undefined {
+  let dir = resolvePath(cwd);
+  for (;;) {
+    if (hasReposkeinDir(dir)) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return undefined; // reached filesystem root
+    dir = parent;
+  }
+}
+
+/** Scans descendants of `cwd` (bounded to `maxDepth` levels, skipping
+ *  build/VCS/tool directories) for directories containing `.reposkein/`.
+ *  Does not recurse further into a hit — nested repos are a graph-federation
+ *  concern (see store/federation.ts), not a workspace-candidate one here.
+ *  Returns hits sorted for deterministic ambiguity-error output. */
+export function walkDown(cwd: string, maxDepth = 2): string[] {
+  const root = resolvePath(cwd);
+  const hits: string[] = [];
+
+  function recurse(dir: string, depth: number): void {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // unreadable dir (permissions, race) — skip, don't fail resolution
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === REPOSKEIN_DIR) continue;
+      if (SKIP_DIR_NAMES.has(entry.name)) continue;
+      const full = join(dir, entry.name);
+      if (hasReposkeinDir(full)) {
+        hits.push(full);
+        continue;
+      }
+      if (depth < maxDepth) recurse(full, depth + 1);
+    }
+  }
+
+  recurse(root, 1);
+  return hits.sort();
+}
+
+/** Zero-config repo resolution.
+ *
+ *  Precedence: explicit tool arg > REPOSKEIN_REPO_PATH > walk-up > walk-down.
+ *  - Walk-up: nearest ancestor of `cwd` (inclusive) containing `.reposkein/`.
+ *  - Walk-down (workspace mode, only tried when no ancestor has one): scans
+ *    `cwd`'s children/grandchildren for `.reposkein/` dirs. One hit auto-
+ *    selects it. Zero or 2+ hits leave `repoPath` undefined ("none"); 2+
+ *    populates `candidates` so the caller can build an actionable error. */
+export function resolveRepoPath(opts: {
+  cwd: string;
+  envRepoPath?: string;
+  explicit?: string;
+}): RepoResolution {
+  if (opts.explicit) return { repoPath: opts.explicit, source: "explicit" };
+  if (opts.envRepoPath) return { repoPath: opts.envRepoPath, source: "env" };
+
+  const up = walkUp(opts.cwd);
+  if (up) return { repoPath: up, source: "walk-up" };
+
+  const down = walkDown(opts.cwd);
+  if (down.length === 1) return { repoPath: down[0], source: "walk-down" };
+  if (down.length > 1) return { repoPath: undefined, source: "none", candidates: down };
+  return { repoPath: undefined, source: "none" };
+}

--- a/mcp/src/tools/indexerTools.ts
+++ b/mcp/src/tools/indexerTools.ts
@@ -2,7 +2,6 @@ import type { ToolResult } from "./readCypher.js";
 import {
   spawnIndexer,
   parseJsonStats,
-  repoPath,
   shouldLoadNeo4j,
 } from "../indexer/runIndexer.js";
 import { ensureIndexerBinary } from "../indexer/fetchBinary.js";
@@ -103,10 +102,16 @@ export interface InitArgs {
   full?: boolean;
 }
 
-export function makeInitCpgSkeleton(repoId: string, deps?: Partial<IndexerDeps>) {
+/** `path` (the repo to index) MUST come from the caller's already-resolved
+ *  active repo (mcp/src/store/repoSession.ts), not re-derived here — this
+ *  tool used to default to REPOSKEIN_REPO_PATH/cwd internally via
+ *  runIndexer.js's `repoPath()`, which bypassed session.select_repo entirely
+ *  and could index the wrong repo in workspace mode. Args-supplied `path`
+ *  still wins, matching the original "explicit arg beats everything" rule. */
+export function makeInitCpgSkeleton(repoId: string, repoPath: string, deps?: Partial<IndexerDeps>) {
   const run = makeRunner(repoId, deps);
   return async (args: InitArgs): Promise<ToolResult> => {
-    const indexPath = args?.path ?? repoPath();
+    const indexPath = args?.path ?? repoPath;
     const start = Date.now();
     const r = await run(repoId, indexPath);
     if (!r.ok) {
@@ -133,13 +138,19 @@ export interface ReindexArgs {
   path: string;
 }
 
-export function makeReindexFile(repoId: string, deps?: Partial<IndexerDeps>) {
+/** `path` has no override — `reindex_file`'s args only carry the file being
+ *  reindexed, not a repo root — so this ALWAYS targets the caller's resolved
+ *  active repo. Same reasoning as `makeInitCpgSkeleton` above: previously
+ *  this read REPOSKEIN_REPO_PATH/cwd internally, independent of
+ *  session.select_repo — the exact "reindex the wrong repo" bug class this
+ *  parameter exists to close. */
+export function makeReindexFile(repoId: string, repoPath: string, deps?: Partial<IndexerDeps>) {
   const run = makeRunner(repoId, deps);
   return async (args: ReindexArgs): Promise<ToolResult> => {
     if (!args || !args.path) {
       return { content: [{ type: "text", text: "reindex_file requires a 'path'" }], isError: true };
     }
-    const indexPath = repoPath();
+    const indexPath = repoPath;
     const start = Date.now();
     const r = await run(repoId, indexPath, { verb: "reindex", file: args.path });
     if (!r.ok) {

--- a/mcp/test/decisionsAffected.test.ts
+++ b/mcp/test/decisionsAffected.test.ts
@@ -160,7 +160,7 @@ describe("reindex_file surfaces decisions_affected", () => {
       pendingDeltaPath(root),
       JSON.stringify(delta({ modified: [`rs1:${REPO_ID}:func:src/y.ts#g@0`], counts: { added: 0, removed: 0, modified: 1 } }))
     );
-    const reindex = makeReindexFile(REPO_ID, {
+    const reindex = makeReindexFile(REPO_ID, root, {
       run: async () => ({
         ok: true,
         nodes: 1,
@@ -185,7 +185,7 @@ describe("reindex_file surfaces decisions_affected", () => {
 
   it("marks the cross-reference incomplete when the delta was truncated", async () => {
     seed(root, "adr:2026-08-01-a", { anchors: [anchor(`rs1:${REPO_ID}:func:src/x.ts#f@0`)] });
-    const reindex = makeReindexFile(REPO_ID, {
+    const reindex = makeReindexFile(REPO_ID, root, {
       run: async () => ({
         ok: true,
         nodes: 1,
@@ -212,7 +212,7 @@ describe("reindex_file surfaces decisions_affected", () => {
     );
     const other = mkdtempSync(join(tmpdir(), "rs-other-"));
     try {
-      const init = makeInitCpgSkeleton(REPO_ID, {
+      const init = makeInitCpgSkeleton(REPO_ID, root, {
         run: async () => ({ ok: true, nodes: 1, edges: 0, files: 1, warnings: [] }),
       });
       const out = JSON.parse((await init({ path: other })).content[0]!.text) as Record<string, any>;
@@ -224,7 +224,7 @@ describe("reindex_file surfaces decisions_affected", () => {
   });
 
   it("omits the fields when there is no drift", async () => {
-    const reindex = makeReindexFile(REPO_ID, {
+    const reindex = makeReindexFile(REPO_ID, root, {
       run: async () => ({ ok: true, nodes: 1, edges: 0, files: 1, warnings: [] }),
     });
     const out = JSON.parse((await reindex({ path: "src/x.ts" })).content[0]!.text) as Record<string, any>;

--- a/mcp/test/doctor.test.ts
+++ b/mcp/test/doctor.test.ts
@@ -2,13 +2,44 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runChecks } from "../src/cli/doctor.js";
+import { runChecks, resolveDoctorRepoPath } from "../src/cli/doctor.js";
 import { decisionChecks } from "../src/cli/doctorDecisions.js";
 import { computeBodyHash, writeDecision, decisionsDir, type DecisionRecord } from "../src/store/decisions.js";
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "rs-doctor-")); });
 afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe("resolveDoctorRepoPath", () => {
+  it("walks up to the repo root when run from a subdirectory cwd (no path arg)", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const sub = join(dir, "src", "nested");
+    mkdirSync(sub, { recursive: true });
+    const result = resolveDoctorRepoPath(undefined, sub, undefined);
+    expect(result).toEqual({ path: dir });
+  });
+
+  it("an explicit path argument wins over cwd resolution", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const result = resolveDoctorRepoPath("/explicit/path", dir, undefined);
+    expect(result).toEqual({ path: "/explicit/path" });
+  });
+
+  it("REPOSKEIN_REPO_PATH wins over walk-up", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const result = resolveDoctorRepoPath(undefined, dir, "/env/path");
+    expect(result).toEqual({ path: "/env/path" });
+  });
+
+  it("reports an error naming candidates when the cwd is workspace-ambiguous", () => {
+    mkdirSync(join(dir, "repo-a", ".reposkein"), { recursive: true });
+    mkdirSync(join(dir, "repo-b", ".reposkein"), { recursive: true });
+    const result = resolveDoctorRepoPath(undefined, dir, undefined);
+    expect(result.path).toBe(dir);
+    expect(result.error).toContain(join(dir, "repo-a"));
+    expect(result.error).toContain(join(dir, "repo-b"));
+  });
+});
 
 describe("doctor runChecks", () => {
   it("flags an unindexed repo (no .reposkein/nodes.jsonl)", async () => {

--- a/mcp/test/gracefulStartup.test.ts
+++ b/mcp/test/gracefulStartup.test.ts
@@ -43,8 +43,8 @@ describe("graceful startup without NEO4J_PASSWORD", () => {
     expect(() => makeReadCypher(store, repoId)).not.toThrow();
     expect(() => makeGetContextProfile(store, repoId)).not.toThrow();
     expect(() => makeWriteSemanticSummary(store, repoId)).not.toThrow();
-    expect(() => makeInitCpgSkeleton(repoId)).not.toThrow();
-    expect(() => makeReindexFile(repoId)).not.toThrow();
+    expect(() => makeInitCpgSkeleton(repoId, "/tmp/testrepo")).not.toThrow();
+    expect(() => makeReindexFile(repoId, "/tmp/testrepo")).not.toThrow();
   });
 
   it("get_context_profile with UnconfiguredStore returns isError mentioning Neo4j", async () => {

--- a/mcp/test/indexerTools.int.test.ts
+++ b/mcp/test/indexerTools.int.test.ts
@@ -41,7 +41,7 @@ gated("init_cpg_skeleton (integration)", () => {
   });
 
   it("indexes a repo and loads it into Neo4j", async () => {
-    const init = makeInitCpgSkeleton(REPO);
+    const init = makeInitCpgSkeleton(REPO, dir);
     const res = await init({});
     const payload = JSON.parse(res.content[0].text);
     expect(res.isError).toBeFalsy();

--- a/mcp/test/indexerTools.test.ts
+++ b/mcp/test/indexerTools.test.ts
@@ -10,7 +10,7 @@ describe("indexer tools", () => {
       files: 3,
       warnings: [] as string[],
     }));
-    const init = makeInitCpgSkeleton("repo1", { run });
+    const init = makeInitCpgSkeleton("repo1", "/tmp/does-not-matter", { run });
     const res = await init({});
     const payload = JSON.parse(res.content[0].text);
     expect(payload.ok).toBe(true);
@@ -30,13 +30,13 @@ describe("indexer tools", () => {
       files: 1,
       warnings: ["parse error in foo.py"],
     }));
-    const init = makeInitCpgSkeleton("repo1", { run });
+    const init = makeInitCpgSkeleton("repo1", "/tmp/does-not-matter", { run });
     const res = await init({});
     const payload = JSON.parse(res.content[0].text);
     expect(payload.warnings).toEqual(["parse error in foo.py"]);
   });
 
-  it("init passes path arg to runner", async () => {
+  it("init defaults to the caller-supplied repoPath when args.path is omitted", async () => {
     const run = vi.fn(async (_id: string, path: string) => ({
       ok: true as const,
       nodes: 1,
@@ -44,14 +44,27 @@ describe("indexer tools", () => {
       files: 1,
       warnings: [] as string[],
     }));
-    const init = makeInitCpgSkeleton("repo1", { run });
+    const init = makeInitCpgSkeleton("repo1", "/resolved/active/repo", { run });
+    await init({});
+    expect(run).toHaveBeenCalledWith("repo1", "/resolved/active/repo");
+  });
+
+  it("init passes an explicit path arg to runner, overriding repoPath", async () => {
+    const run = vi.fn(async (_id: string, path: string) => ({
+      ok: true as const,
+      nodes: 1,
+      edges: 0,
+      files: 1,
+      warnings: [] as string[],
+    }));
+    const init = makeInitCpgSkeleton("repo1", "/resolved/active/repo", { run });
     await init({ path: "/custom/path" });
     expect(run).toHaveBeenCalledWith("repo1", "/custom/path");
   });
 
   it("init surfaces indexer failure as isError", async () => {
     const run = vi.fn(async () => ({ ok: false as const, error: "indexer exited 1: boom" }));
-    const init = makeInitCpgSkeleton("repo1", { run });
+    const init = makeInitCpgSkeleton("repo1", "/tmp/does-not-matter", { run });
     const res = await init({});
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/boom/);
@@ -65,13 +78,13 @@ describe("indexer tools", () => {
       files: 1,
       warnings: [] as string[],
     }));
-    const reindex = makeReindexFile("repo1", { run });
+    const reindex = makeReindexFile("repo1", "/resolved/active/repo", { run });
     const res = await reindex({} as { path: string });
     expect(res.isError).toBe(true);
     expect(run).not.toHaveBeenCalled();
   });
 
-  it("reindex_file returns stats on success", async () => {
+  it("reindex_file targets the caller-supplied repoPath (not env/cwd)", async () => {
     const run = vi.fn(async () => ({
       ok: true as const,
       nodes: 5,
@@ -79,12 +92,23 @@ describe("indexer tools", () => {
       files: 2,
       warnings: [] as string[],
     }));
-    const reindex = makeReindexFile("repo1", { run });
-    const res = await reindex({ path: "src/foo.ts" });
-    const payload = JSON.parse(res.content[0].text);
-    expect(payload.ok).toBe(true);
-    expect(payload.reindexed).toBe("src/foo.ts");
-    expect(payload.files).toBe(2);
-    expect(payload.warnings).toEqual([]);
+    // A deliberately different env value — proves reindex_file never falls
+    // back to REPOSKEIN_REPO_PATH internally (the old runIndexer.js
+    // `repoPath()` this parameter replaced).
+    const prevEnv = process.env.REPOSKEIN_REPO_PATH;
+    process.env.REPOSKEIN_REPO_PATH = "/env/pinned/repo";
+    try {
+      const reindex = makeReindexFile("repo1", "/resolved/active/repo", { run });
+      const res = await reindex({ path: "src/foo.ts" });
+      const payload = JSON.parse(res.content[0].text);
+      expect(payload.ok).toBe(true);
+      expect(payload.reindexed).toBe("src/foo.ts");
+      expect(payload.files).toBe(2);
+      expect(payload.warnings).toEqual([]);
+      expect(run).toHaveBeenCalledWith("repo1", "/resolved/active/repo", { verb: "reindex", file: "src/foo.ts" });
+    } finally {
+      if (prevEnv === undefined) delete process.env.REPOSKEIN_REPO_PATH;
+      else process.env.REPOSKEIN_REPO_PATH = prevEnv;
+    }
   });
 });

--- a/mcp/test/reindexFileRepoSelection.test.ts
+++ b/mcp/test/reindexFileRepoSelection.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { RepoSession } from "../src/store/repoSession.js";
+import { resolveRepoId } from "../src/store/repoId.js";
+import { makeReindexFile, makeInitCpgSkeleton } from "../src/tools/indexerTools.js";
+
+/** Regression coverage for the "wrong repo indexed" bug class: index.ts's
+ *  reindex_file/init_cpg_skeleton handlers used to resolve their target repo
+ *  independently (indexer/runIndexer.js's old `repoPath()`, an
+ *  REPOSKEIN_REPO_PATH-or-cwd fallback baked into indexerTools.ts) instead of
+ *  going through the same RepoSession every other repo-scoped tool uses —
+ *  so a session that called select_repo and then reindex_file could still
+ *  silently reindex a different repo. This mirrors exactly what
+ *  index.ts's resolveActiveRepo() + tool handlers do: RepoSession.resolve()
+ *  -> resolveRepoId -> makeReindexFile/makeInitCpgSkeleton(repoId, repoPath). */
+describe("reindex_file / init_cpg_skeleton target the session-selected repo (not env/cwd)", () => {
+  let ws: string;
+  let repoA: string;
+  let repoB: string;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    ws = mkdtempSync(join(tmpdir(), "rs-workspace-"));
+    repoA = join(ws, "repo-a");
+    repoB = join(ws, "repo-b");
+    mkdirSync(join(repoA, ".reposkein"), { recursive: true });
+    mkdirSync(join(repoB, ".reposkein"), { recursive: true });
+    writeFileSync(join(repoA, ".reposkein", "meta.json"), JSON.stringify({ repo_id: "repo-a-id" }));
+    writeFileSync(join(repoB, ".reposkein", "meta.json"), JSON.stringify({ repo_id: "repo-b-id" }));
+    prevEnv = process.env.REPOSKEIN_REPO_PATH;
+    // Deliberately pin the env var at repo-a, NOT repo-b — proves the
+    // selected repo wins and the tools never fall back to env/cwd internally.
+    process.env.REPOSKEIN_REPO_PATH = repoA;
+  });
+
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.REPOSKEIN_REPO_PATH;
+    else process.env.REPOSKEIN_REPO_PATH = prevEnv;
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  it("reindex_file's runner receives repo-b's path+id after select_repo, never repo-a's", async () => {
+    const session = new RepoSession({ cwd: ws, envRepoPath: process.env.REPOSKEIN_REPO_PATH });
+    // Before select_repo: env wins, as always — sanity check the fixture.
+    expect(session.resolve().repoPath).toBe(repoA);
+
+    const selectResult = session.select("repo-b-id");
+    expect(selectResult.ok).toBe(true);
+
+    // Exactly what index.ts's resolveActiveRepo() does.
+    const resolution = session.resolve();
+    expect(resolution.repoPath).toBe(repoB);
+    const repoId = resolveRepoId(resolution.repoPath, process.env.REPOSKEIN_REPO_ID);
+    expect(repoId).toBe("repo-b-id");
+
+    const calls: Array<{ id: string; path: string }> = [];
+    const reindex = makeReindexFile(repoId!, resolution.repoPath!, {
+      run: async (id, path) => {
+        calls.push({ id, path });
+        return { ok: true, nodes: 0, edges: 0, files: 0, warnings: [] };
+      },
+    });
+    await reindex({ path: "src/x.ts" });
+
+    expect(calls).toEqual([{ id: "repo-b-id", path: repoB }]);
+    expect(calls[0]!.path).not.toBe(repoA);
+  });
+
+  it("init_cpg_skeleton (no explicit args.path) defaults to repo-b after select_repo, never repo-a", async () => {
+    const session = new RepoSession({ cwd: ws, envRepoPath: process.env.REPOSKEIN_REPO_PATH });
+    session.select("repo-b-id");
+    const resolution = session.resolve();
+    const repoId = resolveRepoId(resolution.repoPath, process.env.REPOSKEIN_REPO_ID);
+
+    const calls: Array<{ id: string; path: string }> = [];
+    const init = makeInitCpgSkeleton(repoId!, resolution.repoPath!, {
+      run: async (id, path) => {
+        calls.push({ id, path });
+        return { ok: true, nodes: 0, edges: 0, files: 0, warnings: [] };
+      },
+    });
+    await init({});
+
+    expect(calls).toEqual([{ id: "repo-b-id", path: repoB }]);
+  });
+
+  it("switching selection again (repo-b -> repo-a) redirects the very next reindex_file call", async () => {
+    const session = new RepoSession({ cwd: ws, envRepoPath: process.env.REPOSKEIN_REPO_PATH });
+    session.select("repo-b-id");
+
+    async function reindexOnceWithCurrentSelection(): Promise<string> {
+      const resolution = session.resolve();
+      const repoId = resolveRepoId(resolution.repoPath, process.env.REPOSKEIN_REPO_ID);
+      let targeted = "";
+      const reindex = makeReindexFile(repoId!, resolution.repoPath!, {
+        run: async (_id, path) => {
+          targeted = path;
+          return { ok: true, nodes: 0, edges: 0, files: 0, warnings: [] };
+        },
+      });
+      await reindex({ path: "src/x.ts" });
+      return targeted;
+    }
+
+    expect(await reindexOnceWithCurrentSelection()).toBe(repoB);
+    session.select("repo-a-id");
+    expect(await reindexOnceWithCurrentSelection()).toBe(repoA);
+  });
+});

--- a/mcp/test/repoContextCache.test.ts
+++ b/mcp/test/repoContextCache.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { makeCache } from "../src/store/repoContextCache.js";
+import { resolveRepoId } from "../src/store/repoId.js";
+
+describe("makeCache", () => {
+  it("caches a value the predicate accepts (compute runs once)", async () => {
+    let calls = 0;
+    const cached = makeCache(
+      async (key: string) => {
+        calls++;
+        return `value-for-${key}`;
+      },
+      () => true
+    );
+    expect(await cached("a")).toBe("value-for-a");
+    expect(await cached("a")).toBe("value-for-a");
+    expect(await cached("a")).toBe("value-for-a");
+    expect(calls).toBe(1);
+  });
+
+  it("never caches a value the predicate rejects — compute reruns every call", async () => {
+    let calls = 0;
+    const cached = makeCache(
+      async (key: string) => {
+        calls++;
+        return { ok: false, key };
+      },
+      (v) => v.ok
+    );
+    await cached("a");
+    await cached("a");
+    await cached("a");
+    expect(calls).toBe(3);
+  });
+
+  it("keys are independent (a miss on one key doesn't evict another)", async () => {
+    let calls = 0;
+    const cached = makeCache(
+      async (key: string) => {
+        calls++;
+        return `v-${key}`;
+      },
+      () => true
+    );
+    await cached("a");
+    await cached("b");
+    await cached("a");
+    expect(calls).toBe(2);
+  });
+
+  it("starts retrying, then locks in once the predicate starts accepting", async () => {
+    let calls = 0;
+    const cached = makeCache(
+      async (key: string) => {
+        calls++;
+        // "fails" (not cache-worthy) for the first 2 calls, then "succeeds".
+        return { ok: calls >= 3, key, call: calls };
+      },
+      (v) => v.ok
+    );
+    const first = await cached("a");
+    expect(first.ok).toBe(false);
+    const second = await cached("a");
+    expect(second.ok).toBe(false);
+    expect(calls).toBe(2); // recomputed, not cached
+    const third = await cached("a");
+    expect(third.ok).toBe(true);
+    expect(calls).toBe(3);
+    // Now cached — a 4th call must NOT invoke compute again.
+    const fourth = await cached("a");
+    expect(fourth).toBe(third); // same cached object, no recompute
+    expect(calls).toBe(3);
+  });
+});
+
+/** Realistic version of the same scenario, against the real `resolveRepoId`
+ *  and a real filesystem fixture — this is the exact bug: index.ts's
+ *  getRepoContext used to cache a repo path whose `.reposkein/` exists but
+ *  has no meta.json yet (repoId resolves to undefined) forever, so an agent
+ *  that fixed the repo out-of-band (wrote meta.json / ran `reposkein-mcp
+ *  index` in another terminal) stayed stuck until a server restart. */
+describe("makeCache + resolveRepoId — failed resolution is retried after the repo becomes valid", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reposkein-cache-retry-"));
+    mkdirSync(join(dir, ".reposkein"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("resolve -> error (no meta.json) -> write meta.json -> same-session call succeeds and then stays cached", async () => {
+    let computeCalls = 0;
+    const getRepoContext = makeCache(
+      async (path: string) => {
+        computeCalls++;
+        return { repoId: resolveRepoId(path, undefined) };
+      },
+      (ctx) => !!ctx.repoId
+    );
+
+    // 1) Not indexed yet — no meta.json. Resolution fails, not cached.
+    const first = await getRepoContext(dir);
+    expect(first.repoId).toBeUndefined();
+    expect(computeCalls).toBe(1);
+
+    // 2) Out-of-band fix, in the SAME session (no server restart): meta.json
+    //    now exists (as `reposkein-mcp index` / init_cpg_skeleton would write).
+    writeFileSync(join(dir, ".reposkein", "meta.json"), JSON.stringify({ repo_id: "now-indexed-id" }));
+
+    // 3) The very next call in this session must pick it up — not stay
+    //    stuck on the earlier failure.
+    const second = await getRepoContext(dir);
+    expect(second.repoId).toBe("now-indexed-id");
+    expect(computeCalls).toBe(2);
+
+    // 4) And now that it succeeded, it's cached — a third call must not
+    //    re-read meta.json from disk again.
+    const third = await getRepoContext(dir);
+    expect(third.repoId).toBe("now-indexed-id");
+    expect(computeCalls).toBe(2);
+    expect(third).toBe(second);
+  });
+});

--- a/mcp/test/repoRequiredMessage.test.ts
+++ b/mcp/test/repoRequiredMessage.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { repoRequiredMessage } from "../src/index.js";
+
+describe("repoRequiredMessage", () => {
+  it("points at list_repos and select_repo (not just the env var) on ambiguity", () => {
+    const msg = repoRequiredMessage({
+      repoPath: undefined,
+      source: "none",
+      candidates: ["/ws/repo-a", "/ws/repo-b"],
+    });
+    expect(msg).toContain("/ws/repo-a");
+    expect(msg).toContain("/ws/repo-b");
+    expect(msg).toMatch(/list_repos/);
+    expect(msg).toMatch(/select_repo/);
+  });
+
+  it("mentions list_repos as a diagnostic when nothing resolved at all", () => {
+    const msg = repoRequiredMessage({ repoPath: undefined, source: "none" });
+    expect(msg).toMatch(/list_repos/);
+    expect(msg).toMatch(/reposkein-mcp init/);
+  });
+});

--- a/mcp/test/repoRequiredMessage.test.ts
+++ b/mcp/test/repoRequiredMessage.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { repoRequiredMessage } from "../src/index.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { repoRequiredMessage, repoUnindexedMessage } from "../src/index.js";
 
 describe("repoRequiredMessage", () => {
   it("points at list_repos and select_repo (not just the env var) on ambiguity", () => {
@@ -20,3 +23,31 @@ describe("repoRequiredMessage", () => {
     expect(msg).toMatch(/reposkein-mcp init/);
   });
 });
+
+describe("repoUnindexedMessage", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reposkein-unindexed-msg-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("when .reposkein/ WAS found but has no meta.json, names the path and the index command (not the generic 'no repo found' message)", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const msg = repoUnindexedMessage(dir);
+    expect(msg).toContain(dir);
+    expect(msg).toMatch(/reposkein-mcp index/);
+    expect(msg).not.toMatch(/No RepoSkein repo found/);
+  });
+
+  it("when there's no .reposkein/ at all at the resolved path, says so and points at init instead of index", () => {
+    // dir exists but has no .reposkein/ subdir — e.g. a stale/misconfigured
+    // REPOSKEIN_REPO_PATH or select_repo target.
+    const msg = repoUnindexedMessage(dir);
+    expect(msg).toContain(dir);
+    expect(msg).toMatch(/reposkein-mcp init/);
+    expect(msg).not.toMatch(/reposkein-mcp index/);
+  });
+});
+

--- a/mcp/test/repoSession.test.ts
+++ b/mcp/test/repoSession.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { RepoSession, describeRepo, discoverRepoPaths } from "../src/store/repoSession.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reposkein-session-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("describeRepo", () => {
+  it("uses meta.json's repo_id as the name when present", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    writeFileSync(join(dir, ".reposkein", "meta.json"), JSON.stringify({ repo_id: "rs1:abc" }));
+    const info = describeRepo(dir);
+    expect(info).toEqual({ path: dir, repo_id: "rs1:abc", name: "rs1:abc" });
+  });
+
+  it("falls back to the directory basename when meta.json is absent", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const info = describeRepo(dir);
+    expect(info.repo_id).toBeUndefined();
+    expect(info.name).toBe(dir.split("/").pop());
+  });
+
+  it("includes cheap node/edge counts when the jsonl files exist", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), '{"id":"a"}\n{"id":"b"}\n');
+    writeFileSync(join(dir, ".reposkein", "edges.jsonl"), '{"id":"e1"}\n');
+    const info = describeRepo(dir);
+    expect(info.nodes).toBe(2);
+    expect(info.edges).toBe(1);
+  });
+});
+
+describe("RepoSession — single-repo mode (list_repos)", () => {
+  it("lists exactly the one repo found via walk-up", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const sub = join(dir, "src");
+    mkdirSync(sub, { recursive: true });
+    const session = new RepoSession({ cwd: sub, envRepoPath: undefined });
+    const repos = session.list();
+    expect(repos).toHaveLength(1);
+    expect(repos[0]!.path).toBe(dir);
+    expect(repos[0]!.selected).toBe(true);
+  });
+
+  it("lists the repo pinned by REPOSKEIN_REPO_PATH even when the cwd's own walk finds nothing nearby", () => {
+    mkdirSync(join(dir, ".reposkein")); // the env-pinned repo
+    const unrelatedCwd = mkdtempSync(join(tmpdir(), "reposkein-session-unrelated-"));
+    try {
+      const session = new RepoSession({ cwd: unrelatedCwd, envRepoPath: dir });
+      const repos = session.list();
+      expect(repos).toEqual([expect.objectContaining({ path: dir, selected: true })]);
+    } finally {
+      rmSync(unrelatedCwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("RepoSession — workspace mode (list_repos, select_repo)", () => {
+  function seedTwoRepos(): { repoA: string; repoB: string } {
+    const repoA = join(dir, "repo-a");
+    const repoB = join(dir, "repo-b");
+    mkdirSync(join(repoA, ".reposkein"), { recursive: true });
+    mkdirSync(join(repoB, ".reposkein"), { recursive: true });
+    return { repoA, repoB };
+  }
+
+  it("lists all discovered candidates, none selected by default", () => {
+    const { repoA, repoB } = seedTwoRepos();
+    const session = new RepoSession({ cwd: dir, envRepoPath: undefined });
+    const repos = session.list();
+    expect(repos.map((r) => r.path)).toEqual([repoA, repoB]);
+    expect(repos.every((r) => !r.selected)).toBe(true);
+    expect(session.resolve()).toEqual({ repoPath: undefined, source: "none", candidates: [repoA, repoB] });
+  });
+
+  it("select_repo by path switches resolve() to that repo", () => {
+    const { repoA, repoB } = seedTwoRepos();
+    const session = new RepoSession({ cwd: dir, envRepoPath: undefined });
+    const result = session.select(repoB);
+    expect(result).toEqual({ ok: true, repo: expect.objectContaining({ path: repoB }) });
+    expect(session.resolve()).toEqual({ repoPath: repoB, source: "explicit" });
+    // list_repos reflects the new selection too.
+    const repos = session.list();
+    expect(repos.find((r) => r.path === repoA)!.selected).toBe(false);
+    expect(repos.find((r) => r.path === repoB)!.selected).toBe(true);
+  });
+
+  it("select_repo by name (meta.json repo_id) also works", () => {
+    const { repoA } = seedTwoRepos();
+    writeFileSync(join(repoA, ".reposkein", "meta.json"), JSON.stringify({ repo_id: "my-repo-a" }));
+    const session = new RepoSession({ cwd: dir, envRepoPath: undefined });
+    const result = session.select("my-repo-a");
+    expect(result.ok).toBe(true);
+    expect(session.resolve().repoPath).toBe(repoA);
+  });
+
+  it("select_repo with an unknown value fails, naming the real candidates", () => {
+    const { repoA, repoB } = seedTwoRepos();
+    const session = new RepoSession({ cwd: dir, envRepoPath: undefined });
+    const result = session.select("/nowhere/repo-z");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(repoA);
+      expect(result.error).toContain(repoB);
+      expect(result.error).toMatch(/list_repos/);
+    }
+  });
+
+  it("switching selection back and forth updates resolve() each time", () => {
+    const { repoA, repoB } = seedTwoRepos();
+    const session = new RepoSession({ cwd: dir, envRepoPath: undefined });
+    session.select(repoA);
+    expect(session.resolve().repoPath).toBe(repoA);
+    session.select(repoB);
+    expect(session.resolve().repoPath).toBe(repoB);
+    session.select(repoA);
+    expect(session.resolve().repoPath).toBe(repoA);
+  });
+});
+
+describe("RepoSession — precedence (select_repo > env > walk-up > walk-down)", () => {
+  it("select_repo overrides REPOSKEIN_REPO_PATH once called, even to a sibling env didn't name", () => {
+    const { repoA, repoB } = (() => {
+      const repoA = join(dir, "repo-a");
+      const repoB = join(dir, "repo-b");
+      mkdirSync(join(repoA, ".reposkein"), { recursive: true });
+      mkdirSync(join(repoB, ".reposkein"), { recursive: true });
+      return { repoA, repoB };
+    })();
+    const session = new RepoSession({ cwd: dir, envRepoPath: repoA });
+    // Before select_repo: env wins, as always.
+    expect(session.resolve()).toEqual({ repoPath: repoA, source: "env" });
+    // list_repos still surfaces every repo the workspace walk finds (repo-a
+    // AND repo-b) — env only picks the *default*, it doesn't hide siblings,
+    // which is what makes select_repo useful here in the first place.
+    expect(session.list().map((r) => r.path)).toEqual([repoA, repoB]);
+    // select_repo can switch to that sibling despite the env pin.
+    const result = session.select(repoB);
+    expect(result.ok).toBe(true);
+    expect(session.resolve()).toEqual({ repoPath: repoB, source: "explicit" });
+  });
+
+  it("without select_repo, env still wins over walk-up", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const envPath = join(dir, "elsewhere");
+    mkdirSync(envPath, { recursive: true });
+    const session = new RepoSession({ cwd: dir, envRepoPath: envPath });
+    expect(session.resolve()).toEqual({ repoPath: envPath, source: "env" });
+  });
+});
+
+describe("discoverRepoPaths", () => {
+  it("is a pure filesystem walk (walk-up, else walk-down) regardless of env", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    expect(discoverRepoPaths({ cwd: dir })).toEqual([dir]);
+    expect(discoverRepoPaths({ cwd: dir, envRepoPath: "/some/other/env/path" })).toEqual(
+      ["/some/other/env/path", dir].sort()
+    );
+  });
+
+  it("unions in the env-pinned repo when the walk already found it (no duplicate)", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    expect(discoverRepoPaths({ cwd: dir, envRepoPath: dir })).toEqual([dir]);
+  });
+});

--- a/mcp/test/resolveRepoPath.test.ts
+++ b/mcp/test/resolveRepoPath.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveRepoPath, walkUp, walkDown } from "../src/store/resolveRepoPath.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reposkein-resolve-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("walkUp", () => {
+  it("finds .reposkein/ in the starting directory itself", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    expect(walkUp(dir)).toBe(dir);
+  });
+
+  it("finds .reposkein/ in a nearer ancestor, not a farther one", () => {
+    // dir/.reposkein (farther)  and  dir/a/b (start, no .reposkein of its own,
+    // but should still find dir/.reposkein by walking up).
+    mkdirSync(join(dir, ".reposkein"));
+    const sub = join(dir, "a", "b");
+    mkdirSync(sub, { recursive: true });
+    expect(walkUp(sub)).toBe(dir);
+  });
+
+  it("prefers the nearest ancestor when multiple ancestors have .reposkein/", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const mid = join(dir, "mid");
+    mkdirSync(join(mid, ".reposkein"), { recursive: true });
+    const sub = join(mid, "sub");
+    mkdirSync(sub, { recursive: true });
+    expect(walkUp(sub)).toBe(mid);
+  });
+
+  it("returns undefined when no ancestor has .reposkein/", () => {
+    const sub = join(dir, "a", "b");
+    mkdirSync(sub, { recursive: true });
+    expect(walkUp(sub)).toBeUndefined();
+  });
+});
+
+describe("walkDown", () => {
+  it("finds a single .reposkein/ among children", () => {
+    const child = join(dir, "repo-a");
+    mkdirSync(join(child, ".reposkein"), { recursive: true });
+    expect(walkDown(dir)).toEqual([child]);
+  });
+
+  it("finds a .reposkein/ two levels deep (bounded depth)", () => {
+    const grandchild = join(dir, "group", "repo-a");
+    mkdirSync(join(grandchild, ".reposkein"), { recursive: true });
+    expect(walkDown(dir)).toEqual([grandchild]);
+  });
+
+  it("does not find .reposkein/ three levels deep (depth bound)", () => {
+    const greatGrandchild = join(dir, "a", "b", "repo-a");
+    mkdirSync(join(greatGrandchild, ".reposkein"), { recursive: true });
+    expect(walkDown(dir)).toEqual([]);
+  });
+
+  it("finds multiple candidates, sorted", () => {
+    const repoB = join(dir, "repo-b");
+    const repoA = join(dir, "repo-a");
+    mkdirSync(join(repoB, ".reposkein"), { recursive: true });
+    mkdirSync(join(repoA, ".reposkein"), { recursive: true });
+    expect(walkDown(dir)).toEqual([repoA, repoB]);
+  });
+
+  it("skips node_modules, .git, target, dist, .worktrees, .claude", () => {
+    for (const skip of ["node_modules", ".git", "target", "dist", ".worktrees", ".claude"]) {
+      mkdirSync(join(dir, skip, ".reposkein"), { recursive: true });
+    }
+    expect(walkDown(dir)).toEqual([]);
+  });
+
+  it("does not recurse past a hit looking for nested repos", () => {
+    const repo = join(dir, "repo-a");
+    mkdirSync(join(repo, ".reposkein"), { recursive: true });
+    mkdirSync(join(repo, "nested", ".reposkein"), { recursive: true });
+    expect(walkDown(dir)).toEqual([repo]);
+  });
+});
+
+describe("resolveRepoPath", () => {
+  it("explicit arg wins over everything", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const result = resolveRepoPath({ cwd: dir, envRepoPath: "/env/path", explicit: "/explicit/path" });
+    expect(result).toEqual({ repoPath: "/explicit/path", source: "explicit" });
+  });
+
+  it("env var wins over walk-up when both would resolve", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const result = resolveRepoPath({ cwd: dir, envRepoPath: "/env/path" });
+    expect(result).toEqual({ repoPath: "/env/path", source: "env" });
+  });
+
+  it("walks up when no explicit arg or env var is set", () => {
+    mkdirSync(join(dir, ".reposkein"));
+    const sub = join(dir, "src", "nested");
+    mkdirSync(sub, { recursive: true });
+    const result = resolveRepoPath({ cwd: sub });
+    expect(result).toEqual({ repoPath: dir, source: "walk-up" });
+  });
+
+  it("walks down to a single hit when no ancestor has .reposkein/", () => {
+    const child = join(dir, "repo-a");
+    mkdirSync(join(child, ".reposkein"), { recursive: true });
+    const result = resolveRepoPath({ cwd: dir });
+    expect(result).toEqual({ repoPath: child, source: "walk-down" });
+  });
+
+  it("reports ambiguity with candidate names when walk-down finds multiple hits", () => {
+    const repoA = join(dir, "repo-a");
+    const repoB = join(dir, "repo-b");
+    mkdirSync(join(repoA, ".reposkein"), { recursive: true });
+    mkdirSync(join(repoB, ".reposkein"), { recursive: true });
+    const result = resolveRepoPath({ cwd: dir });
+    expect(result.repoPath).toBeUndefined();
+    expect(result.source).toBe("none");
+    expect(result.candidates).toEqual([repoA, repoB]);
+  });
+
+  it("resolves to undefined/none when nothing is found anywhere", () => {
+    const sub = join(dir, "a", "b");
+    mkdirSync(sub, { recursive: true });
+    const result = resolveRepoPath({ cwd: sub });
+    expect(result).toEqual({ repoPath: undefined, source: "none" });
+  });
+});

--- a/skills/reposkein-graph-rag/SKILL.md
+++ b/skills/reposkein-graph-rag/SKILL.md
@@ -15,14 +15,25 @@ guess file dependencies, and do NOT explore the repo by directory listing or
 grep when the graph can answer structurally.
 
 The server resolves the target repo automatically from your working
-directory — no setup is required. If a tool call still returns an error
-naming `REPOSKEIN_REPO_PATH`, do not abandon these tools and fall back to
-grep: the error is actionable — run `reposkein-mcp init` in the repo (if it
-has no `.reposkein/` yet), or set `REPOSKEIN_REPO_PATH` to the repo it names
-(the error lists candidates if more than one repo was found) — then retry the
-same call.
+directory — no setup is required. If a tool call returns an error naming
+`list_repos`/`select_repo` or `REPOSKEIN_REPO_PATH`, do not abandon these
+tools and fall back to grep — the error is actionable:
+
+- **No repo found at all** — run `reposkein-mcp init` in the repo (if it has
+  no `.reposkein/` yet), or set `REPOSKEIN_REPO_PATH`.
+- **Multiple repos found (workspace mode)** — the error names the
+  candidates. Call `list_repos` to see them (path, name, node/edge counts),
+  then `select_repo` with one candidate's `path` or `name` — this sets the
+  active repo for the rest of the session, so you only do it once. Retry the
+  call that failed.
 
 ## Tools
+
+- **`list_repos`** / **`select_repo`** — only needed in workspace mode
+  (multiple sibling repos, no unambiguous default). `list_repos` enumerates
+  what was discovered; `select_repo` (a `path` or `name` from that list) sets
+  the active repo for every repo-scoped tool below, for the rest of the
+  session. Skip these in the common single-repo case — resolution just works.
 
 - **`semantic_find`** — **start here when you don't have a seed symbol.** Rank
   functions/classes/interfaces/enums by a lexical match (BM25F) over their

--- a/skills/reposkein-graph-rag/SKILL.md
+++ b/skills/reposkein-graph-rag/SKILL.md
@@ -14,6 +14,14 @@ calls — that you enrich with natural-language summaries just-in-time. Do NOT
 guess file dependencies, and do NOT explore the repo by directory listing or
 grep when the graph can answer structurally.
 
+The server resolves the target repo automatically from your working
+directory — no setup is required. If a tool call still returns an error
+naming `REPOSKEIN_REPO_PATH`, do not abandon these tools and fall back to
+grep: the error is actionable — run `reposkein-mcp init` in the repo (if it
+has no `.reposkein/` yet), or set `REPOSKEIN_REPO_PATH` to the repo it names
+(the error lists candidates if more than one repo was found) — then retry the
+same call.
+
 ## Tools
 
 - **`semantic_find`** — **start here when you don't have a seed symbol.** Rank


### PR DESCRIPTION
Closes the REPOSKEIN_REPO_PATH friction observed in real agent sessions: unset env → passive stderr warning → agent abandons tools and hand-greps `.reposkein/`.

## What changed
- **Zero-config resolution** (`mcp/src/store/resolveRepoPath.ts`): walk **up** from cwd to the nearest ancestor with `.reposkein/`; if none, walk **down** (depth 2, skipping node_modules/.git/target/dist) to discover child repos — covers workspace roots whose projects each hold their own `.reposkein/`. Precedence: `select_repo` > `REPOSKEIN_REPO_PATH` > walk-up > walk-down.
- **New session tools** `list_repos` / `select_repo`: enumerate discovered repos and switch the session-active repo without restarting the server; all ~13 repo-scoped tools + `reindex_file`/`init_cpg_skeleton` route through the central resolution (dead `repoPath()` resolver deleted).
- **Actionable errors**: ambiguity errors name candidate repos and point at `list_repos`/`select_repo`; a found-but-unindexed repo now says so and names the fix (`reposkein-mcp index <path>`) instead of "No RepoSkein repo found". Failed contexts are no longer cached, so an out-of-band index is picked up on the next call.
- `--help`/`--version` print no config warnings; `doctor` resolves from subdirectories; skill no longer mandates env setup.

## Tests
`cd mcp && npm test` → **439 passed, 17 skipped, 0 failed** (baseline 392; +47 covering walk-up/down, precedence, session switching, wrong-repo reindex regression, cache retry, message content). `tsc --noEmit` clean.

Linear: REP-23

🤖 Generated with [Claude Code](https://claude.com/claude-code)