### PR TITLE
feat: per-session usage stats — MCP-side instrumentation + `reposkein-mcp stats` terminal report (REP-20)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -73,6 +73,7 @@ Then ask your agent *"what calls this function?"* or *"what breaks if I change X
 - `reposkein-mcp init` — set up a repo (downloads the indexer, installs git hooks + the skill, builds the graph, prints an MCP config block).
 - `reposkein-mcp doctor` — health check (binary → index → MCP reachability).
 - `reposkein-mcp index` — rebuild the committed graph after big changes.
+- `reposkein-mcp stats [--last | --session <id> | --all] [--json]` — session usage report: calls by tool, top queried nodes/files, ADRs/summaries written, session duration, and an *estimated* context-tokens-saved-vs-grep number. See [Session usage stats](#session-usage-stats) below.
 - `reposkein-mcp view [path]` — open the **constellation viewer**: a local, read-only, zero-infra web app (bound to `127.0.0.1`) that renders the committed `.reposkein` graph as an interactive 3D astronomy-style map. `--export <dir>` instead writes a self-contained static site (works from `file://` or any static host). See the [viewer section in the main README](https://github.com/reposkein/reposkein#visualize-the-graph--the-constellation-viewer), or **[try the live demo](https://reposkein.github.io/reposkein/)** (RepoSkein viewing its own graph).
 
 ## How your agent uses it
@@ -93,6 +94,47 @@ npx skills add reposkein/reposkein --all
 ```
 
 (`reposkein-mcp init` already installs the navigation skill for Claude Code; this adds it to Cursor, Codex, and 70+ other agents.)
+
+## Session usage stats
+
+Every tool call is logged, server-side, as one JSONL line to
+`.reposkein/local/sessions/<session-id>.jsonl` under the repo the call
+touched — `{ts, tool, argsShape, resultBytes, nodeIds}`, never argument or
+result *values* (only argument key names — no code/user text ever lands on
+disk). Because logging happens in the server, this works for **any**
+MCP-capable agent (Claude Code, Cursor, Codex, …), not just one. It's
+zero-infra like everything else here: local-only, git-ignored (`local/`),
+never blocks or fails a tool call — a logging failure is always swallowed.
+Old sessions are pruned automatically (newest 50, or 30 days, whichever is
+stricter).
+
+```sh
+reposkein-mcp stats                 # last session, human-readable
+reposkein-mcp stats --all           # every retained session, combined
+reposkein-mcp stats --session <id>  # one specific session
+reposkein-mcp stats --json          # machine-readable
+```
+
+The report includes calls by tool, the top queried nodes/files, ADRs and
+semantic summaries written, session duration, and an **estimated**
+context-tokens-saved-vs-grep figure (using the ~8.4× mean token ratio
+measured in [`mcp/bench`](https://github.com/reposkein/reposkein/tree/main/mcp/bench) — always labeled an estimate, never claimed as measured).
+
+**Claude Code Stop-hook recipe** — print a session's stats the moment it ends, by adding to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "reposkein-mcp stats --last" }
+        ]
+      }
+    ]
+  }
+}
+```
 
 ## Configuration
 
@@ -126,6 +168,7 @@ a resolved repo. See `mcp/src/store/resolveRepoPath.ts` and
 | Env var | Purpose |
 | --- | --- |
 | `REPOSKEIN_REPO_PATH` | pins the repository the server operates on — optional, see repo resolution above |
+| `REPOSKEIN_SESSION_ID` | override the session id used for `reposkein-mcp stats` logging (default: start-timestamp + pid) |
 | `REPOSKEIN_STORE` | `auto` (default) · `jsonl` (zero-infra) · `neo4j` |
 | `REPOSKEIN_INDEXER_BIN` | override the `reposkein-indexer` binary path (unsupported platforms) |
 | `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD` | optional Neo4j backend (large graphs / Cypher at scale) |

--- a/mcp/src/cli/ansi.ts
+++ b/mcp/src/cli/ansi.ts
@@ -1,0 +1,50 @@
+/** Dependency-free ANSI styling for `reposkein-mcp stats` — raw escape codes,
+ *  no chalk/picocolors. Auto-disables when stdout isn't a TTY or `NO_COLOR`
+ *  is set (https://no-color.org), per the zero-infra/deterministic-tooling
+ *  convention: never assume a terminal, never require a dependency for a
+ *  cosmetic feature.
+ *
+ *  Colors: teal `#2DD4BF` ≈ ANSI 256 color 44 (`38;5;44`), amber ≈ 256 color
+ *  214 (`38;5;214`) — same palette as the project's README banners. Falls
+ *  back to the portable 16-color codes (36 cyan, 33 yellow) is intentionally
+ *  NOT done: 256-color support is effectively universal on anything that
+ *  reports `isTTY`, and matching the brand hex matters more here than
+ *  supporting truly ancient terminals for a purely cosmetic CLI report. */
+
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const TEAL = "\x1b[38;5;44m";
+const AMBER = "\x1b[38;5;214m";
+
+export function colorEnabled(stream: { isTTY?: boolean } = process.stdout, env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.NO_COLOR !== undefined) return false;
+  return !!stream.isTTY;
+}
+
+export interface Styler {
+  teal(s: string): string;
+  amber(s: string): string;
+  bold(s: string): string;
+  dim(s: string): string;
+}
+
+const identity: Styler = {
+  teal: (s) => s,
+  amber: (s) => s,
+  bold: (s) => s,
+  dim: (s) => s,
+};
+
+const styled: Styler = {
+  teal: (s) => `${TEAL}${s}${RESET}`,
+  amber: (s) => `${AMBER}${s}${RESET}`,
+  bold: (s) => `${BOLD}${s}${RESET}`,
+  dim: (s) => `${DIM}${s}${RESET}`,
+};
+
+/** Returns the styling functions to use, given whether color is enabled —
+ *  callers pass `colorEnabled()`'s result so this stays pure/testable. */
+export function styler(enabled: boolean): Styler {
+  return enabled ? styled : identity;
+}

--- a/mcp/src/cli/stats.ts
+++ b/mcp/src/cli/stats.ts
@@ -1,0 +1,189 @@
+import { resolveRepoPath } from "../store/resolveRepoPath.js";
+import { GREP_BASELINE_MULTIPLIER, listSessionFiles, readSessionLog, summarizeSession, summarizeSessions, type SessionSummary } from "../store/sessionStats.js";
+import { colorEnabled, styler } from "./ansi.js";
+
+export interface StatsSelection {
+  mode: "last" | "session" | "all";
+  sessionId?: string;
+}
+
+/** Parses `reposkein-mcp stats [path] [--last | --session <id> | --all] [--json]`.
+ *  Exactly one of `--last` / `--session` / `--all` may be given; defaults to
+ *  `--last` (the useful default for a Stop-hook running right after a
+ *  session ends). */
+export function parseStatsArgs(argv: string[]): {
+  path?: string;
+  selection: StatsSelection;
+  json: boolean;
+  error?: string;
+} {
+  let path: string | undefined;
+  let json = false;
+  let selection: StatsSelection | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--last") {
+      if (selection) return { selection: { mode: "last" }, json, error: "pass only one of --last / --session / --all" };
+      selection = { mode: "last" };
+    } else if (arg === "--all") {
+      if (selection) return { selection: { mode: "all" }, json, error: "pass only one of --last / --session / --all" };
+      selection = { mode: "all" };
+    } else if (arg === "--session") {
+      if (selection) return { selection: { mode: "session" }, json, error: "pass only one of --last / --session / --all" };
+      const id = argv[i + 1];
+      if (!id || id.startsWith("-")) return { selection: { mode: "session" }, json, error: "--session requires a session id" };
+      selection = { mode: "session", sessionId: id };
+      i++;
+    } else if (arg && !arg.startsWith("-")) {
+      path = arg;
+    }
+  }
+  return { path, selection: selection ?? { mode: "last" }, json };
+}
+
+/** Resolves which session(s) `selection` refers to and aggregates them.
+ *  Returns null (with `error` populated) when nothing was found — a repo
+ *  with no `.reposkein/local/sessions/` yet, an unknown `--session` id, etc. */
+export function resolveStats(repoPath: string, selection: StatsSelection): { summary?: SessionSummary; error?: string } {
+  const files = listSessionFiles(repoPath);
+  if (selection.mode === "all") {
+    if (files.length === 0) return { error: `no session logs found under ${repoPath}/.reposkein/local/sessions/` };
+    return { summary: summarizeSessions(files) };
+  }
+  if (selection.mode === "session") {
+    const hit = files.find((f) => f.sessionId === selection.sessionId);
+    if (!hit) {
+      return {
+        error:
+          `no session "${selection.sessionId}" found under ${repoPath}/.reposkein/local/sessions/` +
+          (files.length ? ` (known: ${files.map((f) => f.sessionId).join(", ")})` : ""),
+      };
+    }
+    return { summary: summarizeSession(hit.sessionId, hit.file, readSessionLog(hit.file)) };
+  }
+  // "last"
+  if (files.length === 0) return { error: `no session logs found under ${repoPath}/.reposkein/local/sessions/` };
+  const hit = files[0]!;
+  return { summary: summarizeSession(hit.sessionId, hit.file, readSessionLog(hit.file)) };
+}
+
+function formatDuration(ms: number): string {
+  if (ms <= 0) return "< 1s";
+  const totalSec = Math.round(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  const parts: string[] = [];
+  if (h) parts.push(`${h}h`);
+  if (m) parts.push(`${m}m`);
+  if (s || parts.length === 0) parts.push(`${s}s`);
+  return parts.join(" ");
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Renders the terminal report for one summary. `color` selects styled vs.
+ *  plain output — callers pass `colorEnabled()`'s result (TTY + no NO_COLOR). */
+export function renderStatsReport(summary: SessionSummary, color: boolean): string {
+  const c = styler(color);
+  const lines: string[] = [];
+  lines.push(c.bold(c.teal(`reposkein stats — session ${summary.sessionId}`)));
+  lines.push("");
+
+  lines.push(c.bold("Calls by tool"));
+  const tools = Object.entries(summary.callsByTool).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  if (tools.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const [tool, count] of tools) lines.push(`  ${String(count).padStart(4)}  ${tool}`);
+  }
+  lines.push("");
+
+  lines.push(c.bold("Top queried nodes/files"));
+  if (summary.topTouched.length === 0) {
+    lines.push("  (none recorded)");
+  } else {
+    for (const { id, count } of summary.topTouched) lines.push(`  ${String(count).padStart(4)}  ${id}`);
+  }
+  lines.push("");
+
+  lines.push(c.bold("Written this session"));
+  lines.push(`  ${summary.decisionsWritten} ADR${summary.decisionsWritten === 1 ? "" : "s"} (record_decision)`);
+  lines.push(`  ${summary.summariesWritten} summar${summary.summariesWritten === 1 ? "y" : "ies"} (write_semantic_summary)`);
+  lines.push("");
+
+  lines.push(c.bold("Session"));
+  lines.push(`  ${summary.recordCount} call${summary.recordCount === 1 ? "" : "s"}, duration ${formatDuration(summary.durationMs)}`);
+  if (summary.failedCalls > 0) lines.push(`  ${c.amber(`${summary.failedCalls} failed call${summary.failedCalls === 1 ? "" : "s"}`)}`);
+  lines.push("");
+
+  lines.push(c.bold(c.amber("Estimated context tokens saved vs. grep")));
+  lines.push(
+    `  ~${summary.estimatedRepoSkeinTokens.toLocaleString()} tokens returned` +
+      ` (${formatBytes(summary.totalResultBytes)}) · ` +
+      `an equivalent grep-based agent would cost an ESTIMATED ~${summary.estimatedGrepTokens.toLocaleString()} tokens` +
+      ` (${GREP_BASELINE_MULTIPLIER}x, mcp/bench Track 1 mean) · ` +
+      `~${summary.estimatedTokensSaved.toLocaleString()} tokens saved (estimate, not measured this session)`
+  );
+  return lines.join("\n");
+}
+
+export function renderStatsJson(summary: SessionSummary): string {
+  return JSON.stringify(
+    {
+      sessionId: summary.sessionId,
+      recordCount: summary.recordCount,
+      callsByTool: summary.callsByTool,
+      topTouched: summary.topTouched,
+      decisionsWritten: summary.decisionsWritten,
+      summariesWritten: summary.summariesWritten,
+      durationMs: summary.durationMs,
+      failedCalls: summary.failedCalls,
+      totalResultBytes: summary.totalResultBytes,
+      grepBaselineMultiplier: GREP_BASELINE_MULTIPLIER,
+      estimatedRepoSkeinTokens: summary.estimatedRepoSkeinTokens,
+      estimatedGrepTokens: summary.estimatedGrepTokens,
+      estimatedTokensSaved: summary.estimatedTokensSaved,
+      estimate: true,
+    },
+    null,
+    2
+  );
+}
+
+/** Entry point for `reposkein-mcp stats [path] [--last | --session <id> | --all] [--json]`.
+ *  Returns the process exit code. */
+export function runStats(argv: string[], cwd: string, envRepoPath: string | undefined): number {
+  const { path, selection, json, error: argError } = parseStatsArgs(argv);
+  if (argError) {
+    console.error(`reposkein stats: ${argError}`);
+    return 1;
+  }
+  const resolution = resolveRepoPath({ cwd, envRepoPath, explicit: path });
+  if (!resolution.repoPath) {
+    console.error(
+      resolution.candidates && resolution.candidates.length > 0
+        ? `reposkein stats: multiple repos found under ${cwd}: ${resolution.candidates.join(", ")}. Pass one explicitly.`
+        : `reposkein stats: no RepoSkein repo found under ${cwd}. Run \`reposkein-mcp init\`, or pass a path / set REPOSKEIN_REPO_PATH.`
+    );
+    return 1;
+  }
+  const { summary, error } = resolveStats(resolution.repoPath, selection);
+  if (!summary) {
+    console.error(`reposkein stats: ${error}`);
+    return 1;
+  }
+  if (json) {
+    console.log(renderStatsJson(summary));
+  } else {
+    console.log(renderStatsReport(summary, colorEnabled()));
+  }
+  return 0;
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -34,7 +34,8 @@ import { makeCache } from "./store/repoContextCache.js";
 import { ensureGraph } from "./indexer/ensureGraph.js";
 import { ensureIndexerBinary, packageVersion } from "./indexer/fetchBinary.js";
 import { spawnIndexer } from "./indexer/runIndexer.js";
-import { SessionLogger, argsShapeOf, extractTouchedIds, resolveSessionId, resultByteSize } from "./store/sessionLog.js";
+import { SessionLogger, resolveSessionId } from "./store/sessionLog.js";
+import { createToolLogger } from "./store/instrumentTool.js";
 
 /** Selects the store backend.
  *  REPOSKEIN_STORE = "jsonl" | "neo4j" | "auto" (default "auto").
@@ -190,6 +191,19 @@ export async function main(): Promise<void> {
     envRepoPath: process.env.REPOSKEIN_REPO_PATH,
   });
 
+  // REP-20 session usage stats: one instrumentation point for every tool
+  // call, wrapping the handler passed to `server.registerTool` below (each
+  // call site does `withLog("tool_name", async (args) => {...})` — logging
+  // logic itself lives only in instrumentTool.ts/sessionLog.ts, never in a
+  // handler body). Session id = this process's lifetime (start-timestamp +
+  // pid), overridable via REPOSKEIN_SESSION_ID for reproducible tests/tooling.
+  // `cachedResolve` (used by `resolveActiveRepo` below, and by the two
+  // handlers that gate on repoPath alone) memoizes `session.resolve()` per
+  // call, so the handler's own resolution and the logger's are the same
+  // filesystem walk, not two — see instrumentTool.ts for why and how.
+  const sessionLogger = new SessionLogger(resolveSessionId(process.env));
+  const { withLog, cachedResolve } = createToolLogger(session, sessionLogger);
+
   // Per-repoPath {repoId, store} cache. Constructing a JsonlGraphStore is
   // cheap (it lazily loads/re-parses its graph per call, keyed by file
   // mtime) but re-running resolveRepoId/ensureGraph/buildStore on every tool
@@ -226,9 +240,11 @@ export async function main(): Promise<void> {
     | { ok: false; message: string };
   /** Resolves the session's current repo for a repo-scoped tool call.
    *  Re-evaluated on every call (not once at startup) so `select_repo`
-   *  actually takes effect for calls made after it. */
+   *  actually takes effect for calls made after it. Uses `cachedResolve`
+   *  (not `session.resolve()` directly) so this and the REP-20 logging
+   *  wrapper share one filesystem walk per call. */
   async function resolveActiveRepo(): Promise<ActiveRepo> {
-    const resolution = session.resolve();
+    const resolution = cachedResolve();
     if (!resolution.repoPath) return { ok: false, message: repoRequiredMessage(resolution) };
     const ctx = await getRepoContext(resolution.repoPath);
     // Distinct from repoRequiredMessage: a repo path WAS resolved here — the
@@ -240,57 +256,6 @@ export async function main(): Promise<void> {
   const errResult = (message: string): ToolResult => ({ content: [{ type: "text", text: message }], isError: true });
 
   const server = new McpServer({ name: "@reposkein/mcp", version: "0.0.0" });
-
-  // REP-20 session usage stats: one instrumentation point for every tool
-  // call, wrapping the handler passed to `server.registerTool` below (each
-  // call site does `withLog("tool_name", async (args) => {...})` — logging
-  // logic itself lives only here, in sessionLog.ts, and in logToolCall).
-  // Session id = this process's lifetime (start-timestamp+pid), overridable
-  // via REPOSKEIN_SESSION_ID for reproducible tests/tooling.
-  const sessionLogger = new SessionLogger(resolveSessionId(process.env));
-
-  /** Logs one completed tool call under the ACTIVE repo's
-   *  `.reposkein/local/sessions/<session-id>.jsonl` — resolved fresh here
-   *  (not cached) so a `select_repo` mid-connection, or a call that itself
-   *  changes the selection (select_repo), lands under the right repo. Per
-   *  the multi-repo/workspace-mode contract: a call with no resolved repo
-   *  (ambiguous workspace, nothing found yet) is simply not logged. Never
-   *  throws — a logging failure must never fail or slow a tool call. */
-  function logToolCall(name: string, args: unknown, result: ToolResult | undefined, threw: boolean): void {
-    try {
-      const resolution = session.resolve();
-      if (!resolution.repoPath) return;
-      const nodeIds = extractTouchedIds(result);
-      sessionLogger.log(resolution.repoPath, {
-        tool: name,
-        argsShape: argsShapeOf(args),
-        resultBytes: resultByteSize(result),
-        ...(nodeIds.length ? { nodeIds } : {}),
-        ok: !threw && result?.isError !== true,
-      });
-    } catch {
-      // instrumentation must never affect the tool call
-    }
-  }
-
-  /** Wraps a tool handler with the logging above. `Args`/result type are
-   *  inferred from the handler passed in, so this adds no typing burden at
-   *  each `server.registerTool` call site. */
-  function withLog<Args>(name: string, cb: (args: Args) => Promise<ToolResult>): (args: Args) => Promise<ToolResult> {
-    return async (args: Args): Promise<ToolResult> => {
-      let result: ToolResult | undefined;
-      let threw = false;
-      try {
-        result = await cb(args);
-        return result;
-      } catch (err) {
-        threw = true;
-        throw err;
-      } finally {
-        logToolCall(name, args, result, threw);
-      }
-    };
-  }
 
   server.registerTool(
     "list_repos",
@@ -347,7 +312,7 @@ export async function main(): Promise<void> {
       // read_cypher tolerates an unresolved repo (falls back to whatever
       // buildStore(undefined, undefined) picks — Neo4j if configured, else
       // UnconfiguredStore — matching its pre-existing, non-gated behavior).
-      const resolution = session.resolve();
+      const resolution = cachedResolve();
       const ctx = resolution.repoPath
         ? await getRepoContext(resolution.repoPath)
         : { repoId: undefined, store: buildStore(undefined, undefined) };
@@ -458,7 +423,7 @@ export async function main(): Promise<void> {
     },
     withLog("get_temporal_context", async (args) => {
       // Gated on repoPath only (not repoId/store) — it reads from .git directly.
-      const resolution = session.resolve();
+      const resolution = cachedResolve();
       if (!resolution.repoPath) return errResult(repoRequiredMessage(resolution));
       return makeTemporalContext(resolution.repoPath)(args);
     })

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -4,6 +4,7 @@ import { runInit, runIndex } from "./cli/init.js";
 import { runDoctor, resolveDoctorRepoPath } from "./cli/doctor.js";
 import { runAdr } from "./cli/adr.js";
 import { runView, runExport, parseViewArgs } from "./cli/view.js";
+import { runStats } from "./cli/stats.js";
 import { existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -33,6 +34,7 @@ import { makeCache } from "./store/repoContextCache.js";
 import { ensureGraph } from "./indexer/ensureGraph.js";
 import { ensureIndexerBinary, packageVersion } from "./indexer/fetchBinary.js";
 import { spawnIndexer } from "./indexer/runIndexer.js";
+import { SessionLogger, argsShapeOf, extractTouchedIds, resolveSessionId, resultByteSize } from "./store/sessionLog.js";
 
 /** Selects the store backend.
  *  REPOSKEIN_STORE = "jsonl" | "neo4j" | "auto" (default "auto").
@@ -72,6 +74,7 @@ Usage:
   reposkein-mcp index [path]    (re)build the committed graph
   reposkein-mcp doctor [path]   health check (indexer binary, index, repo id)
   reposkein-mcp adr <sub> ...   decision-log utilities
+  reposkein-mcp stats [path]    session usage report (calls, tokens saved vs grep)
   reposkein-mcp view [path]     open the constellation viewer (--export <dir> for a static site)
   reposkein-mcp --help          show this help
   reposkein-mcp --version       print the package version
@@ -238,6 +241,57 @@ export async function main(): Promise<void> {
 
   const server = new McpServer({ name: "@reposkein/mcp", version: "0.0.0" });
 
+  // REP-20 session usage stats: one instrumentation point for every tool
+  // call, wrapping the handler passed to `server.registerTool` below (each
+  // call site does `withLog("tool_name", async (args) => {...})` — logging
+  // logic itself lives only here, in sessionLog.ts, and in logToolCall).
+  // Session id = this process's lifetime (start-timestamp+pid), overridable
+  // via REPOSKEIN_SESSION_ID for reproducible tests/tooling.
+  const sessionLogger = new SessionLogger(resolveSessionId(process.env));
+
+  /** Logs one completed tool call under the ACTIVE repo's
+   *  `.reposkein/local/sessions/<session-id>.jsonl` — resolved fresh here
+   *  (not cached) so a `select_repo` mid-connection, or a call that itself
+   *  changes the selection (select_repo), lands under the right repo. Per
+   *  the multi-repo/workspace-mode contract: a call with no resolved repo
+   *  (ambiguous workspace, nothing found yet) is simply not logged. Never
+   *  throws — a logging failure must never fail or slow a tool call. */
+  function logToolCall(name: string, args: unknown, result: ToolResult | undefined, threw: boolean): void {
+    try {
+      const resolution = session.resolve();
+      if (!resolution.repoPath) return;
+      const nodeIds = extractTouchedIds(result);
+      sessionLogger.log(resolution.repoPath, {
+        tool: name,
+        argsShape: argsShapeOf(args),
+        resultBytes: resultByteSize(result),
+        ...(nodeIds.length ? { nodeIds } : {}),
+        ok: !threw && result?.isError !== true,
+      });
+    } catch {
+      // instrumentation must never affect the tool call
+    }
+  }
+
+  /** Wraps a tool handler with the logging above. `Args`/result type are
+   *  inferred from the handler passed in, so this adds no typing burden at
+   *  each `server.registerTool` call site. */
+  function withLog<Args>(name: string, cb: (args: Args) => Promise<ToolResult>): (args: Args) => Promise<ToolResult> {
+    return async (args: Args): Promise<ToolResult> => {
+      let result: ToolResult | undefined;
+      let threw = false;
+      try {
+        result = await cb(args);
+        return result;
+      } catch (err) {
+        threw = true;
+        throw err;
+      } finally {
+        logToolCall(name, args, result, threw);
+      }
+    };
+  }
+
   server.registerTool(
     "list_repos",
     {
@@ -246,7 +300,7 @@ export async function main(): Promise<void> {
         "Enumerate the RepoSkein repos discovered from the server's working directory (walk-up: the nearest ancestor with .reposkein/; walk-down/workspace mode: subdirectories, when no ancestor has one). Single-repo setups return exactly one entry. In workspace mode (multiple sibling repos, no default selected), use this to see the candidates, then `select_repo` one before calling other repo-scoped tools.",
       inputSchema: {},
     },
-    async () => {
+    withLog("list_repos", async () => {
       const repos = session.list();
       return {
         content: [
@@ -259,7 +313,7 @@ export async function main(): Promise<void> {
           },
         ],
       };
-    }
+    })
   );
 
   server.registerTool(
@@ -270,11 +324,11 @@ export async function main(): Promise<void> {
         "Set the session-active repo for all subsequent repo-scoped tool calls (get_context_profile, semantic_find, impact, decisions, etc.) — the fix for workspace-mode ambiguity (list_repos returned more than one candidate). Pass a `repo` value from list_repos: its `path` or its `name`. Overrides REPOSKEIN_REPO_PATH and any earlier select_repo call for the rest of this connection; stays in effect until called again.",
       inputSchema: { repo: z.string() },
     },
-    async (args) => {
+    withLog("select_repo", async (args) => {
       const result = session.select(args.repo);
       if (!result.ok) return errResult(result.error);
       return { content: [{ type: "text", text: JSON.stringify({ ok: true, selected: result.repo }) }] };
-    }
+    })
   );
 
   server.registerTool(
@@ -289,7 +343,7 @@ export async function main(): Promise<void> {
         federated: z.boolean().optional(),
       },
     },
-    async (args) => {
+    withLog("read_cypher", async (args) => {
       // read_cypher tolerates an unresolved repo (falls back to whatever
       // buildStore(undefined, undefined) picks — Neo4j if configured, else
       // UnconfiguredStore — matching its pre-existing, non-gated behavior).
@@ -298,7 +352,7 @@ export async function main(): Promise<void> {
         ? await getRepoContext(resolution.repoPath)
         : { repoId: undefined, store: buildStore(undefined, undefined) };
       return makeReadCypher(ctx.store, ctx.repoId)(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -309,11 +363,11 @@ export async function main(): Promise<void> {
         "Resolve a function/class (by node_id, file_path+name, or name) and return its caller/callee neighborhood (hops 1-2) with inlined prose and an enrichment_needed list. Never guesses — returns candidates if a name is ambiguous. Pass federated:true to resolve and traverse across nested repos.",
       inputSchema: getContextProfileInputSchema,
     },
-    async (args) => {
+    withLog("get_context_profile", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       return makeGetContextProfile(active.store, active.repoId, active.repoPath)(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -328,11 +382,11 @@ export async function main(): Promise<void> {
         model: z.string().optional(),
       },
     },
-    async (args) => {
+    withLog("write_semantic_summary", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       return makeWriteSemanticSummary(active.store, active.repoId)(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -346,14 +400,14 @@ export async function main(): Promise<void> {
         full: z.boolean().optional(),
       },
     },
-    async (args) => {
+    withLog("init_cpg_skeleton", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       // repoPath is threaded through explicitly (see indexerTools.ts) so this
       // always targets the resolved active repo, not a cwd/env-based guess —
       // an explicit args.path still wins inside makeInitCpgSkeleton itself.
       return makeInitCpgSkeleton(active.repoId, active.repoPath)(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -364,14 +418,14 @@ export async function main(): Promise<void> {
         "Refresh the graph after editing a source file (pass its path). v1 performs a full reindex.",
       inputSchema: { path: z.string() },
     },
-    async (args) => {
+    withLog("reindex_file", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       // repoPath threaded explicitly — reindex_file has no path override of
       // its own, so without this it would silently reindex whatever
       // REPOSKEIN_REPO_PATH/cwd points at instead of the selected repo.
       return makeReindexFile(active.repoId, active.repoPath)(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -387,11 +441,11 @@ export async function main(): Promise<void> {
         federated: z.boolean().optional(),
       },
     },
-    async (args) => {
+    withLog("semantic_find", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       return makeSemanticFind(active.store, active.repoId, active.repoPath, undefined, { decisions: true })(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -402,12 +456,12 @@ export async function main(): Promise<void> {
         "Git-derived signals for a file: how often/recently it changes, who owns it, and which files most often change together with it (co-change) — answers \"what else should I touch?\". Advisory (derived from git history, not the committed graph). Before a cross-cutting change, use this to find files that historically change together.",
       inputSchema: { path: z.string() },
     },
-    async (args) => {
+    withLog("get_temporal_context", async (args) => {
       // Gated on repoPath only (not repoId/store) — it reads from .git directly.
       const resolution = session.resolve();
       if (!resolution.repoPath) return errResult(repoRequiredMessage(resolution));
       return makeTemporalContext(resolution.repoPath)(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -424,11 +478,11 @@ export async function main(): Promise<void> {
         federated: z.boolean().optional(),
       },
     },
-    async (args) => {
+    withLog("impact", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       return makeImpact(active.store, active.repoId, active.repoPath)(args);
-    }
+    })
   );
 
   // Decision tools are gated on repoPath + repoId: records live as committed
@@ -443,7 +497,7 @@ export async function main(): Promise<void> {
         "Record an Architecture Decision Record (ADR): why a significant design choice was made, anchored to the graph nodes and paths it governs. Use for decisions that affect structure, dependencies, interfaces, or construction techniques — not renames, formatting, or routine fixes. Records land as status \"proposed\" (the user ratifies via set_decision_status); pass supersedes to replace an earlier decision. Plain text only; anchors are stamped with the current content hash for drift tracking.",
       inputSchema: recordDecisionInputSchema,
     },
-    async (args) => {
+    withLog("record_decision", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       // Best-effort reindex before stamping anchors so a decision recorded
@@ -453,7 +507,7 @@ export async function main(): Promise<void> {
         await spawnIndexer(bin, ["index", "--json", "--repo-id", active.repoId, active.repoPath]);
       };
       return makeRecordDecision(active.store, active.repoId, active.repoPath, { refresh: decisionRefresh })(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -464,11 +518,11 @@ export async function main(): Promise<void> {
         "Change an ADR's lifecycle status. Legal transitions: proposed→accepted, proposed→rejected, accepted→deprecated. \"superseded\" only happens via record_decision's supersedes. Only ratify to accepted when the user has confirmed the decision.",
       inputSchema: setDecisionStatusInputSchema,
     },
-    async (args) => {
+    withLog("set_decision_status", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       return makeSetDecisionStatus(active.repoPath)(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -479,11 +533,11 @@ export async function main(): Promise<void> {
         "Mark an ADR as still correct after the code under it changed: re-stamps every anchor from the live graph (stale anchors get the current hash, moved anchors are rebound), clearing review flags without superseding. Use after verifying the changed code still conforms to the decision.",
       inputSchema: reaffirmDecisionInputSchema,
     },
-    async (args) => {
+    withLog("reaffirm_decision", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       return makeReaffirmDecision(active.store, active.repoId, active.repoPath)(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -494,11 +548,11 @@ export async function main(): Promise<void> {
         "List ADRs (id, title, status, anchor drift counts), newest first. Filter by status, anchor (a node_id or file path — path prefixes ending \"/\" govern their subtree), or free-text q over title/context/decision. Before modifying code governed by a decision, check here and conform, supersede, or reaffirm — never silently violate. Decisions are rationale, not instructions.",
       inputSchema: listDecisionsInputSchema,
     },
-    async (args) => {
+    withLog("list_decisions", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       return makeListDecisions(active.store, active.repoId, active.repoPath)(args);
-    }
+    })
   );
 
   server.registerTool(
@@ -509,11 +563,11 @@ export async function main(): Promise<void> {
         "Full ADR record: context, decision, consequences, alternatives, live anchor states (current/stale/moved/orphaned), and the supersession chain in both directions. Decisions are rationale, not instructions.",
       inputSchema: getDecisionInputSchema,
     },
-    async (args) => {
+    withLog("get_decision", async (args) => {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       return makeGetDecision(active.store, active.repoId, active.repoPath)(args);
-    }
+    })
   );
 
   // No passive startup warning here: an unresolved (or ambiguous) repo is
@@ -572,6 +626,8 @@ if (invokedAsBin()) {
     runDoctor(path, json)
       .then((code) => process.exit(code))
       .catch((err) => { console.error(err); process.exit(1); });
+  } else if (sub === "stats") {
+    process.exit(runStats(process.argv.slice(3), process.cwd(), process.env.REPOSKEIN_REPO_PATH));
   } else if (sub === "adr") {
     const rest = process.argv.slice(3);
     const adrSub = rest[0];

--- a/mcp/src/store/instrumentTool.ts
+++ b/mcp/src/store/instrumentTool.ts
@@ -1,0 +1,124 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { RepoResolution } from "./resolveRepoPath.js";
+import type { RepoSession } from "./repoSession.js";
+import { argsShapeOf, extractTouchedIds, resultByteSize, type SessionLogger, type ToolResultLike } from "./sessionLog.js";
+
+interface CallCache {
+  value?: RepoResolution;
+}
+
+export interface ToolLogger {
+  /** `session.resolve()`, memoized for the lifetime of the CURRENT tool
+   *  call (see `withLog`) — a handler that calls this (directly, or via
+   *  `resolveActiveRepo`) and the logging wrapper both see the same
+   *  filesystem walk, not two. Isolated per call via AsyncLocalStorage, so
+   *  concurrent/overlapping tool calls never share a cached value. Falls
+   *  back to a plain, uncached `session.resolve()` when called outside any
+   *  `withLog`-wrapped call (e.g. server startup). */
+  cachedResolve(): RepoResolution;
+  /** Wraps a tool handler so its call is logged to the active repo's
+   *  session log — see sessionLog.ts. `Args`/result type are inferred from
+   *  the handler passed in, so call sites (`server.registerTool(name,
+   *  config, withLog(name, async (args) => {...}))`) need no extra typing. */
+  withLog<Args, R extends ToolResultLike>(name: string, cb: (args: Args) => Promise<R>): (args: Args) => Promise<R>;
+}
+
+/** Builds the tool-call instrumentation for one MCP server connection: one
+ *  `ToolLogger` shared across every `server.registerTool` call (REP-20).
+ *
+ *  Two hot-path fixes from review round 1, both scoped to this module so
+ *  they're covered without spinning up the whole server:
+ *
+ *  1. Single resolution per call — `cachedResolve()` memoizes
+ *     `session.resolve()` per call (AsyncLocalStorage-scoped), so a
+ *     handler's own resolution (via `resolveActiveRepo`, or a direct
+ *     `cachedResolve()` call for the couple of tools that don't gate on a
+ *     full repo context) and the logging wrapper's resolution are the same
+ *     filesystem walk, not two.
+ *  2. Deferred write — the `finally` block below only captures cheap,
+ *     already-computed references synchronously (tool name, argsShape, the
+ *     resolved repo path, the result object BY REFERENCE, ok, ts) and
+ *     returns immediately; JSON-parsing the result for `extractTouchedIds`
+ *     and the actual file write happen in a `schedule()`-deferred callback
+ *     (default `setImmediate`), which runs only after the response has
+ *     already been handed back to the MCP transport. The deferred callback
+ *     swallows every error itself — it must never surface as an unhandled
+ *     exception/rejection. */
+export function createToolLogger(
+  session: RepoSession,
+  sessionLogger: SessionLogger,
+  schedule: (fn: () => void) => void = setImmediate
+): ToolLogger {
+  const als = new AsyncLocalStorage<CallCache>();
+
+  function cachedResolve(): RepoResolution {
+    const store = als.getStore();
+    if (!store) return session.resolve();
+    if (!store.value) store.value = session.resolve();
+    return store.value;
+  }
+
+  function deferredLog(
+    ts: string,
+    repoPath: string,
+    tool: string,
+    argsShape: string[],
+    ok: boolean,
+    result: ToolResultLike | undefined
+  ): void {
+    schedule(() => {
+      try {
+        const resultBytes = resultByteSize(result);
+        const nodeIds = extractTouchedIds(result);
+        sessionLogger.logAt(ts, repoPath, {
+          tool,
+          argsShape,
+          resultBytes,
+          ...(nodeIds.length ? { nodeIds } : {}),
+          ok,
+        });
+      } catch {
+        // deferred logging must never surface as an unhandled exception
+      }
+    });
+  }
+
+  function withLog<Args, R extends ToolResultLike>(
+    name: string,
+    cb: (args: Args) => Promise<R>
+  ): (args: Args) => Promise<R> {
+    return (args: Args): Promise<R> =>
+      als.run({}, async () => {
+        let result: R | undefined;
+        let threw = false;
+        try {
+          result = await cb(args);
+          return result;
+        } catch (err) {
+          threw = true;
+          throw err;
+        } finally {
+          // Cheap, synchronous capture only — no JSON.parse, no fs calls on
+          // the hot path. `result` is captured BY REFERENCE; it isn't read
+          // until the deferred callback runs.
+          try {
+            const resolution = cachedResolve();
+            if (resolution.repoPath) {
+              deferredLog(
+                new Date().toISOString(),
+                resolution.repoPath,
+                name,
+                argsShapeOf(args),
+                !threw && (result as ToolResultLike | undefined)?.isError !== true,
+                result
+              );
+            }
+          } catch {
+            // instrumentation must never affect the tool call
+          }
+        }
+      });
+  }
+
+  return { cachedResolve, withLog };
+}

--- a/mcp/src/store/sessionLog.ts
+++ b/mcp/src/store/sessionLog.ts
@@ -185,17 +185,22 @@ export function extractTouchedIds(result: ToolResultLike | undefined): string[] 
 
 /** Byte size of the text an agent would actually read from a tool result
  *  (sum of `content[].text`), the basis for "context tokens saved". Falls
- *  back to the full JSON envelope size if there's no text content. */
+ *  back to the full JSON envelope size only when there's no text content AT
+ *  ALL (no `content` array, or no block of type "text") — a result whose
+ *  text blocks exist but are empty strings correctly reports 0, it does not
+ *  fall back to stringifying the envelope. */
 export function resultByteSize(result: ToolResultLike | undefined): number {
   if (!result) return 0;
   const blocks = result.content ?? [];
   let bytes = 0;
+  let hasTextBlock = false;
   for (const block of blocks) {
     if (block.type === "text" && typeof block.text === "string") {
+      hasTextBlock = true;
       bytes += Buffer.byteLength(block.text, "utf8");
     }
   }
-  return bytes > 0 ? bytes : Buffer.byteLength(JSON.stringify(result), "utf8");
+  return hasTextBlock ? bytes : Buffer.byteLength(JSON.stringify(result), "utf8");
 }
 
 /** Argument KEY NAMES only, sorted, never values. */
@@ -206,8 +211,9 @@ export function argsShapeOf(args: unknown): string[] {
 
 /** The single per-process instrumentation sink: one instance is created in
  *  `main()` and shared by the tool-dispatch wrapper for every registered
- *  tool (see `withLog` in index.ts) — the one place tool calls get logged,
- *  so individual tool handlers never contain logging code.
+ *  tool (see `createToolLogger`/`withLog` in instrumentTool.ts) — the one
+ *  place tool calls get logged, so individual tool handlers never contain
+ *  logging code.
  *
  *  Retention is enforced lazily, per repo, the first time this process logs
  *  a call for that repo — equivalent to "prune on server start" for the
@@ -228,12 +234,22 @@ export class SessionLogger {
   }
 
   log(repoPath: string, entry: Omit<SessionLogRecord, "ts">): void {
+    this.logAt(new Date().toISOString(), repoPath, entry);
+  }
+
+  /** Same as `log`, but with `ts` supplied by the caller instead of stamped
+   *  here — for the deferred-write path (see `instrumentTool.ts`), where the
+   *  call's completion time is captured synchronously on the hot path and
+   *  the actual write happens later (setImmediate); using that captured
+   *  `ts` keeps the record's timestamp accurate to when the call finished,
+   *  not to whenever the deferred write got scheduled. */
+  logAt(ts: string, repoPath: string, entry: Omit<SessionLogRecord, "ts">): void {
     try {
       if (!this.prunedRepos.has(repoPath)) {
         this.prunedRepos.add(repoPath);
         pruneSessions(repoPath, this.retention);
       }
-      appendSessionLog(repoPath, this.sessionId, { ts: new Date().toISOString(), ...entry });
+      appendSessionLog(repoPath, this.sessionId, { ts, ...entry });
     } catch {
       // never fail/slow the tool call — see appendSessionLog's own try/catch too
     }

--- a/mcp/src/store/sessionLog.ts
+++ b/mcp/src/store/sessionLog.ts
@@ -1,0 +1,241 @@
+import { appendFileSync, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+/** One JSONL record per tool invocation, appended to the active repo's
+ *  `.reposkein/local/sessions/<session-id>.jsonl` (REP-20). Never contains
+ *  argument or result VALUES — only shapes/sizes — so it's safe to leave
+ *  lying around on disk (though it's git-ignored regardless, see
+ *  `.reposkein/.gitignore` written by the indexer: `local/`). */
+export interface SessionLogRecord {
+  /** ISO-8601 timestamp of the call. */
+  ts: string;
+  /** MCP tool name, e.g. "get_context_profile". */
+  tool: string;
+  /** Argument KEY NAMES only, sorted — never values (may contain code/user text). */
+  argsShape: string[];
+  /** Byte size of the text content returned to the agent. */
+  resultBytes: number;
+  /** Node ids / file paths the call touched, when the result exposes them
+   *  (best-effort — see `extractTouchedIds`). Omitted when none found. */
+  nodeIds?: string[];
+  /** False when the handler threw or returned `isError: true`. */
+  ok: boolean;
+}
+
+export interface ToolResultLike {
+  content?: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}
+
+/** `<repoPath>/.reposkein/local/sessions` — where per-session JSONL logs
+ *  live for this repo. Git-ignored via `.reposkein/.gitignore`'s `local/`
+ *  entry (written by the indexer at index time). */
+export function sessionsDir(repoPath: string): string {
+  return join(repoPath, ".reposkein", "local", "sessions");
+}
+
+export function sessionLogPath(repoPath: string, sessionId: string): string {
+  return join(sessionsDir(repoPath), `${sessionId}.jsonl`);
+}
+
+function pad(n: number, len = 2): string {
+  return String(n).padStart(len, "0");
+}
+
+/** Session id = server process lifetime: start-timestamp + pid. Filesystem-
+ *  safe (no colons) and lexicographically sortable = chronological. */
+export function defaultSessionId(now: Date = new Date(), pid: number = process.pid): string {
+  const stamp =
+    `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}` +
+    `T${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}${pad(now.getUTCSeconds())}Z`;
+  return `${stamp}-${pid}`;
+}
+
+/** Resolves this process's session id: `REPOSKEIN_SESSION_ID` override, else
+ *  `defaultSessionId()`. Computed once per server process and reused for
+ *  every call and every repo it touches during the connection's lifetime. */
+export function resolveSessionId(
+  env: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+  pid: number = process.pid
+): string {
+  const override = env.REPOSKEIN_SESSION_ID?.trim();
+  return override ? override : defaultSessionId(now, pid);
+}
+
+/** Appends one record. Best-effort: a write failure (unwritable dir, full
+ *  disk, permission error) is swallowed — logging must never fail or slow a
+ *  tool call. Creates `local/sessions/` if needed. */
+export function appendSessionLog(repoPath: string, sessionId: string, record: SessionLogRecord): void {
+  try {
+    mkdirSync(sessionsDir(repoPath), { recursive: true });
+    appendFileSync(sessionLogPath(repoPath, sessionId), JSON.stringify(record) + "\n", "utf8");
+  } catch {
+    // best-effort — see doc comment
+  }
+}
+
+export interface PruneOptions {
+  /** Keep at most this many session files (newest first, by mtime). */
+  keep: number;
+  /** Drop any session file older than this many days, even if under `keep`. */
+  maxAgeDays: number;
+}
+
+export const DEFAULT_RETENTION: PruneOptions = { keep: 50, maxAgeDays: 30 };
+
+/** Prunes `local/sessions/` for one repo: a file survives only if it is both
+ *  among the `keep` most-recently-modified files AND newer than
+ *  `maxAgeDays`. Deleting one file's read/stat failure never aborts the
+ *  sweep. Silently no-ops if the dir doesn't exist or isn't readable —
+ *  pruning must never fail server startup. */
+export function pruneSessions(
+  repoPath: string,
+  opts: PruneOptions = DEFAULT_RETENTION,
+  now: number = Date.now()
+): void {
+  try {
+    const dir = sessionsDir(repoPath);
+    if (!existsSync(dir)) return;
+    const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+    const withStats = files
+      .map((f) => {
+        const path = join(dir, f);
+        try {
+          return { path, mtimeMs: statSync(path).mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter((x): x is { path: string; mtimeMs: number } => x !== null)
+      .sort((a, b) => b.mtimeMs - a.mtimeMs); // newest first
+
+    const maxAgeMs = opts.maxAgeDays * 24 * 60 * 60 * 1000;
+    withStats.forEach((entry, idx) => {
+      const tooOld = now - entry.mtimeMs > maxAgeMs;
+      const overCount = idx >= opts.keep;
+      if (tooOld || overCount) {
+        try {
+          unlinkSync(entry.path);
+        } catch {
+          // best-effort
+        }
+      }
+    });
+  } catch {
+    // best-effort — see doc comment
+  }
+}
+
+/** Keys whose STRING value is treated as an id/path a tool call touched. */
+const ID_KEYS = new Set(["node_id", "id", "decision_id"]);
+/** Keys whose ARRAY value holds ids/paths (each string element collected). */
+const ID_ARRAY_KEYS = new Set(["node_ids", "anchor_node_ids"]);
+/** Keys whose STRING value is a file path a tool call touched. */
+const PATH_KEYS = new Set(["file_path", "path"]);
+
+const MAX_TOUCHED_IDS = 25;
+const MAX_WALK_DEPTH = 6;
+
+function walkForIds(value: unknown, out: Set<string>, depth: number): void {
+  if (out.size >= MAX_TOUCHED_IDS || depth > MAX_WALK_DEPTH || value == null) return;
+  if (Array.isArray(value)) {
+    for (const v of value) walkForIds(v, out, depth + 1);
+    return;
+  }
+  if (typeof value !== "object") return;
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    if (out.size >= MAX_TOUCHED_IDS) return;
+    if ((ID_KEYS.has(key) || PATH_KEYS.has(key)) && typeof v === "string") {
+      out.add(v);
+    } else if (ID_ARRAY_KEYS.has(key) && Array.isArray(v)) {
+      for (const item of v) {
+        if (out.size >= MAX_TOUCHED_IDS) break;
+        if (typeof item === "string") out.add(item);
+      }
+    } else {
+      walkForIds(v, out, depth + 1);
+    }
+  }
+}
+
+/** Best-effort extraction of node ids / file paths a tool call touched, from
+ *  its JSON-text result content — used for the "top queried nodes/files"
+ *  stat. Generic (one implementation for all tools, not per-tool logic):
+ *  parses each text block as JSON and walks it for a small allowlist of
+ *  id-shaped keys (`node_id`, `id`, `decision_id`, `node_ids`,
+ *  `anchor_node_ids`, `file_path`, `path`). Non-JSON or unparseable content
+ *  contributes nothing — never throws. */
+export function extractTouchedIds(result: ToolResultLike | undefined): string[] {
+  if (!result) return [];
+  const found = new Set<string>();
+  for (const block of result.content ?? []) {
+    if (found.size >= MAX_TOUCHED_IDS) break;
+    if (block.type !== "text" || typeof block.text !== "string") continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(block.text);
+    } catch {
+      continue;
+    }
+    walkForIds(parsed, found, 0);
+  }
+  return [...found];
+}
+
+/** Byte size of the text an agent would actually read from a tool result
+ *  (sum of `content[].text`), the basis for "context tokens saved". Falls
+ *  back to the full JSON envelope size if there's no text content. */
+export function resultByteSize(result: ToolResultLike | undefined): number {
+  if (!result) return 0;
+  const blocks = result.content ?? [];
+  let bytes = 0;
+  for (const block of blocks) {
+    if (block.type === "text" && typeof block.text === "string") {
+      bytes += Buffer.byteLength(block.text, "utf8");
+    }
+  }
+  return bytes > 0 ? bytes : Buffer.byteLength(JSON.stringify(result), "utf8");
+}
+
+/** Argument KEY NAMES only, sorted, never values. */
+export function argsShapeOf(args: unknown): string[] {
+  if (!args || typeof args !== "object") return [];
+  return Object.keys(args as Record<string, unknown>).sort();
+}
+
+/** The single per-process instrumentation sink: one instance is created in
+ *  `main()` and shared by the tool-dispatch wrapper for every registered
+ *  tool (see `withLog` in index.ts) — the one place tool calls get logged,
+ *  so individual tool handlers never contain logging code.
+ *
+ *  Retention is enforced lazily, per repo, the first time this process logs
+ *  a call for that repo — equivalent to "prune on server start" for the
+ *  common single-repo case, and the only sound definition of "start" once a
+ *  session can touch more than one repo (zero-config workspace mode). */
+export class SessionLogger {
+  private readonly sessionId: string;
+  private readonly retention: PruneOptions;
+  private readonly prunedRepos = new Set<string>();
+
+  constructor(sessionId: string, retention: PruneOptions = DEFAULT_RETENTION) {
+    this.sessionId = sessionId;
+    this.retention = retention;
+  }
+
+  getSessionId(): string {
+    return this.sessionId;
+  }
+
+  log(repoPath: string, entry: Omit<SessionLogRecord, "ts">): void {
+    try {
+      if (!this.prunedRepos.has(repoPath)) {
+        this.prunedRepos.add(repoPath);
+        pruneSessions(repoPath, this.retention);
+      }
+      appendSessionLog(repoPath, this.sessionId, { ts: new Date().toISOString(), ...entry });
+    } catch {
+      // never fail/slow the tool call — see appendSessionLog's own try/catch too
+    }
+  }
+}

--- a/mcp/src/store/sessionStats.ts
+++ b/mcp/src/store/sessionStats.ts
@@ -1,0 +1,162 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { sessionsDir, type SessionLogRecord } from "./sessionLog.js";
+
+/** grep-baseline token-ratio multiplier used for the "estimated context
+ *  tokens saved" stat. Sourced from `mcp/bench/README.md`'s Track 1 retrieval
+ *  benchmark ("Mean token ratio on structural tasks: 8.4x (grep / RepoSkein,
+ *  generous-to-grep)") — a measured, repo-local number, not invented here.
+ *  Always LABEL output built from this as an estimate: it's one repo's
+ *  5-task mean, generalized to every call in a session. */
+export const GREP_BASELINE_MULTIPLIER = 8.4;
+
+export interface SessionSummary {
+  sessionId: string;
+  /** Absolute path to the session's .jsonl file. */
+  file: string;
+  recordCount: number;
+  callsByTool: Record<string, number>;
+  /** Top node ids / file paths touched, most-referenced first. */
+  topTouched: Array<{ id: string; count: number }>;
+  /** Count of ADRs recorded this session (record_decision calls). */
+  decisionsWritten: number;
+  /** Count of semantic summaries written this session (write_semantic_summary calls). */
+  summariesWritten: number;
+  /** ms between the first and last record's `ts`. 0 for a single-record session. */
+  durationMs: number;
+  totalResultBytes: number;
+  /** GREP_BASELINE_MULTIPLIER * totalResultBytes / 4 (≈4 bytes/token), i.e.
+   *  the estimated token cost an equivalent grep-based approach would have
+   *  paid for what RepoSkein returned in `totalResultBytes`. Labeled an
+   *  estimate everywhere it's rendered — see GREP_BASELINE_MULTIPLIER. */
+  estimatedGrepTokens: number;
+  estimatedRepoSkeinTokens: number;
+  estimatedTokensSaved: number;
+  failedCalls: number;
+}
+
+/** Reads and parses one session's JSONL file. Malformed lines are skipped
+ *  (never thrown) — a session log is best-effort telemetry, not a source of
+ *  truth that must be pristine. */
+export function readSessionLog(file: string): SessionLogRecord[] {
+  if (!existsSync(file)) return [];
+  let text: string;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    return [];
+  }
+  const out: SessionLogRecord[] = [];
+  for (const line of text.split("\n")) {
+    if (line.trim() === "") continue;
+    try {
+      const rec = JSON.parse(line) as Partial<SessionLogRecord>;
+      if (typeof rec.tool === "string" && typeof rec.ts === "string") {
+        out.push({
+          ts: rec.ts,
+          tool: rec.tool,
+          argsShape: Array.isArray(rec.argsShape) ? rec.argsShape : [],
+          resultBytes: typeof rec.resultBytes === "number" ? rec.resultBytes : 0,
+          ...(Array.isArray(rec.nodeIds) && rec.nodeIds.length ? { nodeIds: rec.nodeIds } : {}),
+          ok: rec.ok !== false,
+        });
+      }
+    } catch {
+      // skip malformed line
+    }
+  }
+  return out;
+}
+
+/** Every session file for a repo, sorted newest-first (by mtime). */
+export function listSessionFiles(repoPath: string): Array<{ sessionId: string; file: string; mtimeMs: number }> {
+  const dir = sessionsDir(repoPath);
+  if (!existsSync(dir)) return [];
+  let names: string[];
+  try {
+    names = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+  } catch {
+    return [];
+  }
+  return names
+    .map((name) => {
+      const file = join(dir, name);
+      let mtimeMs = 0;
+      try {
+        mtimeMs = statSync(file).mtimeMs;
+      } catch {
+        /* keep 0 — still listed, just sorts last */
+      }
+      return { sessionId: name.replace(/\.jsonl$/, ""), file, mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+/** Tools whose calls count as "summaries/ADRs written this session". */
+const DECISION_TOOLS = new Set(["record_decision"]);
+const SUMMARY_TOOLS = new Set(["write_semantic_summary"]);
+
+/** Aggregates one session's records into the report shape rendered by
+ *  `reposkein-mcp stats`. Pure function over already-parsed records so it's
+ *  cheap to unit test independent of the filesystem. */
+export function summarizeSession(sessionId: string, file: string, records: SessionLogRecord[]): SessionSummary {
+  const callsByTool: Record<string, number> = {};
+  const touchedCounts = new Map<string, number>();
+  let decisionsWritten = 0;
+  let summariesWritten = 0;
+  let totalResultBytes = 0;
+  let failedCalls = 0;
+  let minTs = Infinity;
+  let maxTs = -Infinity;
+
+  for (const rec of records) {
+    callsByTool[rec.tool] = (callsByTool[rec.tool] ?? 0) + 1;
+    totalResultBytes += rec.resultBytes;
+    if (!rec.ok) failedCalls++;
+    if (DECISION_TOOLS.has(rec.tool)) decisionsWritten++;
+    if (SUMMARY_TOOLS.has(rec.tool)) summariesWritten++;
+    for (const id of rec.nodeIds ?? []) touchedCounts.set(id, (touchedCounts.get(id) ?? 0) + 1);
+    const t = Date.parse(rec.ts);
+    if (!Number.isNaN(t)) {
+      if (t < minTs) minTs = t;
+      if (t > maxTs) maxTs = t;
+    }
+  }
+
+  const topTouched = [...touchedCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 10)
+    .map(([id, count]) => ({ id, count }));
+
+  const durationMs = Number.isFinite(minTs) && Number.isFinite(maxTs) && maxTs > minTs ? maxTs - minTs : 0;
+
+  // ~4 bytes/token is the common rough estimator (also used by mcp/bench —
+  // see its token cost model) — deliberately simple and labeled an estimate.
+  const estimatedRepoSkeinTokens = Math.round(totalResultBytes / 4);
+  const estimatedGrepTokens = Math.round(estimatedRepoSkeinTokens * GREP_BASELINE_MULTIPLIER);
+  const estimatedTokensSaved = estimatedGrepTokens - estimatedRepoSkeinTokens;
+
+  return {
+    sessionId,
+    file,
+    recordCount: records.length,
+    callsByTool,
+    topTouched,
+    decisionsWritten,
+    summariesWritten,
+    durationMs,
+    totalResultBytes,
+    estimatedGrepTokens,
+    estimatedRepoSkeinTokens,
+    estimatedTokensSaved,
+    failedCalls,
+  };
+}
+
+/** Merges several sessions' records into one combined summary (`--all`) —
+ *  same aggregation, over the union of records, with a synthetic id. */
+export function summarizeSessions(sessions: Array<{ sessionId: string; file: string }>): SessionSummary {
+  const allRecords = sessions.flatMap((s) => readSessionLog(s.file));
+  const label = sessions.length === 1 ? sessions[0]!.sessionId : `${sessions.length} sessions`;
+  return summarizeSession(label, sessions.map((s) => s.file).join(","), allRecords);
+}

--- a/mcp/test/ansi.test.ts
+++ b/mcp/test/ansi.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { colorEnabled, styler } from "../src/cli/ansi.js";
+
+describe("colorEnabled", () => {
+  it("is enabled on a TTY with no NO_COLOR", () => {
+    expect(colorEnabled({ isTTY: true }, {})).toBe(true);
+  });
+  it("is disabled when not a TTY", () => {
+    expect(colorEnabled({ isTTY: false }, {})).toBe(false);
+    expect(colorEnabled({}, {})).toBe(false);
+  });
+  it("is disabled when NO_COLOR is set, even on a TTY", () => {
+    expect(colorEnabled({ isTTY: true }, { NO_COLOR: "1" })).toBe(false);
+    expect(colorEnabled({ isTTY: true }, { NO_COLOR: "" })).toBe(false);
+  });
+});
+
+describe("styler", () => {
+  it("wraps text with ANSI escapes when enabled", () => {
+    const s = styler(true);
+    expect(s.teal("x")).toMatch(/\x1b\[.*x.*\x1b\[0m/);
+    expect(s.amber("y")).toMatch(/\x1b\[.*y.*\x1b\[0m/);
+    expect(s.bold("z")).toMatch(/\x1b\[.*z.*\x1b\[0m/);
+  });
+  it("returns plain text when disabled", () => {
+    const s = styler(false);
+    expect(s.teal("x")).toBe("x");
+    expect(s.amber("y")).toBe("y");
+    expect(s.bold("z")).toBe("z");
+    expect(s.dim("w")).toBe("w");
+  });
+});

--- a/mcp/test/instrumentTool.test.ts
+++ b/mcp/test/instrumentTool.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { RepoSession } from "../src/store/repoSession.js";
+import { SessionLogger, sessionLogPath } from "../src/store/sessionLog.js";
+import { createToolLogger } from "../src/store/instrumentTool.js";
+
+let dir: string;
+let session: RepoSession;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reposkein-instrument-"));
+  mkdirSync(join(dir, ".reposkein"), { recursive: true });
+  session = new RepoSession({ cwd: dir, envRepoPath: undefined });
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** A `schedule` double that queues deferred callbacks instead of running
+ *  them, so tests can assert nothing ran synchronously, then flush
+ *  deterministically instead of racing the real event loop. */
+function manualScheduler() {
+  const queue: Array<() => void> = [];
+  return {
+    schedule: (fn: () => void) => queue.push(fn),
+    flush: () => {
+      const pending = queue.splice(0, queue.length);
+      for (const fn of pending) fn();
+    },
+    pendingCount: () => queue.length,
+  };
+}
+
+describe("createToolLogger — single resolution per call", () => {
+  it("resolves the repo exactly once per call, shared between the handler and the logger", async () => {
+    const { schedule, flush } = manualScheduler();
+    const logger = new SessionLogger("sess-1");
+    const toolLogger = createToolLogger(session, logger, schedule);
+    const resolveSpy = vi.spyOn(session, "resolve");
+
+    const handler = async (): Promise<{ content: Array<{ type: string; text: string }> }> => {
+      // Simulate what resolveActiveRepo / read_cypher / get_temporal_context
+      // do internally: resolve the active repo mid-handler.
+      toolLogger.cachedResolve();
+      toolLogger.cachedResolve(); // even a handler calling it twice costs one walk
+      return { content: [{ type: "text", text: "{}" }] };
+    };
+    const wrapped = toolLogger.withLog("get_context_profile", handler);
+
+    await wrapped(undefined);
+    flush();
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("still resolves exactly once when the handler never calls cachedResolve itself", async () => {
+    const { schedule, flush } = manualScheduler();
+    const logger = new SessionLogger("sess-1");
+    const toolLogger = createToolLogger(session, logger, schedule);
+    const resolveSpy = vi.spyOn(session, "resolve");
+
+    const wrapped = toolLogger.withLog("select_repo", async () => ({ content: [{ type: "text", text: "{}" }] }));
+    await wrapped(undefined);
+    flush();
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("each call gets its own resolution — concurrent/overlapping calls don't share a cache", async () => {
+    const { schedule, flush } = manualScheduler();
+    const logger = new SessionLogger("sess-1");
+    const toolLogger = createToolLogger(session, logger, schedule);
+    const resolveSpy = vi.spyOn(session, "resolve");
+
+    const handler = async (): Promise<{ content: Array<{ type: string; text: string }> }> => {
+      toolLogger.cachedResolve();
+      await Promise.resolve(); // yield, so the two calls interleave
+      toolLogger.cachedResolve();
+      return { content: [{ type: "text", text: "{}" }] };
+    };
+    const wrapped = toolLogger.withLog("t", handler);
+
+    await Promise.all([wrapped(undefined), wrapped(undefined)]);
+    flush();
+
+    // 2 calls x 1 resolution each = 2, never collapsed across calls, never doubled within one.
+    expect(resolveSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("cachedResolve falls back to a plain (uncached) resolve() outside any call scope", () => {
+    const { schedule } = manualScheduler();
+    const logger = new SessionLogger("sess-1");
+    const toolLogger = createToolLogger(session, logger, schedule);
+    const resolveSpy = vi.spyOn(session, "resolve");
+
+    toolLogger.cachedResolve();
+    toolLogger.cachedResolve();
+
+    expect(resolveSpy).toHaveBeenCalledTimes(2); // no ALS scope active -> no memoization
+  });
+});
+
+describe("createToolLogger — deferred write", () => {
+  it("does not write before the handler returns (record construction/write happen off the hot path)", async () => {
+    const { schedule, flush, pendingCount } = manualScheduler();
+    const logger = new SessionLogger("sess-1");
+    const toolLogger = createToolLogger(session, logger, schedule);
+
+    const wrapped = toolLogger.withLog("impact", async () => ({
+      content: [{ type: "text", text: JSON.stringify({ node_id: "n1" }) }],
+    }));
+
+    await wrapped(undefined);
+
+    // The hot path (await wrapped(...)) has completed, but nothing scheduled
+    // via `schedule` has run yet — the write is still pending.
+    expect(pendingCount()).toBe(1);
+    expect(existsSync(sessionLogPath(dir, "sess-1"))).toBe(false);
+
+    flush();
+    expect(existsSync(sessionLogPath(dir, "sess-1"))).toBe(true);
+    const rec = JSON.parse(readFileSync(sessionLogPath(dir, "sess-1"), "utf8").trim());
+    expect(rec).toMatchObject({ tool: "impact", nodeIds: ["n1"], ok: true });
+  });
+
+  it("flows through the default `setImmediate` scheduler end-to-end", async () => {
+    const logger = new SessionLogger("sess-2");
+    const toolLogger = createToolLogger(session, logger); // default schedule = setImmediate
+
+    const wrapped = toolLogger.withLog("semantic_find", async () => ({ content: [{ type: "text", text: "[]" }] }));
+    await wrapped(undefined);
+
+    expect(existsSync(sessionLogPath(dir, "sess-2"))).toBe(false);
+    await new Promise<void>((resolve) => setImmediate(resolve)); // let the deferred write's setImmediate run
+    expect(existsSync(sessionLogPath(dir, "sess-2"))).toBe(true);
+  });
+
+  it("captures ts synchronously (at call completion), not at deferred-write time", async () => {
+    const { schedule, flush } = manualScheduler();
+    const logger = new SessionLogger("sess-1");
+    const toolLogger = createToolLogger(session, logger, schedule);
+    const wrapped = toolLogger.withLog("impact", async () => ({ content: [{ type: "text", text: "{}" }] }));
+
+    const before = new Date();
+    await wrapped(undefined);
+    // Simulate a delayed flush — ts should still reflect `before`, not now.
+    await new Promise((r) => setTimeout(r, 5));
+    flush();
+
+    const rec = JSON.parse(readFileSync(sessionLogPath(dir, "sess-1"), "utf8").trim());
+    const tsMs = Date.parse(rec.ts);
+    expect(tsMs).toBeGreaterThanOrEqual(before.getTime());
+    expect(tsMs).toBeLessThan(before.getTime() + 5); // stamped before the artificial delay, not after
+  });
+
+  it("still records ok:false and no nodeIds when the handler throws, without throwing itself", async () => {
+    const { schedule, flush } = manualScheduler();
+    const logger = new SessionLogger("sess-1");
+    const toolLogger = createToolLogger(session, logger, schedule);
+    const wrapped = toolLogger.withLog("impact", async () => {
+      throw new Error("boom");
+    });
+
+    await expect(wrapped(undefined)).rejects.toThrow("boom");
+    expect(() => flush()).not.toThrow();
+
+    const rec = JSON.parse(readFileSync(sessionLogPath(dir, "sess-1"), "utf8").trim());
+    expect(rec).toMatchObject({ tool: "impact", resultBytes: 0, ok: false });
+    expect(rec.nodeIds).toBeUndefined();
+  });
+
+  it("the deferred callback swallows its own errors — never an unhandled exception", () => {
+    const { schedule, flush } = manualScheduler();
+    const logger = new SessionLogger("sess-1");
+    vi.spyOn(logger, "logAt").mockImplementation(() => {
+      throw new Error("disk exploded");
+    });
+    const toolLogger = createToolLogger(session, logger, schedule);
+    const wrapped = toolLogger.withLog("impact", async () => ({ content: [{ type: "text", text: "{}" }] }));
+
+    return wrapped(undefined).then(() => {
+      expect(() => flush()).not.toThrow();
+    });
+  });
+
+  it("skips logging entirely (nothing scheduled) when no repo resolves", async () => {
+    const empty = mkdtempSync(join(tmpdir(), "reposkein-instrument-empty-"));
+    try {
+      const noRepoSession = new RepoSession({ cwd: empty, envRepoPath: undefined });
+      const { schedule, pendingCount } = manualScheduler();
+      const logger = new SessionLogger("sess-1");
+      const toolLogger = createToolLogger(noRepoSession, logger, schedule);
+      const wrapped = toolLogger.withLog("impact", async () => ({ content: [{ type: "text", text: "{}" }] }));
+
+      await wrapped(undefined);
+      expect(pendingCount()).toBe(0);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/mcp/test/sessionLog.test.ts
+++ b/mcp/test/sessionLog.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  DEFAULT_RETENTION,
+  SessionLogger,
+  appendSessionLog,
+  argsShapeOf,
+  defaultSessionId,
+  extractTouchedIds,
+  pruneSessions,
+  resolveSessionId,
+  resultByteSize,
+  sessionLogPath,
+  sessionsDir,
+  type SessionLogRecord,
+} from "../src/store/sessionLog.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reposkein-sessionlog-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function rec(overrides: Partial<SessionLogRecord> = {}): SessionLogRecord {
+  return {
+    ts: new Date().toISOString(),
+    tool: "get_context_profile",
+    argsShape: ["name"],
+    resultBytes: 10,
+    ok: true,
+    ...overrides,
+  };
+}
+
+describe("defaultSessionId / resolveSessionId", () => {
+  it("is start-timestamp + pid, filesystem-safe (no colons)", () => {
+    const id = defaultSessionId(new Date("2026-08-20T21:56:07Z"), 4242);
+    expect(id).toBe("20260820T215607Z-4242");
+    expect(id).not.toMatch(/:/);
+  });
+
+  it("REPOSKEIN_SESSION_ID overrides the default", () => {
+    const id = resolveSessionId({ REPOSKEIN_SESSION_ID: "custom-session-1" } as NodeJS.ProcessEnv);
+    expect(id).toBe("custom-session-1");
+  });
+
+  it("falls back to defaultSessionId when unset or blank", () => {
+    expect(resolveSessionId({} as NodeJS.ProcessEnv, new Date("2026-01-01T00:00:00Z"), 1)).toBe("20260101T000000Z-1");
+    expect(resolveSessionId({ REPOSKEIN_SESSION_ID: "  " } as NodeJS.ProcessEnv, new Date("2026-01-01T00:00:00Z"), 1)).toBe(
+      "20260101T000000Z-1"
+    );
+  });
+});
+
+describe("appendSessionLog", () => {
+  it("creates local/sessions/ and appends a JSONL record", () => {
+    appendSessionLog(dir, "sess-1", rec({ tool: "impact" }));
+    const path = sessionLogPath(dir, "sess-1");
+    expect(existsSync(path)).toBe(true);
+    const lines = readFileSync(path, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!).tool).toBe("impact");
+  });
+
+  it("appends multiple records across calls", () => {
+    appendSessionLog(dir, "sess-1", rec({ tool: "impact" }));
+    appendSessionLog(dir, "sess-1", rec({ tool: "semantic_find" }));
+    const lines = readFileSync(sessionLogPath(dir, "sess-1"), "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+  });
+
+  it("never throws when the target directory is unwritable (failure tolerance)", () => {
+    const readonlyRoot = join(dir, "readonly");
+    mkdirSync(readonlyRoot);
+    chmodSync(readonlyRoot, 0o444);
+    try {
+      expect(() => appendSessionLog(readonlyRoot, "sess-1", rec())).not.toThrow();
+      // best-effort: the write silently failed, nothing was created
+      expect(existsSync(sessionLogPath(readonlyRoot, "sess-1"))).toBe(false);
+    } finally {
+      chmodSync(readonlyRoot, 0o755); // restore so rmSync in afterEach can clean up
+    }
+  });
+
+  it("never throws when repoPath itself doesn't exist", () => {
+    expect(() => appendSessionLog(join(dir, "does", "not", "exist"), "sess-1", rec())).not.toThrow();
+  });
+});
+
+describe("pruneSessions", () => {
+  function writeSessionFile(name: string, ageMs: number): void {
+    const file = join(sessionsDir(dir), `${name}.jsonl`);
+    mkdirSync(sessionsDir(dir), { recursive: true });
+    writeFileSync(file, "{}\n");
+    const mtime = new Date(Date.now() - ageMs);
+    utimesSync(file, mtime, mtime);
+  }
+
+  it("keeps at most `keep` newest files", () => {
+    for (let i = 0; i < 60; i++) writeSessionFile(`s${String(i).padStart(2, "0")}`, i * 1000);
+    pruneSessions(dir, { keep: 50, maxAgeDays: 3650 });
+    const files = readdirSync(sessionsDir(dir));
+    expect(files).toHaveLength(50);
+    // the 50 newest (smallest age index) survive: s00..s49
+    expect(files).toContain("s00.jsonl");
+    expect(files).not.toContain("s59.jsonl");
+  });
+
+  it("drops files older than maxAgeDays even when under the keep limit", () => {
+    const day = 24 * 60 * 60 * 1000;
+    writeSessionFile("fresh", 1 * day);
+    writeSessionFile("stale", 40 * day);
+    pruneSessions(dir, { keep: 50, maxAgeDays: 30 });
+    const files = readdirSync(sessionsDir(dir));
+    expect(files).toContain("fresh.jsonl");
+    expect(files).not.toContain("stale.jsonl");
+  });
+
+  it("uses DEFAULT_RETENTION (50 / 30 days) when no options given", () => {
+    expect(DEFAULT_RETENTION).toEqual({ keep: 50, maxAgeDays: 30 });
+  });
+
+  it("no-ops (never throws) when the sessions dir doesn't exist", () => {
+    expect(() => pruneSessions(join(dir, "nope"))).not.toThrow();
+  });
+});
+
+describe("SessionLogger", () => {
+  it("prunes a repo's sessions dir once, on first log() call for that repo", () => {
+    const day = 24 * 60 * 60 * 1000;
+    const file = join(sessionsDir(dir), "old.jsonl");
+    mkdirSync(sessionsDir(dir), { recursive: true });
+    writeFileSync(file, "{}\n");
+    const old = new Date(Date.now() - 40 * day);
+    utimesSync(file, old, old);
+
+    const logger = new SessionLogger("sess-1", { keep: 50, maxAgeDays: 30 });
+    logger.log(dir, { tool: "impact", argsShape: [], resultBytes: 5, ok: true });
+
+    expect(existsSync(file)).toBe(false); // pruned before the new record was written
+    const lines = readFileSync(sessionLogPath(dir, "sess-1"), "utf8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+  });
+
+  it("logs successive calls under the same session id", () => {
+    const logger = new SessionLogger("sess-x");
+    logger.log(dir, { tool: "a", argsShape: [], resultBytes: 1, ok: true });
+    logger.log(dir, { tool: "b", argsShape: [], resultBytes: 2, ok: false });
+    const lines = readFileSync(sessionLogPath(dir, "sess-x"), "utf8").trim().split("\n");
+    expect(lines.map((l) => JSON.parse(l).tool)).toEqual(["a", "b"]);
+    expect(logger.getSessionId()).toBe("sess-x");
+  });
+
+  it("log() never throws even if the underlying write fails", () => {
+    const readonlyRoot = join(dir, "readonly");
+    mkdirSync(readonlyRoot);
+    chmodSync(readonlyRoot, 0o444);
+    const logger = new SessionLogger("sess-1");
+    try {
+      expect(() => logger.log(readonlyRoot, { tool: "x", argsShape: [], resultBytes: 0, ok: true })).not.toThrow();
+    } finally {
+      chmodSync(readonlyRoot, 0o755);
+    }
+  });
+});
+
+describe("argsShapeOf", () => {
+  it("returns sorted key names only, never values", () => {
+    expect(argsShapeOf({ zeta: "secret code", alpha: 1 })).toEqual(["alpha", "zeta"]);
+  });
+  it("handles non-object args", () => {
+    expect(argsShapeOf(undefined)).toEqual([]);
+    expect(argsShapeOf(null)).toEqual([]);
+    expect(argsShapeOf("x")).toEqual([]);
+  });
+});
+
+describe("resultByteSize", () => {
+  it("sums the byte length of text content blocks", () => {
+    const bytes = resultByteSize({ content: [{ type: "text", text: "hello" }, { type: "text", text: "world!" }] });
+    expect(bytes).toBe(Buffer.byteLength("hello", "utf8") + Buffer.byteLength("world!", "utf8"));
+  });
+  it("falls back to the full envelope size when there's no text content", () => {
+    const result = { content: [], isError: false };
+    expect(resultByteSize(result)).toBe(Buffer.byteLength(JSON.stringify(result), "utf8"));
+  });
+  it("returns 0 for undefined", () => {
+    expect(resultByteSize(undefined)).toBe(0);
+  });
+});
+
+describe("extractTouchedIds", () => {
+  it("collects node_id from a JSON text block", () => {
+    const result = { content: [{ type: "text", text: JSON.stringify({ node_id: "n1" }) }] };
+    expect(extractTouchedIds(result)).toEqual(["n1"]);
+  });
+
+  it("collects node_ids / anchor_node_ids arrays and file_path/path strings", () => {
+    const result = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            node_ids: ["n1", "n2"],
+            anchor_node_ids: ["n3"],
+            file_path: "src/a.ts",
+            nested: { path: "src/b.ts" },
+          }),
+        },
+      ],
+    };
+    const ids = extractTouchedIds(result);
+    expect(ids).toEqual(expect.arrayContaining(["n1", "n2", "n3", "src/a.ts", "src/b.ts"]));
+  });
+
+  it("returns [] for non-JSON text content, without throwing", () => {
+    const result = { content: [{ type: "text", text: "plain error message, not json" }] };
+    expect(() => extractTouchedIds(result)).not.toThrow();
+    expect(extractTouchedIds(result)).toEqual([]);
+  });
+
+  it("returns [] for undefined", () => {
+    expect(extractTouchedIds(undefined)).toEqual([]);
+  });
+
+  it("caps collected ids at 25", () => {
+    const many = Array.from({ length: 100 }, (_, i) => `n${i}`);
+    const result = { content: [{ type: "text", text: JSON.stringify({ node_ids: many }) }] };
+    expect(extractTouchedIds(result).length).toBeLessThanOrEqual(25);
+  });
+});

--- a/mcp/test/sessionLog.test.ts
+++ b/mcp/test/sessionLog.test.ts
@@ -155,6 +155,13 @@ describe("SessionLogger", () => {
     expect(logger.getSessionId()).toBe("sess-x");
   });
 
+  it("logAt() stamps the caller-supplied ts instead of computing one — the deferred-write path", () => {
+    const logger = new SessionLogger("sess-1");
+    logger.logAt("2020-01-01T00:00:00.000Z", dir, { tool: "impact", argsShape: [], resultBytes: 1, ok: true });
+    const rec = JSON.parse(readFileSync(sessionLogPath(dir, "sess-1"), "utf8").trim());
+    expect(rec.ts).toBe("2020-01-01T00:00:00.000Z");
+  });
+
   it("log() never throws even if the underlying write fails", () => {
     const readonlyRoot = join(dir, "readonly");
     mkdirSync(readonlyRoot);
@@ -186,6 +193,14 @@ describe("resultByteSize", () => {
   });
   it("falls back to the full envelope size when there's no text content", () => {
     const result = { content: [], isError: false };
+    expect(resultByteSize(result)).toBe(Buffer.byteLength(JSON.stringify(result), "utf8"));
+  });
+  it("returns 0 (not the envelope fallback) when text blocks exist but are all empty strings", () => {
+    const result = { content: [{ type: "text", text: "" }, { type: "text", text: "" }], isError: false };
+    expect(resultByteSize(result)).toBe(0);
+  });
+  it("ignores non-text blocks when computing the fallback trigger (no text block at all -> fallback)", () => {
+    const result = { content: [{ type: "image" as const }] };
     expect(resultByteSize(result)).toBe(Buffer.byteLength(JSON.stringify(result), "utf8"));
   });
   it("returns 0 for undefined", () => {

--- a/mcp/test/sessionStats.test.ts
+++ b/mcp/test/sessionStats.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { sessionsDir, type SessionLogRecord } from "../src/store/sessionLog.js";
+import {
+  GREP_BASELINE_MULTIPLIER,
+  listSessionFiles,
+  readSessionLog,
+  summarizeSession,
+  summarizeSessions,
+} from "../src/store/sessionStats.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reposkein-sessionstats-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("readSessionLog", () => {
+  it("parses well-formed JSONL records", () => {
+    const file = join(dir, "s.jsonl");
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({ ts: "2026-08-20T10:00:00Z", tool: "impact", argsShape: ["node_id"], resultBytes: 100, ok: true }),
+        JSON.stringify({ ts: "2026-08-20T10:00:01Z", tool: "semantic_find", argsShape: ["query"], resultBytes: 50, ok: false }),
+      ].join("\n") + "\n"
+    );
+    const recs = readSessionLog(file);
+    expect(recs).toHaveLength(2);
+    expect(recs[0]!.tool).toBe("impact");
+    expect(recs[1]!.ok).toBe(false);
+  });
+
+  it("skips malformed lines instead of throwing", () => {
+    const file = join(dir, "s.jsonl");
+    writeFileSync(file, `not json\n${JSON.stringify({ ts: "2026-08-20T10:00:00Z", tool: "impact" })}\n\n`);
+    const recs = readSessionLog(file);
+    expect(recs).toHaveLength(1);
+    expect(recs[0]!.tool).toBe("impact");
+  });
+
+  it("returns [] for a missing file", () => {
+    expect(readSessionLog(join(dir, "nope.jsonl"))).toEqual([]);
+  });
+});
+
+describe("listSessionFiles", () => {
+  it("lists .jsonl files newest-first by mtime", () => {
+    mkdirSync(sessionsDir(dir), { recursive: true });
+    const older = join(sessionsDir(dir), "old.jsonl");
+    const newer = join(sessionsDir(dir), "new.jsonl");
+    writeFileSync(older, "{}\n");
+    writeFileSync(newer, "{}\n");
+    const now = Date.now();
+    utimesSync(older, new Date(now - 10_000), new Date(now - 10_000));
+    utimesSync(newer, new Date(now), new Date(now));
+    const files = listSessionFiles(dir);
+    expect(files.map((f) => f.sessionId)).toEqual(["new", "old"]);
+  });
+
+  it("returns [] when there is no sessions dir", () => {
+    expect(listSessionFiles(dir)).toEqual([]);
+  });
+});
+
+function rec(overrides: Partial<SessionLogRecord> = {}): SessionLogRecord {
+  return { ts: "2026-08-20T10:00:00Z", tool: "impact", argsShape: [], resultBytes: 0, ok: true, ...overrides };
+}
+
+describe("summarizeSession — aggregation math", () => {
+  it("counts calls by tool", () => {
+    const records = [rec({ tool: "impact" }), rec({ tool: "impact" }), rec({ tool: "semantic_find" })];
+    const s = summarizeSession("sess-1", "file", records);
+    expect(s.callsByTool).toEqual({ impact: 2, semantic_find: 1 });
+    expect(s.recordCount).toBe(3);
+  });
+
+  it("ranks top touched node ids/files by frequency, then alphabetically on ties", () => {
+    const records = [
+      rec({ nodeIds: ["a", "b"] }),
+      rec({ nodeIds: ["b"] }),
+      rec({ nodeIds: ["c"] }),
+    ];
+    const s = summarizeSession("sess-1", "file", records);
+    expect(s.topTouched[0]).toEqual({ id: "b", count: 2 });
+    expect(s.topTouched.slice(1)).toEqual(
+      expect.arrayContaining([
+        { id: "a", count: 1 },
+        { id: "c", count: 1 },
+      ])
+    );
+  });
+
+  it("counts record_decision as an ADR written and write_semantic_summary as a summary written", () => {
+    const records = [
+      rec({ tool: "record_decision" }),
+      rec({ tool: "record_decision" }),
+      rec({ tool: "write_semantic_summary" }),
+      rec({ tool: "get_context_profile" }),
+    ];
+    const s = summarizeSession("sess-1", "file", records);
+    expect(s.decisionsWritten).toBe(2);
+    expect(s.summariesWritten).toBe(1);
+  });
+
+  it("computes duration as the span between the first and last record ts", () => {
+    const records = [
+      rec({ ts: "2026-08-20T10:00:00.000Z" }),
+      rec({ ts: "2026-08-20T10:05:30.000Z" }),
+      rec({ ts: "2026-08-20T10:02:00.000Z" }),
+    ];
+    const s = summarizeSession("sess-1", "file", records);
+    expect(s.durationMs).toBe(5.5 * 60 * 1000);
+  });
+
+  it("duration is 0 for a single-record session", () => {
+    const s = summarizeSession("sess-1", "file", [rec()]);
+    expect(s.durationMs).toBe(0);
+  });
+
+  it("counts failed calls (ok: false)", () => {
+    const s = summarizeSession("sess-1", "file", [rec({ ok: true }), rec({ ok: false }), rec({ ok: false })]);
+    expect(s.failedCalls).toBe(2);
+  });
+
+  it("estimates grep-baseline tokens using GREP_BASELINE_MULTIPLIER over ~4 bytes/token", () => {
+    const s = summarizeSession("sess-1", "file", [rec({ resultBytes: 400 }), rec({ resultBytes: 400 })]);
+    expect(s.totalResultBytes).toBe(800);
+    expect(s.estimatedRepoSkeinTokens).toBe(200); // 800 / 4
+    expect(s.estimatedGrepTokens).toBe(Math.round(200 * GREP_BASELINE_MULTIPLIER));
+    expect(s.estimatedTokensSaved).toBe(s.estimatedGrepTokens - s.estimatedRepoSkeinTokens);
+    expect(GREP_BASELINE_MULTIPLIER).toBe(8.4); // mcp/bench/README.md Track 1 mean
+  });
+
+  it("handles an empty session", () => {
+    const s = summarizeSession("sess-1", "file", []);
+    expect(s.recordCount).toBe(0);
+    expect(s.callsByTool).toEqual({});
+    expect(s.topTouched).toEqual([]);
+    expect(s.durationMs).toBe(0);
+    expect(s.estimatedTokensSaved).toBe(0);
+  });
+});
+
+describe("summarizeSessions — --all across multiple session files", () => {
+  it("merges records from every session into one summary", () => {
+    const f1 = join(dir, "a.jsonl");
+    const f2 = join(dir, "b.jsonl");
+    writeFileSync(f1, JSON.stringify(rec({ tool: "impact" })) + "\n");
+    writeFileSync(f2, JSON.stringify(rec({ tool: "semantic_find" })) + "\n");
+    const s = summarizeSessions([
+      { sessionId: "a", file: f1 },
+      { sessionId: "b", file: f2 },
+    ]);
+    expect(s.recordCount).toBe(2);
+    expect(s.callsByTool).toEqual({ impact: 1, semantic_find: 1 });
+    expect(s.sessionId).toBe("2 sessions");
+  });
+});

--- a/mcp/test/statsCli.test.ts
+++ b/mcp/test/statsCli.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { sessionsDir } from "../src/store/sessionLog.js";
+import { summarizeSession } from "../src/store/sessionStats.js";
+import { parseStatsArgs, renderStatsJson, renderStatsReport, resolveStats, runStats } from "../src/cli/stats.js";
+
+describe("parseStatsArgs", () => {
+  it("defaults to --last with no flags", () => {
+    expect(parseStatsArgs([]).selection).toEqual({ mode: "last" });
+  });
+  it("parses --all", () => {
+    expect(parseStatsArgs(["--all"]).selection).toEqual({ mode: "all" });
+  });
+  it("parses --session <id>", () => {
+    expect(parseStatsArgs(["--session", "sess-1"]).selection).toEqual({ mode: "session", sessionId: "sess-1" });
+  });
+  it("parses --json alongside a selection flag", () => {
+    const parsed = parseStatsArgs(["--all", "--json"]);
+    expect(parsed.selection).toEqual({ mode: "all" });
+    expect(parsed.json).toBe(true);
+  });
+  it("parses a leading path positional", () => {
+    const parsed = parseStatsArgs(["/some/repo", "--last"]);
+    expect(parsed.path).toBe("/some/repo");
+  });
+  it("errors when --session is missing its id", () => {
+    expect(parseStatsArgs(["--session"]).error).toMatch(/requires a session id/);
+  });
+  it("errors when more than one selection flag is given", () => {
+    expect(parseStatsArgs(["--last", "--all"]).error).toMatch(/only one/);
+  });
+});
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reposkein-statscli-"));
+  mkdirSync(join(dir, ".reposkein"), { recursive: true });
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeSession(sessionId: string, records: object[]): void {
+  mkdirSync(sessionsDir(dir), { recursive: true });
+  writeFileSync(join(sessionsDir(dir), `${sessionId}.jsonl`), records.map((r) => JSON.stringify(r)).join("\n") + "\n");
+}
+
+describe("resolveStats", () => {
+  it("errors when there are no session logs yet", () => {
+    const { summary, error } = resolveStats(dir, { mode: "last" });
+    expect(summary).toBeUndefined();
+    expect(error).toMatch(/no session logs found/);
+  });
+
+  it("--last picks the most recently modified session", () => {
+    writeSession("sess-a", [{ ts: "2026-08-20T10:00:00Z", tool: "impact", argsShape: [], resultBytes: 10, ok: true }]);
+    const { summary } = resolveStats(dir, { mode: "last" });
+    expect(summary?.sessionId).toBe("sess-a");
+  });
+
+  it("--session <id> picks that specific session, erroring on an unknown id", () => {
+    writeSession("sess-a", [{ ts: "2026-08-20T10:00:00Z", tool: "impact", argsShape: [], resultBytes: 10, ok: true }]);
+    expect(resolveStats(dir, { mode: "session", sessionId: "sess-a" }).summary?.sessionId).toBe("sess-a");
+    expect(resolveStats(dir, { mode: "session", sessionId: "nope" }).error).toMatch(/no session "nope"/);
+  });
+
+  it("--all merges every session", () => {
+    writeSession("sess-a", [{ ts: "2026-08-20T10:00:00Z", tool: "impact", argsShape: [], resultBytes: 10, ok: true }]);
+    writeSession("sess-b", [{ ts: "2026-08-20T11:00:00Z", tool: "semantic_find", argsShape: [], resultBytes: 20, ok: true }]);
+    const { summary } = resolveStats(dir, { mode: "all" });
+    expect(summary?.recordCount).toBe(2);
+  });
+});
+
+describe("renderStatsJson", () => {
+  it("produces a machine-readable shape with the labeled estimate fields", () => {
+    const summary = summarizeSession("sess-1", "f", [
+      { ts: "2026-08-20T10:00:00Z", tool: "impact", argsShape: ["node_id"], resultBytes: 400, nodeIds: ["n1"], ok: true },
+    ]);
+    const parsed = JSON.parse(renderStatsJson(summary));
+    expect(parsed).toMatchObject({
+      sessionId: "sess-1",
+      recordCount: 1,
+      callsByTool: { impact: 1 },
+      topTouched: [{ id: "n1", count: 1 }],
+      decisionsWritten: 0,
+      summariesWritten: 0,
+      failedCalls: 0,
+      totalResultBytes: 400,
+      grepBaselineMultiplier: 8.4,
+      estimate: true,
+    });
+    expect(typeof parsed.estimatedTokensSaved).toBe("number");
+  });
+});
+
+describe("renderStatsReport", () => {
+  it("includes calls-by-tool, top touched, written-this-session, duration, and a labeled token estimate", () => {
+    const summary = summarizeSession("sess-1", "f", [
+      { ts: "2026-08-20T10:00:00Z", tool: "record_decision", argsShape: [], resultBytes: 100, ok: true },
+      { ts: "2026-08-20T10:00:01Z", tool: "write_semantic_summary", argsShape: [], resultBytes: 50, nodeIds: ["n1"], ok: true },
+    ]);
+    const text = renderStatsReport(summary, false);
+    expect(text).toContain("Calls by tool");
+    expect(text).toContain("record_decision");
+    expect(text).toContain("Top queried nodes/files");
+    expect(text).toContain("n1");
+    expect(text).toContain("1 ADR");
+    expect(text).toContain("1 summary");
+    expect(text).toContain("Session");
+    expect(text).toMatch(/ESTIMATED/);
+    expect(text).toContain("8.4x");
+  });
+
+  it("emits raw ANSI escapes only when color is enabled", () => {
+    const summary = summarizeSession("sess-1", "f", []);
+    expect(renderStatsReport(summary, false)).not.toMatch(/\x1b\[/);
+    expect(renderStatsReport(summary, true)).toMatch(/\x1b\[/);
+  });
+});
+
+describe("runStats (end-to-end CLI)", () => {
+  it("exits 1 with an actionable message when no repo is found", () => {
+    const empty = mkdtempSync(join(tmpdir(), "reposkein-norepo-"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const code = runStats([], empty, undefined);
+      expect(code).toBe(1);
+      expect(errSpy).toHaveBeenCalledWith(expect.stringMatching(/no RepoSkein repo found/i));
+    } finally {
+      errSpy.mockRestore();
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it("prints the JSON report and exits 0 for a resolvable repo with session logs", () => {
+    writeSession("sess-a", [{ ts: "2026-08-20T10:00:00Z", tool: "impact", argsShape: [], resultBytes: 40, ok: true }]);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const code = runStats([dir, "--last", "--json"], dir, undefined);
+      expect(code).toBe(0);
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const printed = JSON.parse(logSpy.mock.calls[0]![0] as string);
+      expect(printed.sessionId).toBe("sess-a");
+      expect(printed.callsByTool).toEqual({ impact: 1 });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("propagates a parse error (e.g. --session with no id) as exit 1", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const code = runStats([dir, "--session"], dir, undefined);
+      expect(code).toBe(1);
+      expect(errSpy).toHaveBeenCalledWith(expect.stringMatching(/requires a session id/));
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
When RepoSkein is used in any agent session (Claude Code, Codex, OpenCode, Cursor, …) the MCP server now records how — and `reposkein-mcp stats` prints it in the terminal. Agent-agnostic by construction: instrumentation lives server-side.

## What changed
- **Instrumentation** (`mcp/src/store/sessionLog.ts`, `instrumentTool.ts`): every tool call appends `{ts, tool, argsShape, resultBytes, nodeIds?, ok}` to `.reposkein/local/sessions/<session-id>.jsonl` (gitignored — zero merge surface). Privacy: argsShape is top-level key names only, never values. Hot-path safe: one repo resolution per call (AsyncLocalStorage memo), record build + write deferred via `setImmediate`, all failures swallowed — a logging error can never fail or slow a tool call.
- **`reposkein-mcp stats [--last | --session <id> | --all] [--json]`**: calls by tool, top touched nodes/files, summaries/ADRs written, session duration, estimated context-tokens saved vs grep baseline (8.4× mean from `mcp/bench`, labeled as estimate). Teal/amber ANSI when TTY; plain text / NO_COLOR respected; dependency-free styling.
- Session id = process start + pid, `REPOSKEIN_SESSION_ID` override; retention prunes to newest 50 ∧ ≤30 days.
- Docs: Claude Code Stop-hook recipe (`reposkein-mcp stats --last` at session end); works for any MCP agent.

## Tests
`cd mcp && npm test` → **512 passed, 17 skipped, 0 failed** (+73 over baseline). `tsc --noEmit` clean.

Linear: REP-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)