### PR TITLE
feat: one-command team join — init join mode, agent-config adapters, doctor --ci, proxy-aware fetch (REP-16)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -184,7 +184,7 @@ reposkein-mcp init                    # or: npx @reposkein/mcp init
 
 This:
 1. Verifies/fetches the platform indexer binary.
-2. Installs git hooks (`pre-commit` re-indexes the local graph, staging nothing; `post-merge` reloads Neo4j if configured).
+2. Installs git hooks: `pre-commit` re-indexes the local graph (staging nothing) and `post-commit` records the commit it just became; `post-merge`/`post-checkout` re-index too (a merge/pull/branch switch can change the tree without going through your own commits) and reload Neo4j if configured. All four keep `.reposkein/local/indexed-at` current, which `reposkein-mcp doctor --ci` compares against HEAD to catch a graph nobody's re-indexed.
 3. Installs the `reposkein-graph-rag` skill into `.claude/skills/` (no-op on agents that ignore `.claude/`).
 4. Walks the tree with Tree-sitter → writes deterministic `.reposkein/nodes.jsonl` + `.reposkein/edges.jsonl` + `.reposkein/meta.json`, plus a `.reposkein/.gitignore` that keeps the two derived files out of git.
 5. **Prints an MCP config block** for the user to paste into their agent — you (the agent) should pick the right schema (§6) and write it directly.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,6 +6,42 @@
 
 ---
 
+## 0. Joining an existing RepoSkein repo
+
+Skip everything below if you just cloned a repo that **already has RepoSkein set up** — meaning `.reposkein/meta.json` is already committed. This is the common case for every teammate after the first one: three commands, no questions asked.
+
+```sh
+git clone <repo-url>
+cd <repo>
+npx @reposkein/mcp init
+```
+
+`init` detects the committed `.reposkein/meta.json`, reuses its `repo_id` and `config.toml` (no re-scaffolding), fetches the platform indexer binary, installs git hooks, builds the local graph, and — because this is a **join**, not a first-time setup — automatically detects which agent(s) you have (Claude Code CLI on PATH, an existing `opencode.json`, a `.cursor/` directory, …) and writes their MCP config for you: `.mcp.json` (Claude Code, and the generic fallback), `opencode.json`, or `.cursor/mcp.json`, per the schemas in §6. It finishes by printing a `doctor` summary so you can see at a glance whether anything needs attention.
+
+Useful flags:
+
+| Flag | Effect |
+|---|---|
+| `--agents claude,opencode,cursor` | Write exactly these agents' config, skipping auto-detection. |
+| `--dry-run` | Print what would be written/changed without touching disk. |
+| `--no-index` | Skip the initial index (you'll run `reposkein-mcp index` yourself). |
+
+Every config file `init` edits is idempotent (re-running never adds a duplicate entry) and, when it modifies an **existing** file, backs it up first to a timestamped `<file>.<timestamp>.bak` sibling. `.mcp.json`, `opencode.json` and `.cursor/mcp.json` all hold an absolute local path and are per-machine — `init` gitignores them for you (§6.1).
+
+Restart your agent afterward (most only read MCP config at startup), then verify with `reposkein-mcp doctor .`.
+
+**Devcontainer / CI**: to join automatically on container create, add to `.devcontainer/devcontainer.json`:
+
+```jsonc
+{
+  "postCreateCommand": "npx @reposkein/mcp init --agents claude && npx @reposkein/mcp doctor . --ci"
+}
+```
+
+Pin `--agents` explicitly in a devcontainer/CI image — auto-detection depends on what's installed on PATH, which is less predictable in an ephemeral container than on a developer's own machine. `doctor --ci` exits non-zero (failing the container build / CI job) on a stale committed graph, missing/foreign git hooks, or an unsplit legacy `summaries.jsonl` — the same checks `doctor` already reports, just promoted from a warning to a hard failure so drift gets caught before merge instead of at the next `init`.
+
+---
+
 ## TL;DR (the one-liner an agent should already know how to run)
 
 ```sh
@@ -100,7 +136,17 @@ uv --version             # optional (recommended for native embed-server venv)
 rg --version             # optional (only for running Track 1 benchmark)
 ```
 
-Platform support: macOS (Apple Silicon), Linux (x64/arm64), Windows (x64). Intel Macs are not built — use `REPOSKEIN_INDEXER_BIN` with a from-source build.
+Platform support: macOS (Apple Silicon), Linux (x64/arm64), Windows (x64). Intel Macs and Windows ARM64 have no prebuilt binary — `init`/`doctor`/`index` print cargo-install fallback instructions and **continue** (agent config still gets written; only the hooks/index step is skipped, with a warning) rather than failing outright. Build from source and point `REPOSKEIN_INDEXER_BIN` at the result:
+
+```sh
+git clone https://github.com/reposkein/reposkein.git && cd reposkein
+cargo install --path indexer/crates/cli --root ./cargo-out
+export REPOSKEIN_INDEXER_BIN=$PWD/cargo-out/bin/reposkein-indexer
+```
+
+`REPOSKEIN_INDEXER_BIN` also works as an **offline fallback on supported platforms** — set it to skip the GitHub Releases fetch entirely (air-gapped installs, vendored binaries, etc.).
+
+**Behind a proxy?** The binary fetch honors `HTTPS_PROXY`/`HTTP_PROXY` (either case) and `NO_PROXY` — set them the same way you would for any other tool (`export HTTPS_PROXY=http://proxy.internal:8080`) and `init`/`index` will route the download through it automatically.
 
 ---
 
@@ -390,7 +436,7 @@ For multi-repo workspaces under OpenCode, define one server **per repo** under d
 
 After everything is configured, restart the user's agent (most agents only read MCP config at startup), then ask the agent to run:
 
-1. **`reposkein-mcp doctor .`** in each indexed repo — expects `✓ binary  ✓ indexed (N nodes)  ✓ ready`.
+1. **`reposkein-mcp doctor .`** in each indexed repo — expects `✓ binary  ✓ indexed (N nodes)  ✓ ready`. Add `--ci` in CI/devcontainer contexts to fail the job on a stale graph, missing hooks, or an unsplit legacy `summaries.jsonl`; add `--json` for machine-readable output.
 2. **A `semantic_find` call** through the MCP tool — should return ranked candidates with one-line summaries.
 3. **A `get_context_profile` call** on one of those candidates — should return caller/callee neighborhood as prose.
 4. **If Neo4j:** open <http://localhost:7474> and run `MATCH (n) RETURN count(n)` — should match `meta.json` node counts (cumulative across loaded repos).
@@ -433,6 +479,7 @@ npx skills add reposkein/reposkein --all
 |---|---|---|
 | `REPOSKEIN_REPO_PATH (or REPOSKEIN_REPO_ID) must be set` | The env var is missing from the MCP server entry. | Add it to the agent's MCP config (§6). |
 | `npm install -g @reposkein/mcp` succeeds but no `reposkein-indexer` binary | Postinstall fetch failed. | Re-run `npm install -g @reposkein/mcp --force` with network access. Else point `REPOSKEIN_INDEXER_BIN` at a [from-source build](https://github.com/reposkein/reposkein#build-from-source). |
+| Binary fetch hangs or fails behind a corporate firewall | No proxy configured for the download. | Set `HTTPS_PROXY` (and `NO_PROXY` for internal hosts) — see §2 — or set `REPOSKEIN_INDEXER_BIN` to skip the fetch entirely. |
 | `TypeError: create_causal_mask() got an unexpected keyword argument 'input_embeds'` | Native embed-server with `transformers >= 5.0`. | `uv pip install 'transformers>=4.51,<5'` and restart. |
 | Neo4j gated tests skipping or `MATCH (n) RETURN count(n)` is 0 | Indexer never ran `load`. | Run `reposkein-indexer load .` once per repo. |
 | `semantic_find` returns nothing despite a real query | Index empty (no supported languages in the repo). | Check supported languages in the [README](../README.md#supported-languages). |

--- a/indexer/crates/cli/src/main.rs
+++ b/indexer/crates/cli/src/main.rs
@@ -22,12 +22,28 @@ const PRE_COMMIT: &str = r#"#!/bin/sh
 # which IS committed: `stage-summaries` prints a hint when those shards changed
 # and were left out of the commit, and stages them only if you opted in with
 # `[hooks] stage_summaries = true` in .reposkein/config.toml.
+#
+# On success, drops a transient flag (.reposkein/local/.precommit-indexed-ok)
+# for post-commit to consume: pre-commit and post-commit are separate
+# processes with no shared exit status, and post-commit must never record
+# the indexed-at marker (.reposkein/local/indexed-at) off a failed index —
+# that would read as "fresh" when the graph is actually stale/absent. On
+# failure the flag is removed instead, so a stale flag from an earlier
+# successful commit can never be mistaken for this one's result.
+FLAG=".reposkein/local/.precommit-indexed-ok"
 BIN="${REPOSKEIN_INDEXER_BIN:-reposkein-indexer}"
 if ! command -v "$BIN" >/dev/null 2>&1 && [ ! -x "$BIN" ]; then
   echo "reposkein: indexer not found; skipping graph refresh (commit continues)" >&2
+  rm -f "$FLAG"
   exit 0
 fi
-"$BIN" index . >/dev/null 2>&1 || { echo "reposkein: index failed; skipping refresh" >&2; exit 0; }
+if "$BIN" index . >/dev/null 2>&1; then
+  mkdir -p .reposkein/local
+  : > "$FLAG"
+else
+  echo "reposkein: index failed; skipping refresh" >&2
+  rm -f "$FLAG"
+fi
 "$BIN" stage-summaries . || true
 exit 0
 "#;
@@ -38,15 +54,26 @@ exit 0
 // that becomes this commit, so post-commit has no reindexing to do — it
 // only has to record the commit that tree turned into, which isn't known
 // until after `git commit` actually creates it (pre-commit's `git rev-parse
-// HEAD` would still name the *parent* commit).
+// HEAD` would still name the *parent* commit). It gates on pre-commit's
+// transient success flag (see PRE_COMMIT above) rather than writing
+// unconditionally — a failed index must never be recorded as "fresh".
 const POST_COMMIT: &str = r#"#!/bin/sh
 # reposkein-managed
 # RepoSkein: record the commit that pre-commit's index run became, so
 # `doctor --ci`'s graph_stale check (.reposkein/local/indexed-at vs. HEAD)
 # doesn't read a false "stale" after every normal commit. No reindex here —
 # pre-commit already built the graph for the tree that just got committed.
-mkdir -p .reposkein/local
-git rev-parse HEAD > .reposkein/local/indexed-at 2>/dev/null || true
+# Only runs if pre-commit's transient success flag is present (consumed
+# here); a failed pre-commit index leaves the marker untouched instead of
+# recording a false "fresh".
+FLAG=".reposkein/local/.precommit-indexed-ok"
+if [ -f "$FLAG" ]; then
+  rm -f "$FLAG"
+  mkdir -p .reposkein/local
+  git rev-parse HEAD > .reposkein/local/indexed-at 2>/dev/null || true
+else
+  echo "reposkein: pre-commit's index did not succeed; leaving the indexed-at marker as-is" >&2
+fi
 exit 0
 "#;
 
@@ -56,15 +83,20 @@ const POST_MERGE: &str = r#"#!/bin/sh
 # own pre-commit, so re-index the local graph here too, record the commit it
 # was just built from (.reposkein/local/indexed-at — same marker post-commit
 # writes, read by `doctor --ci`'s graph_stale check), then import into the
-# local database (async, best-effort).
+# local database (async, best-effort). The marker is only written when the
+# reindex actually succeeds — a failed index must never be recorded as
+# "fresh".
 BIN="${REPOSKEIN_INDEXER_BIN:-reposkein-indexer}"
 if ! command -v "$BIN" >/dev/null 2>&1 && [ ! -x "$BIN" ]; then
   echo "reposkein: indexer not found; skipping graph refresh" >&2
   exit 0
 fi
-"$BIN" index . >/dev/null 2>&1 || echo "reposkein: index failed; skipping refresh" >&2
-mkdir -p .reposkein/local
-git rev-parse HEAD > .reposkein/local/indexed-at 2>/dev/null || true
+if "$BIN" index . >/dev/null 2>&1; then
+  mkdir -p .reposkein/local
+  git rev-parse HEAD > .reposkein/local/indexed-at 2>/dev/null || true
+else
+  echo "reposkein: index failed; skipping refresh (indexed-at marker left untouched)" >&2
+fi
 ( "$BIN" load . >/dev/null 2>&1 || echo "reposkein: graph import skipped (database unavailable)" >&2 ) &
 exit 0
 "#;
@@ -1605,6 +1637,66 @@ mod tests {
         let index_pos = POST_MERGE.find("\"$BIN\" index .").unwrap();
         let marker_pos = POST_MERGE.find("> .reposkein/local/indexed-at").unwrap();
         assert!(index_pos < marker_pos);
+    }
+
+    #[test]
+    fn post_merge_hook_gates_the_marker_write_on_index_success() {
+        use super::POST_MERGE;
+        // The marker write must be reachable only through the success branch
+        // of an `if "$BIN" index . ...; then ... fi` — not written
+        // unconditionally after a `||`-swallowed failure (the bug this test
+        // guards against: an `if`/`then` gate is required, a bare `||` isn't
+        // enough since control flow continues past it either way).
+        assert!(POST_MERGE.contains("if \"$BIN\" index ."));
+        let then_pos = POST_MERGE.find("if \"$BIN\" index .").unwrap();
+        let marker_pos = POST_MERGE.find("> .reposkein/local/indexed-at").unwrap();
+        let else_pos = POST_MERGE
+            .find("else")
+            .expect("post-merge must have an else branch for a failed index");
+        assert!(
+            then_pos < marker_pos,
+            "marker write must be inside the success branch"
+        );
+        assert!(
+            marker_pos < else_pos,
+            "marker write must come before the else (failure) branch"
+        );
+    }
+
+    #[test]
+    fn pre_commit_hook_gates_its_success_flag_on_index_success_and_clears_it_on_failure() {
+        use super::PRE_COMMIT;
+        const FLAG: &str = ".reposkein/local/.precommit-indexed-ok";
+        assert!(PRE_COMMIT.contains(FLAG));
+        assert!(
+            PRE_COMMIT.contains("if \"$BIN\" index ."),
+            "the flag write must be gated by an if/then on the index command's exit status"
+        );
+        // Both branches must mention the flag: the success branch writes it,
+        // the failure branch (and the indexer-not-found branch) remove it —
+        // never leave a stale success flag from an earlier commit around.
+        assert_eq!(
+            PRE_COMMIT.matches("rm -f \"$FLAG\"").count(),
+            2,
+            "the flag must be removed on both the 'not found' and 'index failed' paths:\n{PRE_COMMIT}"
+        );
+    }
+
+    #[test]
+    fn post_commit_hook_only_writes_the_marker_when_the_precommit_flag_is_present() {
+        use super::POST_COMMIT;
+        const FLAG: &str = ".reposkein/local/.precommit-indexed-ok";
+        assert!(POST_COMMIT.contains(FLAG));
+        assert!(
+            POST_COMMIT.contains("if [ -f \"$FLAG\" ]"),
+            "the marker write must be gated on the transient flag pre-commit left behind:\n{POST_COMMIT}"
+        );
+        let if_pos = POST_COMMIT.find("if [ -f \"$FLAG\" ]").unwrap();
+        let marker_pos = POST_COMMIT.find("> .reposkein/local/indexed-at").unwrap();
+        assert!(
+            if_pos < marker_pos,
+            "marker write must be inside the flag-present branch"
+        );
     }
 
     #[test]

--- a/indexer/crates/cli/src/main.rs
+++ b/indexer/crates/cli/src/main.rs
@@ -32,14 +32,39 @@ fi
 exit 0
 "#;
 
+// Recorded in .reposkein/local/indexed-at: a single git commit SHA (plus
+// trailing newline), read by `doctor --ci`'s graph_stale check (mcp-side:
+// mcp/src/store/indexedAt.ts). pre-commit already indexed the exact tree
+// that becomes this commit, so post-commit has no reindexing to do — it
+// only has to record the commit that tree turned into, which isn't known
+// until after `git commit` actually creates it (pre-commit's `git rev-parse
+// HEAD` would still name the *parent* commit).
+const POST_COMMIT: &str = r#"#!/bin/sh
+# reposkein-managed
+# RepoSkein: record the commit that pre-commit's index run became, so
+# `doctor --ci`'s graph_stale check (.reposkein/local/indexed-at vs. HEAD)
+# doesn't read a false "stale" after every normal commit. No reindex here —
+# pre-commit already built the graph for the tree that just got committed.
+mkdir -p .reposkein/local
+git rev-parse HEAD > .reposkein/local/indexed-at 2>/dev/null || true
+exit 0
+"#;
+
 const POST_MERGE: &str = r#"#!/bin/sh
 # reposkein-managed
-# RepoSkein: import the merged graph into the local database (async, best-effort).
+# RepoSkein: a merge/checkout can change the tree without going through your
+# own pre-commit, so re-index the local graph here too, record the commit it
+# was just built from (.reposkein/local/indexed-at — same marker post-commit
+# writes, read by `doctor --ci`'s graph_stale check), then import into the
+# local database (async, best-effort).
 BIN="${REPOSKEIN_INDEXER_BIN:-reposkein-indexer}"
 if ! command -v "$BIN" >/dev/null 2>&1 && [ ! -x "$BIN" ]; then
-  echo "reposkein: indexer not found; skipping graph import" >&2
+  echo "reposkein: indexer not found; skipping graph refresh" >&2
   exit 0
 fi
+"$BIN" index . >/dev/null 2>&1 || echo "reposkein: index failed; skipping refresh" >&2
+mkdir -p .reposkein/local
+git rev-parse HEAD > .reposkein/local/indexed-at 2>/dev/null || true
 ( "$BIN" load . >/dev/null 2>&1 || echo "reposkein: graph import skipped (database unavailable)" >&2 ) &
 exit 0
 "#;
@@ -1289,8 +1314,11 @@ fn main() -> Result<()> {
                              {}",
                             name,
                             body.lines()
-                                .find(|l| l.contains("reposkein-indexer") && !l.starts_with('#'))
-                                .unwrap_or("\"$BIN\" index . >/dev/null 2>&1 || true")
+                                .find(|l| {
+                                    !l.starts_with('#')
+                                        && (l.contains("reposkein-indexer") || l.contains("indexed-at"))
+                                })
+                                .unwrap_or("see docs/INSTALL.md for the RepoSkein hook content")
                         );
                         return Ok(());
                     }
@@ -1304,6 +1332,7 @@ fn main() -> Result<()> {
                 Ok(())
             };
             write_hook("pre-commit", PRE_COMMIT)?;
+            write_hook("post-commit", POST_COMMIT)?;
             write_hook("post-merge", POST_MERGE)?;
             write_hook("post-checkout", POST_MERGE)?; // same action as post-merge
 
@@ -1548,6 +1577,34 @@ mod tests {
     fn post_merge_hook_contains_marker() {
         use super::POST_MERGE;
         assert!(POST_MERGE.contains("# reposkein-managed"));
+    }
+
+    #[test]
+    fn post_commit_hook_contains_marker() {
+        use super::POST_COMMIT;
+        assert!(POST_COMMIT.contains("# reposkein-managed"));
+    }
+
+    #[test]
+    fn post_commit_hook_writes_the_indexed_at_marker_and_nothing_else() {
+        use super::POST_COMMIT;
+        assert!(POST_COMMIT.contains(".reposkein/local/indexed-at"));
+        assert!(POST_COMMIT.contains("git rev-parse HEAD"));
+        // Single responsibility: record the commit, don't reindex (pre-commit
+        // already indexed the tree that became it).
+        assert!(!POST_COMMIT.contains("index ."));
+    }
+
+    #[test]
+    fn post_merge_hook_reindexes_before_recording_the_marker() {
+        use super::POST_MERGE;
+        assert!(POST_MERGE.contains("index ."));
+        assert!(POST_MERGE.contains(".reposkein/local/indexed-at"));
+        // Search for the actual command invocation, not the prose comment
+        // above it (which also happens to contain the substring "index ").
+        let index_pos = POST_MERGE.find("\"$BIN\" index .").unwrap();
+        let marker_pos = POST_MERGE.find("> .reposkein/local/indexed-at").unwrap();
+        assert!(index_pos < marker_pos);
     }
 
     #[test]

--- a/indexer/crates/cli/tests/init_hooks_cli.rs
+++ b/indexer/crates/cli/tests/init_hooks_cli.rs
@@ -448,3 +448,180 @@ fn post_merge_hook_reindexes_and_records_marker_end_to_end() {
     let marker = fs::read_to_string(root.join(".reposkein/local/indexed-at")).unwrap();
     assert_eq!(marker.trim(), head_sha);
 }
+
+/// A stand-in `$BIN` that always fails, regardless of subcommand/args — used
+/// to prove the marker is withheld on a failed index rather than written
+/// unconditionally (the exact bug this test file's other tests would NOT
+/// have caught, since they only exercise the success path).
+fn write_failing_binary(root: &std::path::Path) -> std::path::PathBuf {
+    let p = root.join("fake-failing-indexer.sh");
+    fs::write(&p, "#!/bin/sh\nexit 1\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&p, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    p
+}
+
+fn head_sha(root: &std::path::Path) -> String {
+    let out = Proc::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[test]
+fn precommit_postcommit_withhold_the_marker_when_the_index_fails() {
+    let dir = git_repo();
+    let root = dir.path();
+    configure_identity(root);
+    run_init(root);
+    let failing_bin = write_failing_binary(root);
+
+    fs::write(root.join("a.py"), "def f():\n    return 1\n").unwrap();
+    Proc::new("git")
+        .args(["add", "a.py"])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    let commit_status = Proc::new("git")
+        .args(["commit", "-qm", "add a.py"])
+        .current_dir(root)
+        .env("REPOSKEIN_INDEXER_BIN", &failing_bin)
+        .status()
+        .unwrap();
+    // A failed index must not block the commit (pre-existing design: exit 0
+    // either way) — only the marker write is gated.
+    assert!(commit_status.success());
+
+    assert!(
+        !root.join(".reposkein/local/indexed-at").exists(),
+        "the indexed-at marker must not be written when pre-commit's index failed"
+    );
+    assert!(
+        !root.join(".reposkein/local/.precommit-indexed-ok").exists(),
+        "the transient success flag must not survive a failed index (nothing to consume)"
+    );
+}
+
+#[test]
+fn precommit_postcommit_do_not_advance_a_marker_left_by_an_earlier_successful_commit() {
+    // Same as above, but starting from a repo that already has a real,
+    // correctly-recorded marker (from a prior successful commit) — proves a
+    // later *failed* index doesn't advance it to the new (unindexed) HEAD.
+    let dir = git_repo();
+    let root = dir.path();
+    configure_identity(root);
+    run_init(root);
+    let real_bin = cargo_bin("reposkein-indexer");
+
+    fs::write(root.join("a.py"), "def f():\n    return 1\n").unwrap();
+    Proc::new("git")
+        .args(["add", "a.py"])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    Proc::new("git")
+        .args(["commit", "-qm", "commit A (indexes successfully)"])
+        .current_dir(root)
+        .env("REPOSKEIN_INDEXER_BIN", &real_bin)
+        .status()
+        .unwrap();
+    let sha_a = head_sha(root);
+    let marker_after_a = fs::read_to_string(root.join(".reposkein/local/indexed-at")).unwrap();
+    assert_eq!(marker_after_a.trim(), sha_a);
+
+    let failing_bin = write_failing_binary(root);
+    fs::write(root.join("a.py"), "def f():\n    return 2\n").unwrap();
+    Proc::new("git")
+        .args(["add", "a.py"])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    Proc::new("git")
+        .args(["commit", "-qm", "commit B (index fails)"])
+        .current_dir(root)
+        .env("REPOSKEIN_INDEXER_BIN", &failing_bin)
+        .status()
+        .unwrap();
+    let sha_b = head_sha(root);
+    assert_ne!(sha_a, sha_b);
+
+    let marker_after_b = fs::read_to_string(root.join(".reposkein/local/indexed-at")).unwrap();
+    assert_eq!(
+        marker_after_b.trim(),
+        sha_a,
+        "the marker must stay at the last successfully-indexed commit, not advance to HEAD"
+    );
+}
+
+#[test]
+fn post_merge_hook_withholds_the_marker_when_the_index_fails() {
+    let dir = git_repo();
+    let root = dir.path();
+    configure_identity(root);
+    run_init(root);
+    let real_bin = cargo_bin("reposkein-indexer");
+
+    fs::write(root.join("a.py"), "def f():\n    return 1\n").unwrap();
+    Proc::new("git")
+        .args(["add", "a.py"])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    Proc::new("git")
+        .args(["commit", "-qm", "init"])
+        .current_dir(root)
+        .env("REPOSKEIN_INDEXER_BIN", &real_bin)
+        .status()
+        .unwrap();
+    let sha_a = head_sha(root);
+    let marker_after_a = fs::read_to_string(root.join(".reposkein/local/indexed-at")).unwrap();
+    assert_eq!(marker_after_a.trim(), sha_a);
+
+    // Land a second commit as if via merge/pull (skip hooks entirely), then
+    // invoke post-merge by hand with a failing $BIN — simulating the
+    // reindex itself failing (missing binary handling is already covered
+    // by the "indexer not found" early-exit branch; this is the "found but
+    // fails" case the fix targets).
+    fs::write(root.join("b.py"), "def g():\n    return 2\n").unwrap();
+    Proc::new("git")
+        .args(["add", "b.py"])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    Proc::new("git")
+        .args([
+            "commit",
+            "-qm",
+            "simulate a merge commit landing b.py",
+            "--no-verify",
+        ])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    let sha_b = head_sha(root);
+    assert_ne!(sha_a, sha_b);
+
+    let failing_bin = write_failing_binary(root);
+    let status = Proc::new(root.join(".git/hooks/post-merge"))
+        .current_dir(root)
+        .env("REPOSKEIN_INDEXER_BIN", &failing_bin)
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "post-merge must still exit 0 even when the index fails"
+    );
+
+    let marker_after_failed_merge =
+        fs::read_to_string(root.join(".reposkein/local/indexed-at")).unwrap();
+    assert_eq!(
+        marker_after_failed_merge.trim(),
+        sha_a,
+        "a failed post-merge index must not advance the marker to the new (unindexed) HEAD"
+    );
+}

--- a/indexer/crates/cli/tests/init_hooks_cli.rs
+++ b/indexer/crates/cli/tests/init_hooks_cli.rs
@@ -1,3 +1,4 @@
+use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
 use std::fs;
 use std::process::Command as Proc;
@@ -38,7 +39,7 @@ fn init_hooks_installs_all_artifacts() {
     let root = dir.path();
     run_init(root);
 
-    for hook in ["pre-commit", "post-merge", "post-checkout"] {
+    for hook in ["pre-commit", "post-commit", "post-merge", "post-checkout"] {
         let p = root.join(".git/hooks").join(hook);
         assert!(p.exists(), "{hook} should exist");
         let body = fs::read_to_string(&p).unwrap();
@@ -217,6 +218,45 @@ fn init_without_a_reposkein_dir_writes_no_attributes_file() {
 }
 
 #[test]
+fn reinit_adds_post_commit_to_a_repo_that_predates_it() {
+    // Simulate a repo set up by an older RepoSkein: reposkein-managed
+    // pre-commit/post-merge/post-checkout hooks, but no post-commit at all
+    // (it didn't exist yet). Re-running `init --hooks` must add it — no
+    // special upgrade logic needed, since write_hook only preserves a hook
+    // it finds *without* the marker; an absent file just gets written fresh.
+    let dir = git_repo();
+    let root = dir.path();
+    let hooks_dir = root.join(".git/hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    fs::write(
+        hooks_dir.join("pre-commit"),
+        "#!/bin/sh\n# reposkein-managed\nold pre-commit\n",
+    )
+    .unwrap();
+    fs::write(
+        hooks_dir.join("post-merge"),
+        "#!/bin/sh\n# reposkein-managed\nold post-merge (load-only, no reindex)\n",
+    )
+    .unwrap();
+    assert!(!hooks_dir.join("post-commit").exists());
+
+    run_init(root);
+
+    assert!(
+        hooks_dir.join("post-commit").exists(),
+        "post-commit should now be installed"
+    );
+    let post_commit = fs::read_to_string(hooks_dir.join("post-commit")).unwrap();
+    assert!(post_commit.contains(".reposkein/local/indexed-at"));
+    // The old post-merge (reposkein-managed, so eligible for overwrite) gets
+    // upgraded to the new reindex+marker content.
+    let post_merge = fs::read_to_string(hooks_dir.join("post-merge")).unwrap();
+    assert!(post_merge.contains("index ."));
+    assert!(post_merge.contains(".reposkein/local/indexed-at"));
+    assert!(!post_merge.contains("load-only"));
+}
+
+#[test]
 fn pre_commit_hook_runs_the_summary_stage_check() {
     let dir = git_repo();
     let root = dir.path();
@@ -227,4 +267,184 @@ fn pre_commit_hook_runs_the_summary_stage_check() {
         body.contains("stage-summaries"),
         "the hook must notice authored shards left out of the commit:\n{body}"
     );
+}
+
+#[test]
+fn post_commit_hook_only_records_the_marker_no_reindex() {
+    let dir = git_repo();
+    let root = dir.path();
+    run_init(root);
+
+    let body = fs::read_to_string(root.join(".git/hooks/post-commit")).unwrap();
+    assert!(
+        body.contains(".reposkein/local/indexed-at"),
+        "post-commit should record the indexed-at marker:\n{body}"
+    );
+    assert!(
+        body.contains("git rev-parse HEAD"),
+        "post-commit should record HEAD (only knowable after the commit exists):\n{body}"
+    );
+    assert!(
+        !body.contains("index ."),
+        "post-commit must not reindex — pre-commit already indexed the tree \
+         that became this commit:\n{body}"
+    );
+}
+
+#[test]
+fn post_merge_hook_reindexes_then_records_the_marker() {
+    let dir = git_repo();
+    let root = dir.path();
+    run_init(root);
+
+    let body = fs::read_to_string(root.join(".git/hooks/post-merge")).unwrap();
+    assert!(
+        body.contains("index ."),
+        "post-merge must reindex — a merge/checkout changes the tree without \
+         going through the developer's own pre-commit:\n{body}"
+    );
+    assert!(
+        body.contains(".reposkein/local/indexed-at"),
+        "post-merge should record the indexed-at marker after reindexing:\n{body}"
+    );
+    // Order matters: the marker write must follow the reindex, or a stale
+    // marker could read as fresh. Search for the actual command invocation,
+    // not the prose comment above it (which also contains "index ").
+    let index_pos = body.find("\"$BIN\" index .").unwrap();
+    let marker_pos = body.find("> .reposkein/local/indexed-at").unwrap();
+    assert!(
+        index_pos < marker_pos,
+        "reindex must happen before the marker write:\n{body}"
+    );
+}
+
+fn configure_identity(root: &std::path::Path) {
+    for (k, v) in [("user.email", "t@example.com"), ("user.name", "t")] {
+        Proc::new("git")
+            .args(["config", k, v])
+            .current_dir(root)
+            .status()
+            .unwrap();
+    }
+}
+
+/// End-to-end: install hooks with the *real* compiled binary wired up via
+/// REPOSKEIN_INDEXER_BIN, make a real commit, and confirm the post-commit
+/// hook recorded exactly the new HEAD — the false-fail-loop repro this whole
+/// hook change closes (pre-commit indexes; without post-commit, nothing ever
+/// records that the marker should advance, so `doctor --ci` reads stale
+/// after every single commit until someone runs `reposkein-mcp index` by
+/// hand).
+#[test]
+fn post_commit_records_new_head_after_a_real_commit() {
+    let dir = git_repo();
+    let root = dir.path();
+    configure_identity(root);
+    run_init(root);
+
+    let bin = cargo_bin("reposkein-indexer");
+    fs::write(root.join("a.py"), "def f():\n    return 1\n").unwrap();
+    Proc::new("git")
+        .args(["add", "a.py"])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    let commit_status = Proc::new("git")
+        .args(["commit", "-qm", "add a.py"])
+        .current_dir(root)
+        .env("REPOSKEIN_INDEXER_BIN", &bin)
+        .status()
+        .unwrap();
+    assert!(commit_status.success());
+
+    let head_out = Proc::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    let head_sha = String::from_utf8_lossy(&head_out.stdout).trim().to_string();
+    assert!(!head_sha.is_empty());
+
+    let marker = fs::read_to_string(root.join(".reposkein/local/indexed-at"))
+        .expect("post-commit hook should have written the marker");
+    assert_eq!(
+        marker.trim(),
+        head_sha,
+        "the marker must name the commit that was just created, not its parent"
+    );
+
+    // nodes.jsonl was built by pre-commit against the pre-commit tree — the
+    // same tree that became this commit.
+    let nodes = fs::read_to_string(root.join(".reposkein/nodes.jsonl")).unwrap();
+    assert!(
+        nodes.contains("a.py"),
+        "pre-commit should have indexed a.py: {nodes}"
+    );
+}
+
+/// End-to-end: directly invoking the post-merge hook (simulating what git
+/// runs after a real `git merge`/`git pull`) reindexes the changed tree AND
+/// records the marker — so a merge that lands new code doesn't leave the
+/// marker pointing at a graph that predates it.
+#[test]
+fn post_merge_hook_reindexes_and_records_marker_end_to_end() {
+    let dir = git_repo();
+    let root = dir.path();
+    configure_identity(root);
+    run_init(root);
+    let bin = cargo_bin("reposkein-indexer");
+
+    fs::write(root.join("a.py"), "def f():\n    return 1\n").unwrap();
+    Proc::new("git")
+        .args(["add", "a.py"])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    Proc::new("git")
+        .args(["commit", "-qm", "init"])
+        .current_dir(root)
+        .env("REPOSKEIN_INDEXER_BIN", &bin)
+        .status()
+        .unwrap();
+
+    // Simulate new code landing via a merge/checkout that does NOT go
+    // through the developer's own pre-commit (e.g. a fast-forward pull).
+    fs::write(root.join("b.py"), "def g():\n    return 2\n").unwrap();
+    Proc::new("git")
+        .args(["add", "b.py"])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    Proc::new("git")
+        .args([
+            "commit",
+            "-qm",
+            "simulate a merge commit landing b.py",
+            "--no-verify",
+        ])
+        .current_dir(root)
+        .status()
+        .unwrap();
+
+    let status = Proc::new(root.join(".git/hooks/post-merge"))
+        .current_dir(root)
+        .env("REPOSKEIN_INDEXER_BIN", &bin)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let nodes = fs::read_to_string(root.join(".reposkein/nodes.jsonl")).unwrap();
+    assert!(
+        nodes.contains("b.py"),
+        "post-merge should have reindexed to include the newly-landed file: {nodes}"
+    );
+
+    let head_out = Proc::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    let head_sha = String::from_utf8_lossy(&head_out.stdout).trim().to_string();
+    let marker = fs::read_to_string(root.join(".reposkein/local/indexed-at")).unwrap();
+    assert_eq!(marker.trim(), head_sha);
 }

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "neo4j-driver": "^6.1.0",
+        "undici": "^8.10.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -2870,6 +2871,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -54,12 +54,13 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "neo4j-driver": "^6.1.0",
+    "undici": "^8.10.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "typescript": "^5.7.0",
-    "vitest": "^4.1.9",
     "@types/node": "^24.0.0",
-    "tsx": "^4.0.0"
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/mcp/src/cli/agentAdapters.ts
+++ b/mcp/src/cli/agentAdapters.ts
@@ -1,0 +1,248 @@
+/** Per-agent MCP config adapters for `reposkein-mcp init`'s join mode
+ *  (REP-16 T5). A "join" is: someone cloned a repo that already has RepoSkein
+ *  set up (committed `.reposkein/meta.json`) — the one thing left to do is
+ *  wire the local agent(s) up, which today means hand-copying a JSON snippet
+ *  from docs/INSTALL.md §6. These adapters do that automatically.
+ *
+ *  Schemas match docs/INSTALL.md §6 exactly — that doc is the spec:
+ *   - Claude Code: `<repo>/.mcp.json`, `mcpServers` key. Prefers `claude mcp
+ *     add` (scope "project", which itself targets .mcp.json) when the CLI is
+ *     on PATH, so Claude's own approval/health-check flow sees the entry;
+ *     falls back to writing the file directly.
+ *   - OpenCode (+omo): `<repo>/opencode.json`, `mcp` key (NOT `mcpServers`).
+ *   - Cursor: `<repo>/.cursor/mcp.json`, `mcpServers` key.
+ *   - Unknown/no agent detected: falls back to `.mcp.json` (§6.6 "generic").
+ *
+ *  Every write is idempotent (re-run = no-op, byte-identical file), dry-run
+ *  aware (never touches disk when `dryRun: true`), and backs up any file it
+ *  actually modifies to a timestamped `.bak` sibling first. */
+
+import { existsSync, readFileSync, writeFileSync, copyFileSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+
+export type AgentId = "claude" | "opencode" | "cursor";
+export const ALL_AGENT_IDS: readonly AgentId[] = ["claude", "opencode", "cursor"];
+
+export type AdapterAction = "created" | "updated" | "unchanged" | "dry-run" | "error";
+
+export interface AdapterResult {
+  agent: AgentId;
+  /** File this adapter wrote (or would write). For the "claude" adapter via
+   *  the CLI this is still `.mcp.json` — `claude mcp add -s project` writes
+   *  there under the hood. */
+  path: string;
+  action: AdapterAction;
+  /** Set only when an existing file was actually modified. */
+  backupPath?: string;
+  message: string;
+}
+
+export interface ExecResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Injectable command runner — never throws (unlike execFileSync). Tests
+ *  inject a fake to avoid shelling out to a real `claude`/`opencode` CLI or
+ *  mutating a real project's MCP config. */
+export type Exec = (cmd: string, args: string[], opts: { cwd: string }) => ExecResult;
+
+export const defaultExec: Exec = (cmd, args, opts) => {
+  try {
+    const stdout = execFileSync(cmd, args, { cwd: opts.cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string; message?: string };
+    return {
+      status: typeof e.status === "number" ? e.status : 1,
+      stdout: e.stdout ? e.stdout.toString() : "",
+      stderr: e.stderr ? e.stderr.toString() : String(e.message ?? err),
+    };
+  }
+};
+
+function commandAvailable(exec: Exec, cmd: string, cwd: string): boolean {
+  return exec(cmd, ["--version"], { cwd }).status === 0;
+}
+
+/** Detects which agents are "present": their CLI is on PATH, or their config
+ *  file already exists (someone opted in previously — keep writing there).
+ *  Falls back to `["claude"]` (→ `.mcp.json`, the generic/broadest-compat
+ *  target) when nothing is detected at all, matching docs/INSTALL.md §6.6. */
+export function detectAgents(repoPath: string, exec: Exec = defaultExec): AgentId[] {
+  const present: AgentId[] = [];
+  if (existsSync(join(repoPath, ".mcp.json")) || commandAvailable(exec, "claude", repoPath)) present.push("claude");
+  if (existsSync(join(repoPath, "opencode.json")) || commandAvailable(exec, "opencode", repoPath)) present.push("opencode");
+  if (existsSync(join(repoPath, ".cursor"))) present.push("cursor");
+  if (present.length === 0) present.push("claude");
+  return present;
+}
+
+/** Parses a comma/space-separated `--agents` value into AgentId[], ignoring
+ *  unknown tokens (never throws — an unrecognized agent name just writes
+ *  nothing rather than crashing `init`). */
+export function parseAgentsFlag(value: string): AgentId[] {
+  const known = new Set<string>(ALL_AGENT_IDS);
+  return value
+    .split(/[,\s]+/)
+    .map((s) => s.trim().toLowerCase())
+    .filter((s): s is AgentId => known.has(s));
+}
+
+function timestampSuffix(now: Date): string {
+  return now.toISOString().replace(/[:.]/g, "-");
+}
+
+/** Copies `path` to `<path>.<timestamp>.bak` before it's modified. */
+function backupFile(path: string, now: Date): string {
+  const backupPath = `${path}.${timestampSuffix(now)}.bak`;
+  copyFileSync(path, backupPath);
+  return backupPath;
+}
+
+interface JsonAdapterSpec {
+  /** Relative to repoPath. */
+  relPath: string;
+  topKey: "mcpServers" | "mcp";
+  buildEntry: (absRepoPath: string) => unknown;
+}
+
+const MCP_JSON_SPEC: JsonAdapterSpec = {
+  relPath: ".mcp.json",
+  topKey: "mcpServers",
+  buildEntry: (absRepoPath) => ({ command: "reposkein-mcp", env: { REPOSKEIN_REPO_PATH: absRepoPath } }),
+};
+
+const OPENCODE_JSON_SPEC: JsonAdapterSpec = {
+  relPath: "opencode.json",
+  topKey: "mcp",
+  buildEntry: (absRepoPath) => ({
+    type: "local",
+    command: ["reposkein-mcp"],
+    environment: { REPOSKEIN_REPO_PATH: absRepoPath },
+    enabled: true,
+  }),
+};
+
+const CURSOR_JSON_SPEC: JsonAdapterSpec = {
+  relPath: join(".cursor", "mcp.json"),
+  topKey: "mcpServers",
+  buildEntry: (absRepoPath) => ({ command: "reposkein-mcp", env: { REPOSKEIN_REPO_PATH: absRepoPath } }),
+};
+
+/** Idempotently upserts `doc[topKey].reposkein = entry` in a JSON config
+ *  file, preserving every other key untouched (other MCP servers, `$schema`,
+ *  etc.). Unparseable existing JSON is treated as empty (still backed up
+ *  before being overwritten) rather than crashing `init`. */
+function upsertJsonAdapter(
+  repoPath: string,
+  spec: JsonAdapterSpec,
+  dryRun: boolean,
+  now: Date
+): { path: string; action: AdapterAction; backupPath?: string; message: string } {
+  const path = join(repoPath, spec.relPath);
+  const exists = existsSync(path);
+  let doc: Record<string, unknown> = {};
+  if (exists) {
+    try {
+      doc = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    } catch {
+      doc = {}; // corrupt/hand-edited JSON — don't guess; overwrite (after backup)
+    }
+  }
+  const section = (doc[spec.topKey] as Record<string, unknown> | undefined) ?? {};
+  const entry = spec.buildEntry(resolve(repoPath));
+  if (JSON.stringify(section.reposkein ?? null) === JSON.stringify(entry)) {
+    return { path, action: "unchanged", message: `${spec.relPath} already has an up-to-date reposkein entry` };
+  }
+  if (dryRun) {
+    return {
+      path,
+      action: "dry-run",
+      message: `would ${exists ? "update" : "create"} ${spec.relPath} (${spec.topKey}.reposkein)`,
+    };
+  }
+  let backupPath: string | undefined;
+  if (exists) backupPath = backupFile(path, now);
+  doc[spec.topKey] = { ...section, reposkein: entry };
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(doc, null, 2) + "\n", "utf8");
+  return { path, action: exists ? "updated" : "created", backupPath, message: `${exists ? "updated" : "created"} ${spec.relPath}` };
+}
+
+function claudeCliEntryExists(exec: Exec, repoPath: string): boolean {
+  return exec("claude", ["mcp", "get", "reposkein"], { cwd: repoPath }).status === 0;
+}
+
+/** Writes the Claude Code entry via `claude mcp add -s project` (which
+ *  itself targets `.mcp.json`), so Claude's own health-check/approval UI
+ *  picks it up immediately. Idempotent via `claude mcp get` — a re-run
+ *  no-ops instead of erroring on a duplicate name. */
+function writeViaClaudeCli(repoPath: string, dryRun: boolean, exec: Exec): AdapterResult {
+  const path = join(repoPath, ".mcp.json");
+  if (claudeCliEntryExists(exec, repoPath)) {
+    return { agent: "claude", path, action: "unchanged", message: "`claude mcp get reposkein` already resolves — nothing to add" };
+  }
+  const args = ["mcp", "add", "reposkein", "-s", "project", "-e", `REPOSKEIN_REPO_PATH=${resolve(repoPath)}`, "--", "reposkein-mcp"];
+  if (dryRun) {
+    return { agent: "claude", path, action: "dry-run", message: `would run: claude ${args.join(" ")}` };
+  }
+  const r = exec("claude", args, { cwd: repoPath });
+  if (r.status !== 0) {
+    return { agent: "claude", path, action: "error", message: `claude mcp add failed: ${(r.stderr || r.stdout).trim()}` };
+  }
+  return { agent: "claude", path, action: "created", message: "added via `claude mcp add` (project scope → .mcp.json)" };
+}
+
+export interface WriteAgentConfigsOptions {
+  /** Explicit `--agents` override — write exactly these, skipping detection. */
+  agents?: AgentId[];
+  dryRun?: boolean;
+  /** Injectable for tests. */
+  exec?: Exec;
+  now?: () => Date;
+}
+
+/** Writes (or plans, under `dryRun`) the local agent MCP config for every
+ *  detected/requested agent. Pure w.r.t. its inputs beyond `exec`/`now`/fs —
+ *  same repo state + same options always produces the same plan, which is
+ *  what makes idempotence and dry-run trustworthy. */
+export function writeAgentConfigs(repoPath: string, opts: WriteAgentConfigsOptions = {}): AdapterResult[] {
+  const exec = opts.exec ?? defaultExec;
+  const now = (opts.now ?? (() => new Date()))();
+  const dryRun = !!opts.dryRun;
+  const agents = opts.agents ?? detectAgents(repoPath, exec);
+
+  const results: AdapterResult[] = [];
+  for (const agent of agents) {
+    if (agent === "claude") {
+      if (commandAvailable(exec, "claude", repoPath)) {
+        results.push(writeViaClaudeCli(repoPath, dryRun, exec));
+      } else {
+        const r = upsertJsonAdapter(repoPath, MCP_JSON_SPEC, dryRun, now);
+        results.push({ agent: "claude", ...r });
+      }
+    } else if (agent === "opencode") {
+      const r = upsertJsonAdapter(repoPath, OPENCODE_JSON_SPEC, dryRun, now);
+      results.push({ agent: "opencode", ...r });
+    } else if (agent === "cursor") {
+      const r = upsertJsonAdapter(repoPath, CURSOR_JSON_SPEC, dryRun, now);
+      results.push({ agent: "cursor", ...r });
+    }
+  }
+  return results;
+}
+
+/** One line per adapter result, for `init`'s stderr summary. */
+export function formatAdapterResult(r: AdapterResult): string {
+  const verb =
+    r.action === "created" ? "wrote" :
+    r.action === "updated" ? "updated" :
+    r.action === "unchanged" ? "unchanged" :
+    r.action === "dry-run" ? "[dry-run]" :
+    "ERROR";
+  const backup = r.backupPath ? ` (backup: ${r.backupPath})` : "";
+  return `reposkein: [${r.agent}] ${verb} — ${r.message}${backup}`;
+}

--- a/mcp/src/cli/agentAdapters.ts
+++ b/mcp/src/cli/agentAdapters.ts
@@ -134,8 +134,10 @@ const CURSOR_JSON_SPEC: JsonAdapterSpec = {
 
 /** Idempotently upserts `doc[topKey].reposkein = entry` in a JSON config
  *  file, preserving every other key untouched (other MCP servers, `$schema`,
- *  etc.). Unparseable existing JSON is treated as empty (still backed up
- *  before being overwritten) rather than crashing `init`. */
+ *  etc.). Never guesses at a corrupt/hand-edited existing file — see the
+ *  early return below: it backs the file up (real run only) and reports an
+ *  "error" result instead of overwriting it with a reposkein-only doc,
+ *  which would silently destroy whatever else was in there. */
 function upsertJsonAdapter(
   repoPath: string,
   spec: JsonAdapterSpec,
@@ -146,10 +148,38 @@ function upsertJsonAdapter(
   const exists = existsSync(path);
   let doc: Record<string, unknown> = {};
   if (exists) {
+    let raw: string;
     try {
-      doc = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
-    } catch {
-      doc = {}; // corrupt/hand-edited JSON — don't guess; overwrite (after backup)
+      raw = readFileSync(path, "utf8");
+    } catch (err) {
+      return {
+        path,
+        action: "error",
+        message: `could not read ${spec.relPath}: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+    try {
+      doc = JSON.parse(raw) as Record<string, unknown>;
+    } catch (err) {
+      const parseMessage = err instanceof Error ? err.message : String(err);
+      if (dryRun) {
+        return {
+          path,
+          action: "error",
+          message:
+            `${spec.relPath} is not valid JSON (${parseMessage}) — left untouched. ` +
+            "Fix the JSON and re-run, or delete the file.",
+        };
+      }
+      const backupPath = backupFile(path, now);
+      return {
+        path,
+        action: "error",
+        backupPath,
+        message:
+          `${spec.relPath} is not valid JSON (${parseMessage}) — left untouched, backed up to ${backupPath}. ` +
+          "Fix the JSON and re-run, or delete the file.",
+      };
     }
   }
   const section = (doc[spec.topKey] as Record<string, unknown> | undefined) ?? {};

--- a/mcp/src/cli/doctor.ts
+++ b/mcp/src/cli/doctor.ts
@@ -6,6 +6,7 @@ import { resolveRepoId } from "../store/repoId.js";
 import { resolveRepoPath } from "../store/resolveRepoPath.js";
 import { decisionChecks } from "./doctorDecisions.js";
 import { summaryChecks } from "./doctorSummaries.js";
+import { hooksCheck, graphStaleCheck } from "./doctorFreshness.js";
 
 export interface DoctorPathResolution {
   path: string;
@@ -119,11 +120,30 @@ export async function runChecks(repoPath: string): Promise<DoctorReport> {
   // 5) Decision log validation (all non-critical: degrade, don't block).
   checks.push(...decisionChecks(repoPath));
 
+  // 6) Git hooks installed + graph freshness (non-critical here; `doctor
+  //    --ci` promotes both to a failing exit code — see CI_FAIL_IDS below).
+  checks.push(hooksCheck(repoPath));
+  checks.push(graphStaleCheck(repoPath));
+
   const ok = checks.filter((c) => c.critical).every((c) => c.ok);
   return { repoPath, ok, checks };
 }
 
-function render(report: DoctorReport): string {
+/** Check ids that `doctor --ci` treats as build-breaking even though they're
+ *  non-critical for interactive use (degrade gracefully for a human at the
+ *  keyboard, but should fail a CI job so drift gets caught before it's
+ *  merged): missing/foreign git hooks, a stale committed graph, and an
+ *  unsplit legacy `summaries.jsonl` (see docs/INSTALL.md §4.2 — every branch
+ *  that writes a summary would conflict on it). */
+export const CI_FAIL_IDS = new Set(["hooks_installed", "graph_stale", "summaries_unsplit"]);
+
+/** Checks (by id) that `doctor --ci` additionally fails on, beyond the
+ *  normal critical-check gate. */
+export function ciFailingChecks(report: DoctorReport): Check[] {
+  return report.checks.filter((c) => CI_FAIL_IDS.has(c.id) && !c.ok);
+}
+
+export function renderDoctorReport(report: DoctorReport): string {
   const lines = [`reposkein doctor — ${report.repoPath}`, ""];
   for (const c of report.checks) {
     lines.push(`${c.ok ? "✓" : "✗"} ${c.label}: ${c.detail}`);
@@ -135,10 +155,30 @@ function render(report: DoctorReport): string {
   return lines.join("\n");
 }
 
-/** Entry point for `reposkein-mcp doctor [path] [--json]`. Returns process exit code. */
-export async function runDoctor(repoPath = ".", json = false): Promise<number> {
+export interface RunDoctorOptions {
+  json?: boolean;
+  /** `doctor --ci`: additionally fail (non-zero exit) when any CI_FAIL_IDS
+   *  check is non-ok, even though those checks are non-critical for
+   *  interactive use. Doesn't change what's printed — only the exit code. */
+  ci?: boolean;
+}
+
+/** Entry point for `reposkein-mcp doctor [path] [--json] [--ci]`. Returns the
+ *  process exit code. Accepts a bare boolean for `json` for backwards
+ *  compatibility with the pre-`--ci` call signature. */
+export async function runDoctor(
+  repoPath = ".",
+  opts: RunDoctorOptions | boolean = {}
+): Promise<number> {
+  const { json = false, ci = false } = typeof opts === "boolean" ? { json: opts } : opts;
   const report = await runChecks(repoPath);
   if (json) console.log(JSON.stringify(report, null, 2));
-  else console.error(render(report));
-  return report.ok ? 0 : 1;
+  else console.error(renderDoctorReport(report));
+  const ciFailures = ci ? ciFailingChecks(report) : [];
+  if (ci && ciFailures.length > 0 && !json) {
+    console.error(
+      `\n--ci: failing on ${ciFailures.length} additional check(s): ${ciFailures.map((c) => c.id).join(", ")}`
+    );
+  }
+  return report.ok && ciFailures.length === 0 ? 0 : 1;
 }

--- a/mcp/src/cli/doctorFreshness.ts
+++ b/mcp/src/cli/doctorFreshness.ts
@@ -67,7 +67,13 @@ function currentHeadSha(repoPath: string): string | null {
 
 /** Content-based staleness: the committed graph is fresh iff the commit SHA
  *  recorded the last time it was (re)built (`.reposkein/local/indexed-at` —
- *  see mcp/src/store/indexedAt.ts) equals the current git HEAD.
+ *  see mcp/src/store/indexedAt.ts) equals the current git HEAD. The marker
+ *  is kept current two ways: the installed git hooks maintain it on their
+ *  own (`post-commit` after every commit, `post-merge`/`post-checkout` —
+ *  which also re-index — after a merge/pull/branch switch), and
+ *  `reposkein-mcp index`/`init` write it directly. A mismatch therefore
+ *  means one of: the hooks were never installed (or were removed), or
+ *  nobody's indexed this repo at all yet.
  *
  *  Replaces an earlier mtime-based heuristic (mtime(nodes.jsonl) vs. the last
  *  commit's timestamp) that turned out to be structurally blind after any
@@ -87,10 +93,12 @@ function currentHeadSha(repoPath: string): string | null {
  *  being fixed — so the simpler, conservative rule wins here.
  *
  *  Two distinct failure shapes, both reported under the same check id:
- *   - no recorded SHA at all → never indexed via the mcp-side path (a fresh
- *     clone's local/ never carries over, since it's gitignored) — FAIL.
- *   - a recorded SHA that doesn't match HEAD → commits landed since the last
- *     index — FAIL.
+ *   - no recorded SHA at all → never indexed via a hook or the mcp-side path
+ *     (a fresh clone's local/ never carries over, since it's gitignored) —
+ *     FAIL.
+ *   - a recorded SHA that doesn't match HEAD → the hooks are missing (or
+ *     were bypassed, e.g. `git commit --no-verify`) and nobody's re-indexed
+ *     by hand either — FAIL.
  *
  *  Non-critical by default; `doctor --ci` promotes it (CI_FAIL_IDS in
  *  doctor.ts). */
@@ -113,7 +121,9 @@ export function graphStaleCheck(repoPath: string): Check {
       "graph freshness",
       false,
       "nodes.jsonl exists but no recorded indexed-at commit (.reposkein/local/indexed-at) — " +
-        "never indexed via `reposkein-mcp index`/`init`, or a fresh clone whose local/ scratch didn't carry over",
+        "the post-commit/post-merge/post-checkout hooks maintain this automatically, so its " +
+        "absence means the hooks aren't installed (or local/ never carried over a clone) and " +
+        "nobody's run `reposkein-mcp index`/`init` by hand either",
       "run `reposkein-mcp index`"
     );
   }
@@ -130,7 +140,8 @@ export function graphStaleCheck(repoPath: string): Check {
     "graph_stale",
     "graph freshness",
     false,
-    `graph was indexed at ${recordedSha.slice(0, 7)}, but HEAD is now ${headSha.slice(0, 7)} — commits landed since the last index`,
+    `graph was indexed at ${recordedSha.slice(0, 7)}, but HEAD is now ${headSha.slice(0, 7)} — commits landed since ` +
+      "the last index without the marker advancing (hooks missing/bypassed, or the graph was never re-indexed)",
     "run `reposkein-mcp index`"
   );
 }

--- a/mcp/src/cli/doctorFreshness.ts
+++ b/mcp/src/cli/doctorFreshness.ts
@@ -1,7 +1,8 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Check } from "./doctor.js";
+import { readIndexedAtSha } from "../store/indexedAt.js";
 
 /** Marker `init --hooks` (the Rust indexer) writes into every hook it
  *  installs — see indexer/crates/cli/src/main.rs `write_hook`. Doctor uses
@@ -50,33 +51,49 @@ export function hooksCheck(repoPath: string): Check {
   );
 }
 
-/** `git -C repoPath log -1 --format=%ct` for the given pathspec, or null on
- *  any failure (no git, not a repo, no commits, no matching commit). */
-function lastCommitEpochMs(repoPath: string, pathspec: string[]): number | null {
+/** `git -C repoPath rev-parse HEAD`, or null on any failure (no git, not a
+ *  repo, no commits yet). */
+function currentHeadSha(repoPath: string): string | null {
   try {
-    const out = execFileSync("git", ["-C", repoPath, "log", "-1", "--format=%ct", "--", ...pathspec], {
+    const out = execFileSync("git", ["-C", repoPath, "rev-parse", "HEAD"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    if (!out) return null;
-    const sec = parseInt(out, 10);
-    return Number.isFinite(sec) ? sec * 1000 : null;
+    return out || null;
   } catch {
     return null;
   }
 }
 
-/** Pragmatic staleness heuristic: the committed graph (`.reposkein/nodes.jsonl`)
- *  should be at least as new as the last commit that touched tracked files
- *  outside `.reposkein/` (a commit that only edits summaries/decisions
- *  doesn't require a re-index). Compares mtimes, not content — cheap, no
- *  hashing, and good enough to catch "forgot to re-index after a big change".
+/** Content-based staleness: the committed graph is fresh iff the commit SHA
+ *  recorded the last time it was (re)built (`.reposkein/local/indexed-at` —
+ *  see mcp/src/store/indexedAt.ts) equals the current git HEAD.
  *
- *  Known limitation (documented, not fixed): `git checkout`/`clone` sets
- *  every file's mtime to checkout time, not commit time, so a fresh clone's
- *  nodes.jsonl (rebuilt by `init`/hooks right after) usually reads as fresh
- *  by construction, and a long-lived local checkout is the case this most
- *  reliably catches. Non-critical by default; `doctor --ci` promotes it. */
+ *  Replaces an earlier mtime-based heuristic (mtime(nodes.jsonl) vs. the last
+ *  commit's timestamp) that turned out to be structurally blind after any
+ *  fresh checkout: `git clone`/`checkout` — or a CI cache restoring
+ *  `.reposkein/` from a prior run — stamps every file it writes with
+ *  "now", which is always ≥ any past commit's timestamp, so
+ *  `mtime < lastCommitMs` could never be true right when it mattered most.
+ *  A recorded SHA has no such blind spot: it's compared by value, not by
+ *  filesystem timestamp.
+ *
+ *  Deliberately a **plain SHA mismatch**, not a diff filtered to
+ *  indexed-language extensions: filtering would need to stay in sync with
+ *  `config.toml`'s `[languages] enabled` list and the indexer's own
+ *  extension→language table, which is one more thing to drift. The cost of
+ *  getting it wrong is asymmetric — a false "stale" just costs a redundant
+ *  `reposkein-mcp index` (cheap), while a false "fresh" is exactly the bug
+ *  being fixed — so the simpler, conservative rule wins here.
+ *
+ *  Two distinct failure shapes, both reported under the same check id:
+ *   - no recorded SHA at all → never indexed via the mcp-side path (a fresh
+ *     clone's local/ never carries over, since it's gitignored) — FAIL.
+ *   - a recorded SHA that doesn't match HEAD → commits landed since the last
+ *     index — FAIL.
+ *
+ *  Non-critical by default; `doctor --ci` promotes it (CI_FAIL_IDS in
+ *  doctor.ts). */
 export function graphStaleCheck(repoPath: string): Check {
   const nodesFile = join(repoPath, ".reposkein", "nodes.jsonl");
   if (!existsSync(nodesFile)) {
@@ -88,23 +105,32 @@ export function graphStaleCheck(repoPath: string): Check {
       "run `reposkein-mcp index`"
     );
   }
-  // Exclude .reposkein/ itself (summaries/decisions land there and don't
-  // require a re-index) with git's exclude pathspec magic; fall back to an
-  // unscoped query on older git versions that reject it.
-  let lastCommitMs = lastCommitEpochMs(repoPath, [".", ":(exclude).reposkein"]);
-  if (lastCommitMs === null) lastCommitMs = lastCommitEpochMs(repoPath, ["."]);
-  if (lastCommitMs === null) {
-    return warn("graph_stale", "graph freshness", true, "no git history to compare against (skipped)");
+
+  const recordedSha = readIndexedAtSha(repoPath);
+  if (!recordedSha) {
+    return warn(
+      "graph_stale",
+      "graph freshness",
+      false,
+      "nodes.jsonl exists but no recorded indexed-at commit (.reposkein/local/indexed-at) — " +
+        "never indexed via `reposkein-mcp index`/`init`, or a fresh clone whose local/ scratch didn't carry over",
+      "run `reposkein-mcp index`"
+    );
   }
-  const mtimeMs = statSync(nodesFile).mtimeMs;
-  const stale = mtimeMs < lastCommitMs;
+
+  const headSha = currentHeadSha(repoPath);
+  if (headSha === null) {
+    return warn("graph_stale", "graph freshness", true, "no git HEAD to compare against (skipped)");
+  }
+
+  if (recordedSha === headSha) {
+    return warn("graph_stale", "graph freshness", true, `graph matches HEAD (${headSha.slice(0, 7)})`);
+  }
   return warn(
     "graph_stale",
     "graph freshness",
-    !stale,
-    stale
-      ? "nodes.jsonl is older than the last commit touching tracked files outside .reposkein/"
-      : "graph is at least as new as the last relevant commit",
-    stale ? "run `reposkein-mcp index`" : undefined
+    false,
+    `graph was indexed at ${recordedSha.slice(0, 7)}, but HEAD is now ${headSha.slice(0, 7)} — commits landed since the last index`,
+    "run `reposkein-mcp index`"
   );
 }

--- a/mcp/src/cli/doctorFreshness.ts
+++ b/mcp/src/cli/doctorFreshness.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { Check } from "./doctor.js";
+
+/** Marker `init --hooks` (the Rust indexer) writes into every hook it
+ *  installs — see indexer/crates/cli/src/main.rs `write_hook`. Doctor uses
+ *  the same marker to tell "RepoSkein installed this hook" from "the user
+ *  has their own pre-commit hook and never ran `reposkein-mcp init`". */
+const HOOK_MARKER = "# reposkein-managed";
+
+const warn = (id: string, label: string, ok: boolean, detail: string, fix?: string): Check => ({
+  id,
+  label,
+  ok,
+  critical: false, // these checks degrade the workflow; they never block startup
+  detail,
+  fix: ok ? undefined : fix,
+});
+
+/** Non-critical by default: a repo can be perfectly usable without hooks
+ *  (an agent can always run `reposkein-mcp index` by hand). `doctor --ci`
+ *  promotes this id to a failing exit code — see CI_FAIL_IDS in doctor.ts. */
+export function hooksCheck(repoPath: string): Check {
+  const hookPath = join(repoPath, ".git", "hooks", "pre-commit");
+  if (!existsSync(hookPath)) {
+    return warn(
+      "hooks_installed",
+      "git hooks installed",
+      false,
+      "no .git/hooks/pre-commit",
+      "run `reposkein-mcp init` to install the pre-commit/post-merge hooks"
+    );
+  }
+  let content = "";
+  try {
+    content = readFileSync(hookPath, "utf8");
+  } catch {
+    /* unreadable — treat like missing below */
+  }
+  const managed = content.includes(HOOK_MARKER);
+  return warn(
+    "hooks_installed",
+    "git hooks installed",
+    managed,
+    managed
+      ? "pre-commit hook installed"
+      : ".git/hooks/pre-commit exists but was not installed by RepoSkein",
+    managed ? undefined : "run `reposkein-mcp init` to install the pre-commit/post-merge hooks"
+  );
+}
+
+/** `git -C repoPath log -1 --format=%ct` for the given pathspec, or null on
+ *  any failure (no git, not a repo, no commits, no matching commit). */
+function lastCommitEpochMs(repoPath: string, pathspec: string[]): number | null {
+  try {
+    const out = execFileSync("git", ["-C", repoPath, "log", "-1", "--format=%ct", "--", ...pathspec], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!out) return null;
+    const sec = parseInt(out, 10);
+    return Number.isFinite(sec) ? sec * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Pragmatic staleness heuristic: the committed graph (`.reposkein/nodes.jsonl`)
+ *  should be at least as new as the last commit that touched tracked files
+ *  outside `.reposkein/` (a commit that only edits summaries/decisions
+ *  doesn't require a re-index). Compares mtimes, not content — cheap, no
+ *  hashing, and good enough to catch "forgot to re-index after a big change".
+ *
+ *  Known limitation (documented, not fixed): `git checkout`/`clone` sets
+ *  every file's mtime to checkout time, not commit time, so a fresh clone's
+ *  nodes.jsonl (rebuilt by `init`/hooks right after) usually reads as fresh
+ *  by construction, and a long-lived local checkout is the case this most
+ *  reliably catches. Non-critical by default; `doctor --ci` promotes it. */
+export function graphStaleCheck(repoPath: string): Check {
+  const nodesFile = join(repoPath, ".reposkein", "nodes.jsonl");
+  if (!existsSync(nodesFile)) {
+    return warn(
+      "graph_stale",
+      "graph freshness",
+      false,
+      "no .reposkein/nodes.jsonl (never indexed)",
+      "run `reposkein-mcp index`"
+    );
+  }
+  // Exclude .reposkein/ itself (summaries/decisions land there and don't
+  // require a re-index) with git's exclude pathspec magic; fall back to an
+  // unscoped query on older git versions that reject it.
+  let lastCommitMs = lastCommitEpochMs(repoPath, [".", ":(exclude).reposkein"]);
+  if (lastCommitMs === null) lastCommitMs = lastCommitEpochMs(repoPath, ["."]);
+  if (lastCommitMs === null) {
+    return warn("graph_stale", "graph freshness", true, "no git history to compare against (skipped)");
+  }
+  const mtimeMs = statSync(nodesFile).mtimeMs;
+  const stale = mtimeMs < lastCommitMs;
+  return warn(
+    "graph_stale",
+    "graph freshness",
+    !stale,
+    stale
+      ? "nodes.jsonl is older than the last commit touching tracked files outside .reposkein/"
+      : "graph is at least as new as the last relevant commit",
+    stale ? "run `reposkein-mcp index`" : undefined
+  );
+}

--- a/mcp/src/cli/init.ts
+++ b/mcp/src/cli/init.ts
@@ -146,10 +146,11 @@ export function writeCiWorkflow(repoPath: string): { written: boolean; path: str
  *  binary is fetched into the package (not on PATH), so end users run this.
  *  On success, also records the current git HEAD to `.reposkein/local/indexed-at`
  *  — `doctor --ci`'s `graph_stale` check reads it back (see doctorFreshness.ts).
- *  Known gap (documented, not fixed here): the pre-commit hook re-indexes by
- *  calling the indexer binary directly, not through this path, so it doesn't
- *  update the marker — `graph_stale` can read as stale after a string of
- *  hook-driven commits until someone runs `reposkein-mcp index`/`init` again. */
+ *  The installed git hooks maintain the same marker themselves (`post-commit`
+ *  after every commit, `post-merge`/`post-checkout` — which also re-index —
+ *  after a merge/pull/branch switch; see the hook templates in
+ *  indexer/crates/cli/src/main.rs), so this mcp-side write is the "manual
+ *  index" case, not the only path that keeps the marker current. */
 export async function runIndex(repoPath = "."): Promise<number> {
   const bin = await ensureIndexerBinary();
   const r = await spawnIndexer(bin, ["index", repoPath]);

--- a/mcp/src/cli/init.ts
+++ b/mcp/src/cli/init.ts
@@ -1,7 +1,10 @@
 import { mkdirSync, copyFileSync, existsSync, readFileSync, appendFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
-import { ensureIndexerBinary, packageRoot } from "../indexer/fetchBinary.js";
+import { ensureIndexerBinary, packageRoot, platformKey, cargoInstallFallbackMessage } from "../indexer/fetchBinary.js";
 import { spawnIndexer } from "../indexer/runIndexer.js";
+import { writeAgentConfigs, formatAdapterResult, type AgentId, type WriteAgentConfigsOptions } from "./agentAdapters.js";
+import { runChecks, renderDoctorReport } from "./doctor.js";
 
 /** Where the navigation skill is installed for a repo (Claude project skills). */
 export function skillTargetPath(repoPath: string): string {
@@ -30,8 +33,9 @@ export function mcpConfigSnippet(repoPath: string): string {
 }
 
 /** Per-machine MCP config files setup writes to a repo root: they hold absolute
- *  paths and a local backend password, so they must never be committed. */
-const LOCAL_MCP_CONFIG_FILES = [".mcp.json", "opencode.json"] as const;
+ *  paths and a local backend password, so they must never be committed.
+ *  Written as gitignore patterns (always forward-slash, regardless of OS). */
+const LOCAL_MCP_CONFIG_FILES = [".mcp.json", "opencode.json", ".cursor/mcp.json"] as const;
 
 /** Idempotently add the per-machine MCP config files to the repo's .gitignore
  *  (creating it if absent), so `reposkein-mcp init` never leaves them tracked. */
@@ -49,6 +53,29 @@ export function ensureLocalConfigGitignored(repoPath: string): void {
     `${missing.join("\n")}\n`;
   appendFileSync(gitignorePath, block);
   console.error(`reposkein: gitignored ${missing.join(", ")} (per-machine config, never commit)`);
+}
+
+/** True when `.reposkein/meta.json` is tracked by git — this clone joined a
+ *  repo that already has RepoSkein set up (someone else ran `init` and
+ *  committed it), rather than being the first machine to set it up (whose
+ *  meta.json exists on disk but isn't committed yet). Join mode skips
+ *  first-time scaffolding entirely and instead wires up the local agent(s)
+ *  automatically (REP-16 T5) — see `runInit`.
+ *
+ *  Falls back to plain existence when git itself is unavailable (no `git`
+ *  binary, or `repoPath` isn't a git repo yet) so `init` still behaves
+ *  sensibly outside a git repo rather than throwing. */
+export function detectJoinMode(repoPath: string): boolean {
+  if (!existsSync(join(repoPath, ".reposkein", "meta.json"))) return false;
+  try {
+    execFileSync("git", ["ls-files", "--error-unmatch", ".reposkein/meta.json"], {
+      cwd: repoPath,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Where `init --ci` writes the Pages-publish workflow in the target repo. */
@@ -126,31 +153,89 @@ export async function runIndex(repoPath = "."): Promise<number> {
   return r.code;
 }
 
-/** `reposkein-mcp init [path] [--no-index] [--ci]`: ensure the indexer, install git
- *  hooks, build the initial graph, install the navigation skill, print the MCP
- *  config + next steps. Pass `index: false` to skip the initial index; `ci: true`
- *  to also write the GitHub Pages publish workflow (see docs/HOSTING.md). */
-export async function runInit(
-  repoPath = ".",
-  opts: { index?: boolean; ci?: boolean } = {}
-): Promise<number> {
-  // 1) Indexer binary (fetches it if needed).
-  const bin = await ensureIndexerBinary();
+export interface RunInitOptions {
+  index?: boolean;
+  ci?: boolean;
+  /** Explicit `--agents` override for join mode; detected when omitted. */
+  agents?: AgentId[];
+  /** `--dry-run`: plan agent config writes without touching disk. */
+  dryRun?: boolean;
+  /** Force join-mode on/off; auto-detected (committed .reposkein/meta.json)
+   *  when omitted — see `detectJoinMode`. */
+  join?: boolean;
+  /** Test-only injection point for the agent-adapter step (fake `exec`/`now`). */
+  agentWriteOpts?: Pick<WriteAgentConfigsOptions, "exec" | "now">;
+}
 
-  // 2) Git hooks (needs a git repo). Also strips any merge declaration an older
-  //    RepoSkein left behind for the derived JSONL, which is no longer committed.
-  const r = await spawnIndexer(bin, ["init", "--hooks", repoPath]);
-  if (r.code !== 0) {
-    console.error(`reposkein: indexer init failed: ${r.stderr || r.stdout}`);
-    console.error("  (is this a git repository? run `git init` first.)");
-    return 1;
+/** `reposkein-mcp init [path] [--no-index] [--ci] [--agents <list>] [--dry-run]`:
+ *  ensure the indexer, install git hooks, build the initial graph, install
+ *  the navigation skill, then either (join mode) auto-write the local
+ *  agent(s) MCP config, or (first-time) print the config snippet to paste in
+ *  by hand. Pass `index: false` to skip the initial index; `ci: true` to
+ *  also write the GitHub Pages publish workflow (see docs/HOSTING.md).
+ *
+ *  Join mode (REP-16 T5): auto-detected when `.reposkein/meta.json` is
+ *  already committed (`detectJoinMode`) — i.e. someone cloned a repo that
+ *  already has RepoSkein set up. Skips nothing structural (hooks/index/skill
+ *  still run so a stale local checkout gets caught up) but additionally
+ *  writes `.mcp.json` / `opencode.json` / `.cursor/mcp.json` for whichever
+ *  agent(s) are detected present (or `opts.agents`), then prints a doctor
+ *  summary instead of a config snippet to copy by hand.
+ *
+ *  Unsupported platform (darwin-x64, win32-arm64, no REPOSKEIN_INDEXER_BIN):
+ *  prints cargo-install fallback instructions and CONTINUES instead of
+ *  crashing — hooks + the initial index are skipped (nothing to run them
+ *  with), but the skill, CI workflow, and (in join mode) agent config are
+ *  still written, and the function returns 0. */
+export async function runInit(repoPath = ".", opts: RunInitOptions = {}): Promise<number> {
+  const joinMode = opts.join ?? detectJoinMode(repoPath);
+  if (joinMode) {
+    console.error(
+      "reposkein: found a committed .reposkein/meta.json — joining an existing repo " +
+        "(skipping first-time scaffolding; wiring up your agent(s) automatically)."
+    );
   }
 
-  // 2b) Keep the per-machine MCP config out of git; only .reposkein/ is shared.
-  ensureLocalConfigGitignored(repoPath);
+  // 1) Indexer binary — but only attempt it on a platform that has one (or
+  //    with an explicit offline override). Everything binary-dependent below
+  //    degrades to a warning instead of crashing when neither is true.
+  const platformSupported = platformKey() !== null || !!process.env.REPOSKEIN_INDEXER_BIN;
+  let bin: string | null = null;
+  if (!platformSupported) {
+    console.error(cargoInstallFallbackMessage());
+  } else {
+    bin = await ensureIndexerBinary();
+  }
+
+  // 2) Git hooks (needs the indexer binary + a git repo). Also strips any
+  //    merge declaration an older RepoSkein left behind for the derived
+  //    JSONL, which is no longer committed.
+  let hooksOk = false;
+  if (bin) {
+    try {
+      const r = await spawnIndexer(bin, ["init", "--hooks", repoPath]);
+      if (r.code !== 0) {
+        console.error(`reposkein: indexer init failed: ${r.stderr || r.stdout}`);
+        console.error("  (is this a git repository? run `git init` first.)");
+        return 1;
+      }
+      hooksOk = true;
+      // 2b) Keep the per-machine MCP config out of git; only .reposkein/ is shared.
+      ensureLocalConfigGitignored(repoPath);
+    } catch (err) {
+      console.error(
+        `reposkein: could not run the indexer binary (${err instanceof Error ? err.message : String(err)}).\n` +
+          "  Set REPOSKEIN_INDEXER_BIN to a working `reposkein-indexer` path and re-run."
+      );
+    }
+  } else {
+    console.error(
+      "reposkein: skipping git hook install and the initial index — no indexer binary for this platform."
+    );
+  }
 
   // 3) Build the initial code graph (the whole point of setup) unless opted out.
-  if (opts.index !== false) {
+  if (bin && hooksOk && opts.index !== false) {
     console.error("reposkein: building the initial code graph…");
     const ic = await runIndex(repoPath);
     if (ic !== 0) {
@@ -174,17 +259,33 @@ export async function runInit(
   // 5) Optionally write the GitHub Pages publish workflow.
   if (opts.ci) writeCiWorkflow(repoPath);
 
-  // 6) Next steps + MCP config.
-  console.error("\nreposkein: ready. Add this MCP server to your client config:\n");
-  console.error(mcpConfigSnippet(repoPath));
-  console.error(
-    "\nCommit .reposkein/meta.json, config.toml, .gitignore, .gitattributes and summaries/. " +
-      "nodes.jsonl and edges.jsonl are derived from your working tree and git-ignored: every clone " +
-      "rebuilds them in seconds, and committing them would conflict on every branch that touches code. " +
-      "Authored summaries live in .reposkein/summaries/<xx>.jsonl — one small file per hash bucket, so " +
-      "two branches summarising different code never touch the same file." +
-      "\nVerify anytime with `reposkein-mcp doctor`; re-index after big changes with `reposkein-mcp index` " +
-      "(or the agent's reindex_file / init_cpg_skeleton tools)."
-  );
+  // 6) Join mode: auto-write agent MCP config + a doctor summary. First-time
+  //    setup: print the config snippet for the user to paste in by hand.
+  if (joinMode) {
+    console.error("\nreposkein: wiring up local agent MCP config…");
+    const results = writeAgentConfigs(repoPath, {
+      agents: opts.agents,
+      dryRun: opts.dryRun,
+      ...opts.agentWriteOpts,
+    });
+    for (const r of results) console.error(formatAdapterResult(r));
+    if (opts.dryRun) {
+      console.error("\nreposkein: --dry-run — no config files were written. Re-run without --dry-run to apply.");
+    }
+    console.error("\nreposkein: doctor summary\n");
+    console.error(renderDoctorReport(await runChecks(repoPath)));
+  } else {
+    console.error("\nreposkein: ready. Add this MCP server to your client config:\n");
+    console.error(mcpConfigSnippet(repoPath));
+    console.error(
+      "\nCommit .reposkein/meta.json, config.toml, .gitignore, .gitattributes and summaries/. " +
+        "nodes.jsonl and edges.jsonl are derived from your working tree and git-ignored: every clone " +
+        "rebuilds them in seconds, and committing them would conflict on every branch that touches code. " +
+        "Authored summaries live in .reposkein/summaries/<xx>.jsonl — one small file per hash bucket, so " +
+        "two branches summarising different code never touch the same file." +
+        "\nVerify anytime with `reposkein-mcp doctor`; re-index after big changes with `reposkein-mcp index` " +
+        "(or the agent's reindex_file / init_cpg_skeleton tools)."
+    );
+  }
   return 0;
 }

--- a/mcp/src/cli/init.ts
+++ b/mcp/src/cli/init.ts
@@ -5,6 +5,7 @@ import { ensureIndexerBinary, packageRoot, platformKey, cargoInstallFallbackMess
 import { spawnIndexer } from "../indexer/runIndexer.js";
 import { writeAgentConfigs, formatAdapterResult, type AgentId, type WriteAgentConfigsOptions } from "./agentAdapters.js";
 import { runChecks, renderDoctorReport } from "./doctor.js";
+import { writeIndexedAtMarker } from "../store/indexedAt.js";
 
 /** Where the navigation skill is installed for a repo (Claude project skills). */
 export function skillTargetPath(repoPath: string): string {
@@ -142,13 +143,21 @@ export function writeCiWorkflow(repoPath: string): { written: boolean; path: str
 
 /** `reposkein-mcp index [path]`: (re)build the code graph at `repoPath` using the
  *  native indexer. The package-friendly way to index — the `reposkein-indexer`
- *  binary is fetched into the package (not on PATH), so end users run this. */
+ *  binary is fetched into the package (not on PATH), so end users run this.
+ *  On success, also records the current git HEAD to `.reposkein/local/indexed-at`
+ *  — `doctor --ci`'s `graph_stale` check reads it back (see doctorFreshness.ts).
+ *  Known gap (documented, not fixed here): the pre-commit hook re-indexes by
+ *  calling the indexer binary directly, not through this path, so it doesn't
+ *  update the marker — `graph_stale` can read as stale after a string of
+ *  hook-driven commits until someone runs `reposkein-mcp index`/`init` again. */
 export async function runIndex(repoPath = "."): Promise<number> {
   const bin = await ensureIndexerBinary();
   const r = await spawnIndexer(bin, ["index", repoPath]);
   if (r.stdout.trim()) console.error(r.stdout.trim());
   if (r.code !== 0) {
     console.error(`reposkein: index failed: ${r.stderr || r.stdout}`);
+  } else {
+    writeIndexedAtMarker(repoPath);
   }
   return r.code;
 }

--- a/mcp/src/cli/view.ts
+++ b/mcp/src/cli/view.ts
@@ -13,6 +13,7 @@ import { join, resolve, normalize, extname } from "node:path";
 import { gzipSync } from "node:zlib";
 import { spawn, execFileSync } from "node:child_process";
 import { packageRoot } from "../indexer/fetchBinary.js";
+import { readTeamPagesUrl } from "../store/teamConfig.js";
 import { getTemporal } from "../temporal/temporal.js";
 import { discoverFederatedRepos } from "./federatedDiscovery.js";
 import { collectSourceSlices, type SourceSliceEntry } from "./sourceSlices.js";
@@ -87,13 +88,21 @@ export interface RepoBakeMeta {
   commitSha: string | null;
   builtAt: string | null;
   repoUrl: string | null;
+  /** `[team] pages_url` from `.reposkein/config.toml`, or null when unset.
+   *  The team's canonical/CI-published constellation link (e.g. a GitHub
+   *  Pages URL) — distinct from whatever local `view`/export a machine
+   *  happens to be looking at. Drives the viewer header's "team constellation"
+   *  link (viz/src/routes/Root.tsx). */
+  pagesUrl: string | null;
 }
 
 /** Best-effort git introspection for the live `view` server: the current HEAD
  *  sha + a guessed web URL for `origin` (github.com only; other hosts degrade
- *  to null rather than guessing wrong). Never throws — any git failure (not a
- *  repo, no origin, git missing) yields nulls so the badge just doesn't render.
- *  Computed ONCE at server start (not per-request) since it shells out to git. */
+ *  to null rather than guessing wrong), plus `[team] pages_url` from
+ *  config.toml. Never throws — any failure (not a repo, no origin, git
+ *  missing, no config.toml) yields nulls so the affected UI just doesn't
+ *  render. Computed ONCE at server start (not per-request) since it shells
+ *  out to git. */
 export function resolveServerRepoMeta(repoPath: string): RepoBakeMeta {
   const git = (args: string[]): string | null => {
     try {
@@ -105,7 +114,8 @@ export function resolveServerRepoMeta(repoPath: string): RepoBakeMeta {
   const commitSha = git(["rev-parse", "HEAD"]);
   const remote = git(["remote", "get-url", "origin"]);
   const repoUrl = remote ? githubHttpsUrl(remote) : null;
-  return { commitSha, builtAt: new Date().toISOString(), repoUrl };
+  const pagesUrl = readTeamPagesUrl(repoPath);
+  return { commitSha, builtAt: new Date().toISOString(), repoUrl, pagesUrl };
 }
 
 /** Normalizes a git remote URL (https or ssh form) to an https://github.com/...
@@ -329,6 +339,10 @@ export interface ExportBakeOptions {
   commitSha?: string | null;
   repoUrl?: string | null;
   builtAt?: string | null;
+  /** `[team] pages_url`; defaults to reading `.reposkein/config.toml` at
+   *  export time when omitted (same source resolveServerRepoMeta uses in
+   *  server mode) — pass explicitly only to override or pin it. */
+  pagesUrl?: string | null;
   /** Bake size-capped per-node source slices (design: optional, flag-gated). */
   withSource?: boolean;
   /** Byte cap for baked source slices; only consulted when withSource is true. */
@@ -350,6 +364,7 @@ export function parseViewArgs(argv: string[]): {
   let commitSha: string | null = null;
   let repoUrl: string | null = null;
   let builtAt: string | null = null;
+  let pagesUrl: string | undefined;
   let withSource = false;
   let sourceMaxBytes: number | undefined;
   const positional: string[] = [];
@@ -368,6 +383,8 @@ export function parseViewArgs(argv: string[]): {
     else if (a.startsWith("--repo-url=")) repoUrl = a.slice(11);
     else if (a === "--built-at") builtAt = argv[++i] ?? null;
     else if (a.startsWith("--built-at=")) builtAt = a.slice(11);
+    else if (a === "--pages-url") pagesUrl = argv[++i];
+    else if (a.startsWith("--pages-url=")) pagesUrl = a.slice(12);
     else if (a === "--with-source") {
       withSource = true;
       // Optional numeric byte-cap as the next bare token (e.g. `--with-source 500000`).
@@ -384,6 +401,7 @@ export function parseViewArgs(argv: string[]): {
     commitSha: commitSha ?? process.env.REPOSKEIN_COMMIT_SHA ?? null,
     repoUrl: repoUrl ?? process.env.REPOSKEIN_REPO_URL ?? null,
     builtAt,
+    pagesUrl: pagesUrl ?? process.env.REPOSKEIN_PAGES_URL, // undefined -> runExport reads config.toml itself
     withSource,
     sourceMaxBytes,
   };
@@ -453,7 +471,7 @@ export function buildGraphDataJs(
       nodesText: f.nodesText,
       edgesText: f.edgesText,
     })),
-    meta: extra.meta ?? { commitSha: null, builtAt: null, repoUrl: null },
+    meta: extra.meta ?? { commitSha: null, builtAt: null, repoUrl: null, pagesUrl: null },
     cochange: extra.cochange ?? {},
     ...(extra.sourceSlices ? { sourceSlices: extra.sourceSlices } : {}),
   };
@@ -525,6 +543,7 @@ export async function runExport(
       commitSha: bake.commitSha ?? null,
       repoUrl: bake.repoUrl ?? null,
       builtAt: bake.builtAt ?? new Date().toISOString(),
+      pagesUrl: bake.pagesUrl !== undefined ? bake.pagesUrl : readTeamPagesUrl(repoPath),
     };
 
     // Temporal co-change data: the SAME code path /api/temporal uses, called

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { pathToFileURL } from "node:url";
 import { runInit, runIndex } from "./cli/init.js";
+import { parseAgentsFlag } from "./cli/agentAdapters.js";
 import { runDoctor, resolveDoctorRepoPath } from "./cli/doctor.js";
 import { runAdr } from "./cli/adr.js";
 import { runView, runExport, parseViewArgs } from "./cli/view.js";
@@ -71,9 +72,9 @@ const HELP_TEXT = `reposkein-mcp — deterministic code-graph MCP server
 
 Usage:
   reposkein-mcp                 start the MCP server (stdio transport)
-  reposkein-mcp init [path]     set up a repo (indexer, git hooks, skill, graph); --no-index skips the initial index, --ci also writes a GitHub Pages publish workflow (see docs/HOSTING.md)
+  reposkein-mcp init [path]     set up a repo (indexer, git hooks, skill, graph); --no-index skips the initial index, --ci also writes a GitHub Pages publish workflow (see docs/HOSTING.md). On a repo joined from a committed .reposkein/meta.json, also auto-writes local agent MCP config (--agents claude,opencode,cursor to override detection, --dry-run to preview)
   reposkein-mcp index [path]    (re)build the committed graph
-  reposkein-mcp doctor [path]   health check (indexer binary, index, repo id)
+  reposkein-mcp doctor [path]   health check (indexer binary, index, repo id, hooks, graph freshness); --json for machine output, --ci additionally fails on stale graph / missing hooks / unsplit legacy summaries
   reposkein-mcp adr <sub> ...   decision-log utilities
   reposkein-mcp stats [path]    session usage report (calls, tokens saved vs grep)
   reposkein-mcp view [path]     open the constellation viewer (--export <dir> for a static site)
@@ -571,8 +572,11 @@ if (invokedAsBin()) {
     const rest = process.argv.slice(3);
     const noIndex = rest.includes("--no-index");
     const ci = rest.includes("--ci");
-    const path = rest.find((a) => !a.startsWith("-")) ?? ".";
-    runInit(path, { index: !noIndex, ci })
+    const dryRun = rest.includes("--dry-run");
+    const agentsIdx = rest.indexOf("--agents");
+    const agents = agentsIdx !== -1 ? parseAgentsFlag(rest[agentsIdx + 1] ?? "") : undefined;
+    const path = rest.find((a, i) => !a.startsWith("-") && rest[i - 1] !== "--agents") ?? ".";
+    runInit(path, { index: !noIndex, ci, dryRun, agents })
       .then((code) => process.exit(code))
       .catch((err) => { console.error(err); process.exit(1); });
   } else if (sub === "index") {
@@ -583,13 +587,14 @@ if (invokedAsBin()) {
   } else if (sub === "doctor") {
     const rest = process.argv.slice(3);
     const json = rest.includes("--json");
+    const ci = rest.includes("--ci");
     const explicitPath = rest.find((a) => !a.startsWith("-"));
     const { path, error } = resolveDoctorRepoPath(explicitPath, process.cwd(), process.env.REPOSKEIN_REPO_PATH);
     if (error) {
       console.error(`reposkein doctor: ${error}`);
       process.exit(1);
     }
-    runDoctor(path, json)
+    runDoctor(path, { json, ci })
       .then((code) => process.exit(code))
       .catch((err) => { console.error(err); process.exit(1); });
   } else if (sub === "stats") {

--- a/mcp/src/indexer/fetchBinary.ts
+++ b/mcp/src/indexer/fetchBinary.ts
@@ -1,8 +1,9 @@
 import { createWriteStream, existsSync, mkdirSync, chmodSync, statSync, readFileSync, unlinkSync, renameSync } from "node:fs";
 import { createHash, randomBytes } from "node:crypto";
-import { get } from "node:https";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { pipeline } from "node:stream/promises";
+import { request, EnvHttpProxyAgent, type Dispatcher } from "undici";
 
 /** Supported platform keys → must match the release asset suffixes (D2).
  *  Intel macOS (darwin-x64) is intentionally unsupported: all Macs have shipped
@@ -34,6 +35,62 @@ export function platformKey(
 
 export function isWindows(platform: string = process.platform): boolean {
   return platform === "win32";
+}
+
+/** Whether this host has a prebuilt indexer release asset. Convenience
+ *  wrapper over `platformKey()` for call sites that just need a boolean
+ *  (e.g. `init`'s pre-flight check, before attempting any fetch). */
+export function isSupportedPlatform(
+  platform: string = process.platform,
+  arch: string = process.arch
+): boolean {
+  return platformKey(platform, arch) !== null;
+}
+
+/** Printed when a host has no prebuilt indexer (darwin-x64, win32-arm64, …):
+ *  the from-source fallback plus the offline override env var, so `init` can
+ *  continue (write agent config, skip only the binary-dependent steps)
+ *  instead of crashing. See docs/INSTALL.md §2 "Platform support". */
+export function cargoInstallFallbackMessage(
+  platform: string = process.platform,
+  arch: string = process.arch
+): string {
+  return (
+    `reposkein: no prebuilt indexer for ${platform}-${arch}. Build from source:\n` +
+    "  git clone https://github.com/reposkein/reposkein.git && cd reposkein\n" +
+    "  cargo install --path indexer/crates/cli --root ./cargo-out\n" +
+    "  export REPOSKEIN_INDEXER_BIN=$PWD/cargo-out/bin/reposkein-indexer\n" +
+    "Then re-run `reposkein-mcp init` (or `doctor`/`index`) with that env var set — " +
+    "REPOSKEIN_INDEXER_BIN is also the offline fallback on supported platforms " +
+    "when the GitHub Releases fetch is unreachable."
+  );
+}
+
+/** Reads HTTP(S)_PROXY / NO_PROXY (either case) via undici's
+ *  `EnvHttpProxyAgent` — the standard way to proxy `undici.request()` once
+ *  undici is a direct dependency (the global `fetch`'s own undici instance
+ *  isn't importable to attach a dispatcher to). Returns `undefined` (use
+ *  undici's default, non-proxying dispatcher) when no proxy env var is set,
+ *  so the common case pays zero extra cost. Cached per-process — proxy env
+ *  vars don't change mid-run. */
+let _proxyDispatcher: Dispatcher | null | undefined;
+
+export function proxyDispatcher(): Dispatcher | undefined {
+  if (_proxyDispatcher !== undefined) return _proxyDispatcher ?? undefined;
+  const hasProxyEnv = !!(
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy
+  );
+  _proxyDispatcher = hasProxyEnv ? new EnvHttpProxyAgent() : null;
+  return _proxyDispatcher ?? undefined;
+}
+
+/** For testing only: reset the cached proxy dispatcher so env var changes
+ *  take effect on the next call. */
+export function _resetProxyDispatcherCache(): void {
+  _proxyDispatcher = undefined;
 }
 
 /** Release asset name for a platform key, e.g. reposkein-indexer-darwin-arm64. */
@@ -108,47 +165,45 @@ export function verifyDigest(tempPath: string, expected: string | null): void {
 
 /** Follows redirects (GitHub release assets redirect to a CDN) and streams the
  *  body to `dest`. Rejects on non-2xx (after redirects) or network error.
- *  Redirect hardening: only follows https:// redirects to github.com or *.githubusercontent.com. */
-function downloadTo(url: string, dest: string, redirects = 5): Promise<void> {
-  return new Promise((resolve, reject) => {
-    get(url, (res) => {
-      const status = res.statusCode ?? 0;
-      if (status >= 300 && status < 400 && res.headers.location) {
-        if (redirects <= 0) {
-          reject(new Error("too many redirects"));
-          return;
-        }
-        const location = res.headers.location;
-        const next = new URL(location, url);
-        if (next.protocol !== "https:") {
-          reject(new Error(`reposkein: redirect to non-https URL rejected: ${next.href}`));
-          return;
-        }
-        const host = next.hostname;
-        if (
-          host !== "github.com" &&
-          host !== "objects.githubusercontent.com" &&
-          !host.endsWith(".githubusercontent.com")
-        ) {
-          reject(new Error(`reposkein: redirect to non-allowlisted host rejected: ${host}`));
-          return;
-        }
-        res.resume();
-        downloadTo(next.href, dest, redirects - 1).then(resolve, reject);
-        return;
-      }
-      if (status !== 200) {
-        res.resume();
-        reject(new Error(`download failed: HTTP ${status} for ${url}`));
-        return;
-      }
-      mkdirSync(dirname(dest), { recursive: true });
-      const file = createWriteStream(dest);
-      res.pipe(file);
-      file.on("finish", () => file.close(() => resolve()));
-      file.on("error", reject);
-    }).on("error", reject);
-  });
+ *  Redirect hardening: only follows https:// redirects to github.com or
+ *  *.githubusercontent.com.
+ *
+ *  Uses undici's `request()` (not node:https) so a `proxyDispatcher()` can be
+ *  attached — that's the only way to honor HTTPS_PROXY/NO_PROXY for this
+ *  fetch, since the global `fetch()`'s own undici instance isn't reachable to
+ *  set a dispatcher on. `request()` never auto-follows redirects (no redirect
+ *  interceptor configured), so they're handled manually below to keep the
+ *  host allowlist in the loop. */
+async function downloadTo(url: string, dest: string, redirects = 5): Promise<void> {
+  const res = await request(url, { dispatcher: proxyDispatcher() });
+  const status = res.statusCode;
+  if (status >= 300 && status < 400 && res.headers.location) {
+    await res.body.dump().catch(() => {});
+    if (redirects <= 0) {
+      throw new Error("too many redirects");
+    }
+    const locationHeader = res.headers.location;
+    const location = Array.isArray(locationHeader) ? locationHeader[0]! : locationHeader;
+    const next = new URL(location, url);
+    if (next.protocol !== "https:") {
+      throw new Error(`reposkein: redirect to non-https URL rejected: ${next.href}`);
+    }
+    const host = next.hostname;
+    if (
+      host !== "github.com" &&
+      host !== "objects.githubusercontent.com" &&
+      !host.endsWith(".githubusercontent.com")
+    ) {
+      throw new Error(`reposkein: redirect to non-allowlisted host rejected: ${host}`);
+    }
+    return downloadTo(next.href, dest, redirects - 1);
+  }
+  if (status !== 200) {
+    await res.body.dump().catch(() => {});
+    throw new Error(`download failed: HTTP ${status} for ${url}`);
+  }
+  mkdirSync(dirname(dest), { recursive: true });
+  await pipeline(res.body, createWriteStream(dest));
 }
 
 /** Downloads the indexer binary for this host into the package cache, verifies

--- a/mcp/src/store/indexedAt.ts
+++ b/mcp/src/store/indexedAt.ts
@@ -1,0 +1,53 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+/** Path to the file recording the git commit SHA that was HEAD the last time
+ *  the mcp-side index invocation path (`reposkein-mcp index`, or `init`'s
+ *  initial index) completed successfully. Lives under `.reposkein/local/` —
+ *  per-machine scratch that's gitignored and never committed — so it never
+ *  survives a `git clone`. That's deliberate: a fresh clone has no idea what
+ *  commit (if any) its nonexistent graph was built from, which is exactly
+ *  the state `doctor --ci`'s `graph_stale` check should fail on. */
+export function indexedAtPath(repoPath: string): string {
+  return join(repoPath, ".reposkein", "local", "indexed-at");
+}
+
+/** Records the current git HEAD as "the commit the graph was just built
+ *  from". Best-effort and silent: not a git repo / no HEAD yet / a read-only
+ *  filesystem all just skip the write — `graph_stale` degrades to "never
+ *  recorded" (fails, conservatively) rather than the index step itself
+ *  failing over a scratch-file write. */
+export function writeIndexedAtMarker(repoPath: string): void {
+  let sha: string;
+  try {
+    sha = execFileSync("git", ["-C", repoPath, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return;
+  }
+  if (!sha) return;
+  try {
+    const path = indexedAtPath(repoPath);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, sha + "\n", "utf8");
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Reads the recorded indexed-at SHA, or null when never recorded — never
+ *  indexed via the mcp-side path, or a fresh clone (local/ isn't committed,
+ *  so it never carries over). */
+export function readIndexedAtSha(repoPath: string): string | null {
+  const path = indexedAtPath(repoPath);
+  if (!existsSync(path)) return null;
+  try {
+    const sha = readFileSync(path, "utf8").trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}

--- a/mcp/src/store/teamConfig.ts
+++ b/mcp/src/store/teamConfig.ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Reads `pages_url` from the `[team]` section of `.reposkein/config.toml`,
+ *  or null when the file/section/key is absent (the common case — this is
+ *  an opt-in field a team adds after publishing a hosted constellation, see
+ *  docs/HOSTING.md). Points the viewer's header at wherever the team's
+ *  canonical/CI-published constellation lives (e.g. a GitHub Pages URL),
+ *  distinct from whatever ad-hoc `view`/`view --export` a given machine
+ *  happens to be looking at right now.
+ *
+ *  A deliberate ~20-line scanner rather than a TOML dependency — mirrors
+ *  `config_bool` in indexer/crates/cli/src/main.rs: this reads exactly one
+ *  setting, and its config is a file `reposkein-indexer init` writes.
+ *  Absent file, section, or key all mean `null`. */
+export function readTeamPagesUrl(repoPath: string): string | null {
+  const path = join(repoPath, ".reposkein", "config.toml");
+  if (!existsSync(path)) return null;
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  let inTeamSection = false;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    if (line.startsWith("[")) {
+      inTeamSection = line === "[team]";
+      continue;
+    }
+    if (!inTeamSection) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    if (key !== "pages_url") continue;
+    const rawValue = line.slice(eq + 1).split("#")[0]!.trim();
+    const quoted = rawValue.match(/^"([^"]*)"$/) ?? rawValue.match(/^'([^']*)'$/);
+    return quoted ? quoted[1]! : null;
+  }
+  return null;
+}

--- a/mcp/test/agentAdapters.test.ts
+++ b/mcp/test/agentAdapters.test.ts
@@ -109,12 +109,61 @@ describe("writeAgentConfigs — .mcp.json (claude, no CLI)", () => {
     expect(results[0]!.action).toBe("unchanged");
   });
 
-  it("recovers from a corrupt existing .mcp.json instead of crashing", () => {
-    writeFileSync(join(dir, ".mcp.json"), "{ not json");
+  it("never rewrites a corrupt existing .mcp.json — backs it up and reports an error instead", () => {
+    const corrupt = "{ not json";
+    writeFileSync(join(dir, ".mcp.json"), corrupt);
     const results = writeAgentConfigs(dir, { agents: ["claude"], exec: noCliExec() });
-    expect(results[0]!.action).toBe("updated");
-    const doc = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf8"));
-    expect(doc.mcpServers.reposkein.command).toBe("reposkein-mcp");
+    const r = results[0]!;
+    expect(r.action).toBe("error");
+    // The never-corrupt constraint: the original file is left exactly as it
+    // was (no reposkein-only doc silently clobbering whatever else was there).
+    expect(readFileSync(join(dir, ".mcp.json"), "utf8")).toBe(corrupt);
+    // Backed up so the (already-corrupt) original isn't lost either.
+    expect(r.backupPath).toBeDefined();
+    expect(existsSync(r.backupPath!)).toBe(true);
+    expect(readFileSync(r.backupPath!, "utf8")).toBe(corrupt);
+    // Actionable message: names the file, the parse problem, and next steps.
+    expect(r.message).toContain(".mcp.json");
+    expect(r.message).toMatch(/fix the json|delete the file/i);
+  });
+
+  it("dry-run on a corrupt existing file reports the error without writing a backup", () => {
+    const corrupt = "{ not json";
+    writeFileSync(join(dir, ".mcp.json"), corrupt);
+    const results = writeAgentConfigs(dir, { agents: ["claude"], dryRun: true, exec: noCliExec() });
+    const r = results[0]!;
+    expect(r.action).toBe("error");
+    expect(r.backupPath).toBeUndefined();
+    expect(readFileSync(join(dir, ".mcp.json"), "utf8")).toBe(corrupt);
+    const filesAfter = readdirSync(dir);
+    expect(filesAfter.filter((f: string) => f.endsWith(".bak")).length).toBe(0);
+  });
+
+  it("continues with other agents when one has a corrupt file (init doesn't abort the whole run)", () => {
+    writeFileSync(join(dir, ".mcp.json"), "{ not json");
+    const results = writeAgentConfigs(dir, { agents: ["claude", "opencode", "cursor"], exec: noCliExec() });
+    const byAgent = new Map(results.map((r) => [r.agent, r]));
+    expect(byAgent.get("claude")!.action).toBe("error");
+    expect(byAgent.get("opencode")!.action).toBe("created");
+    expect(byAgent.get("cursor")!.action).toBe("created");
+    expect(existsSync(join(dir, "opencode.json"))).toBe(true);
+    expect(existsSync(join(dir, ".cursor", "mcp.json"))).toBe(true);
+  });
+});
+
+describe("writeAgentConfigs — stale entry + --dry-run leaves no backup", () => {
+  it("an existing, different reposkein entry under --dry-run reports 'dry-run' and creates no .bak", () => {
+    writeFileSync(
+      join(dir, ".mcp.json"),
+      JSON.stringify({ mcpServers: { reposkein: { command: "reposkein-mcp", env: { REPOSKEIN_REPO_PATH: "/stale/path" } } } }, null, 2),
+    );
+    const before = readFileSync(join(dir, ".mcp.json"), "utf8");
+    const results = writeAgentConfigs(dir, { agents: ["claude"], dryRun: true, exec: noCliExec() });
+    expect(results[0]!.action).toBe("dry-run");
+    expect(results[0]!.backupPath).toBeUndefined();
+    expect(readFileSync(join(dir, ".mcp.json"), "utf8")).toBe(before); // untouched
+    const filesAfter = readdirSync(dir);
+    expect(filesAfter.filter((f: string) => f.endsWith(".bak")).length).toBe(0);
   });
 });
 

--- a/mcp/test/agentAdapters.test.ts
+++ b/mcp/test/agentAdapters.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  detectAgents,
+  parseAgentsFlag,
+  writeAgentConfigs,
+  formatAdapterResult,
+  type Exec,
+  type ExecResult,
+  type AdapterResult,
+} from "../src/cli/agentAdapters.js";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "rs-agents-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+/** No CLI ever "available" — forces every adapter down its direct-file-write
+ *  path, so tests don't depend on what's installed on the machine running
+ *  them. */
+function noCliExec(overrides: Partial<Record<string, ExecResult>> = {}): Exec {
+  return (cmd) => overrides[cmd] ?? { status: 1, stdout: "", stderr: "not found" };
+}
+
+describe("parseAgentsFlag", () => {
+  it("parses a comma-separated list", () => {
+    expect(parseAgentsFlag("claude,cursor")).toEqual(["claude", "cursor"]);
+  });
+  it("parses space-separated and mixed case", () => {
+    expect(parseAgentsFlag("Claude Opencode")).toEqual(["claude", "opencode"]);
+  });
+  it("drops unknown tokens instead of throwing", () => {
+    expect(parseAgentsFlag("claude,bogus,cursor")).toEqual(["claude", "cursor"]);
+  });
+});
+
+describe("detectAgents", () => {
+  it("falls back to ['claude'] (generic .mcp.json) when nothing is detected", () => {
+    expect(detectAgents(dir, noCliExec())).toEqual(["claude"]);
+  });
+  it("detects an existing .mcp.json even without the claude CLI", () => {
+    writeFileSync(join(dir, ".mcp.json"), "{}");
+    expect(detectAgents(dir, noCliExec())).toContain("claude");
+  });
+  it("detects opencode.json and .cursor/ independently", () => {
+    writeFileSync(join(dir, "opencode.json"), "{}");
+    mkdirSync(join(dir, ".cursor"));
+    const agents = detectAgents(dir, noCliExec());
+    expect(agents).toContain("opencode");
+    expect(agents).toContain("cursor");
+  });
+  it("detects the claude CLI on PATH", () => {
+    const exec = noCliExec({ claude: { status: 0, stdout: "1.0.0", stderr: "" } });
+    expect(detectAgents(dir, exec)).toContain("claude");
+  });
+});
+
+describe("writeAgentConfigs — .mcp.json (claude, no CLI)", () => {
+  it("creates .mcp.json with mcpServers.reposkein on first run", () => {
+    const results = writeAgentConfigs(dir, { agents: ["claude"], exec: noCliExec() });
+    expect(results).toHaveLength(1);
+    const r = results[0]!;
+    expect(r.action).toBe("created");
+    expect(existsSync(join(dir, ".mcp.json"))).toBe(true);
+    const doc = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf8"));
+    expect(doc.mcpServers.reposkein.command).toBe("reposkein-mcp");
+    expect(doc.mcpServers.reposkein.env.REPOSKEIN_REPO_PATH).toBe(resolve(dir));
+  });
+
+  it("is idempotent: a second run reports unchanged and writes nothing new", () => {
+    writeAgentConfigs(dir, { agents: ["claude"], exec: noCliExec() });
+    const before = readFileSync(join(dir, ".mcp.json"), "utf8");
+    const second = writeAgentConfigs(dir, { agents: ["claude"], exec: noCliExec() });
+    expect(second[0]!.action).toBe("unchanged");
+    expect(second[0]!.backupPath).toBeUndefined();
+    expect(readFileSync(join(dir, ".mcp.json"), "utf8")).toBe(before);
+    // No duplicate entries / no stray backup files.
+    const filesAfter = readdirSync(dir);
+    expect(filesAfter.filter((f: string) => f.startsWith(".mcp.json")).length).toBe(1);
+  });
+
+  it("preserves other keys and other mcpServers entries when updating", () => {
+    writeFileSync(
+      join(dir, ".mcp.json"),
+      JSON.stringify({ $schema: "x", mcpServers: { other: { command: "y" } } }, null, 2)
+    );
+    const before = readFileSync(join(dir, ".mcp.json"), "utf8");
+    const results = writeAgentConfigs(dir, { agents: ["claude"], exec: noCliExec() });
+    expect(results[0]!.action).toBe("updated");
+    expect(results[0]!.backupPath).toBeDefined();
+    expect(existsSync(results[0]!.backupPath!)).toBe(true);
+    expect(readFileSync(results[0]!.backupPath!, "utf8")).toBe(before);
+    const doc = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf8"));
+    expect(doc.$schema).toBe("x");
+    expect(doc.mcpServers.other.command).toBe("y");
+    expect(doc.mcpServers.reposkein.command).toBe("reposkein-mcp");
+  });
+
+  it("dry-run never touches disk", () => {
+    const results = writeAgentConfigs(dir, { agents: ["claude"], dryRun: true, exec: noCliExec() });
+    expect(results[0]!.action).toBe("dry-run");
+    expect(existsSync(join(dir, ".mcp.json"))).toBe(false);
+  });
+
+  it("dry-run on an already-configured file reports unchanged, not dry-run", () => {
+    writeAgentConfigs(dir, { agents: ["claude"], exec: noCliExec() });
+    const results = writeAgentConfigs(dir, { agents: ["claude"], dryRun: true, exec: noCliExec() });
+    expect(results[0]!.action).toBe("unchanged");
+  });
+
+  it("recovers from a corrupt existing .mcp.json instead of crashing", () => {
+    writeFileSync(join(dir, ".mcp.json"), "{ not json");
+    const results = writeAgentConfigs(dir, { agents: ["claude"], exec: noCliExec() });
+    expect(results[0]!.action).toBe("updated");
+    const doc = JSON.parse(readFileSync(join(dir, ".mcp.json"), "utf8"));
+    expect(doc.mcpServers.reposkein.command).toBe("reposkein-mcp");
+  });
+});
+
+describe("writeAgentConfigs — opencode.json", () => {
+  it("uses the `mcp` (not mcpServers) key with type/command/environment/enabled", () => {
+    const results = writeAgentConfigs(dir, { agents: ["opencode"], exec: noCliExec() });
+    expect(results[0]!.action).toBe("created");
+    const doc = JSON.parse(readFileSync(join(dir, "opencode.json"), "utf8"));
+    expect(doc.mcpServers).toBeUndefined();
+    expect(doc.mcp.reposkein).toEqual({
+      type: "local",
+      command: ["reposkein-mcp"],
+      environment: { REPOSKEIN_REPO_PATH: resolve(dir) },
+      enabled: true,
+    });
+  });
+});
+
+describe("writeAgentConfigs — .cursor/mcp.json", () => {
+  it("writes under .cursor/ with mcpServers, creating the directory", () => {
+    const results = writeAgentConfigs(dir, { agents: ["cursor"], exec: noCliExec() });
+    expect(results[0]!.action).toBe("created");
+    expect(results[0]!.path).toBe(join(dir, ".cursor", "mcp.json"));
+    const doc = JSON.parse(readFileSync(join(dir, ".cursor", "mcp.json"), "utf8"));
+    expect(doc.mcpServers.reposkein.command).toBe("reposkein-mcp");
+  });
+});
+
+describe("writeAgentConfigs — claude CLI path", () => {
+  it("prefers `claude mcp add` when the CLI is available, and is idempotent via `claude mcp get`", () => {
+    const calls: string[][] = [];
+    let entryExists = false;
+    const exec: Exec = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      if (cmd !== "claude") return { status: 1, stdout: "", stderr: "not found" };
+      if (args[0] === "--version") return { status: 0, stdout: "1.0.0", stderr: "" };
+      if (args[0] === "mcp" && args[1] === "get") return { status: entryExists ? 0 : 1, stdout: "", stderr: "" };
+      if (args[0] === "mcp" && args[1] === "add") { entryExists = true; return { status: 0, stdout: "", stderr: "" }; }
+      return { status: 1, stdout: "", stderr: "" };
+    };
+    const first = writeAgentConfigs(dir, { agents: ["claude"], exec });
+    expect(first[0]!.action).toBe("created");
+    expect(calls.some((c) => c[0] === "claude" && c[1] === "mcp" && c[2] === "add")).toBe(true);
+    // No file written directly — the CLI is the one writing .mcp.json.
+    expect(existsSync(join(dir, ".mcp.json"))).toBe(false);
+
+    const second = writeAgentConfigs(dir, { agents: ["claude"], exec });
+    expect(second[0]!.action).toBe("unchanged");
+  });
+
+  it("dry-run prints the planned command and never invokes `mcp add`", () => {
+    const calls: string[][] = [];
+    const exec: Exec = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      if (cmd !== "claude") return { status: 1, stdout: "", stderr: "" };
+      if (args[0] === "--version") return { status: 0, stdout: "1.0.0", stderr: "" };
+      if (args[0] === "mcp" && args[1] === "get") return { status: 1, stdout: "", stderr: "" };
+      return { status: 0, stdout: "", stderr: "" };
+    };
+    const results = writeAgentConfigs(dir, { agents: ["claude"], dryRun: true, exec });
+    expect(results[0]!.action).toBe("dry-run");
+    expect(results[0]!.message).toContain("claude mcp add");
+    expect(calls.some((c) => c[1] === "mcp" && c[2] === "add")).toBe(false);
+  });
+
+  it("surfaces a non-zero `claude mcp add` exit as an error result, not a throw", () => {
+    const exec: Exec = (cmd, args) => {
+      if (cmd !== "claude") return { status: 1, stdout: "", stderr: "" };
+      if (args[0] === "--version") return { status: 0, stdout: "1.0.0", stderr: "" };
+      if (args[0] === "mcp" && args[1] === "get") return { status: 1, stdout: "", stderr: "" };
+      return { status: 1, stdout: "", stderr: "boom" };
+    };
+    const results = writeAgentConfigs(dir, { agents: ["claude"], exec });
+    expect(results[0]!.action).toBe("error");
+    expect(results[0]!.message).toContain("boom");
+  });
+});
+
+describe("writeAgentConfigs — multi-agent + full idempotence sweep", () => {
+  it("running all three agents twice in a row yields unchanged the second time, no duplicate files", () => {
+    const first = writeAgentConfigs(dir, { agents: ["claude", "opencode", "cursor"], exec: noCliExec() });
+    expect(first.every((r) => r.action === "created")).toBe(true);
+    const second = writeAgentConfigs(dir, { agents: ["claude", "opencode", "cursor"], exec: noCliExec() });
+    expect(second.every((r) => r.action === "unchanged")).toBe(true);
+  });
+});
+
+describe("formatAdapterResult", () => {
+  it("renders a readable one-liner including the backup path when present", () => {
+    const r: AdapterResult = { agent: "claude", path: "/x/.mcp.json", action: "updated", backupPath: "/x/.mcp.json.abc.bak", message: "updated .mcp.json" };
+    const line = formatAdapterResult(r);
+    expect(line).toContain("[claude]");
+    expect(line).toContain("updated .mcp.json");
+    expect(line).toContain("/x/.mcp.json.abc.bak");
+  });
+});

--- a/mcp/test/doctor.test.ts
+++ b/mcp/test/doctor.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runChecks, resolveDoctorRepoPath } from "../src/cli/doctor.js";
+import { runChecks, resolveDoctorRepoPath, runDoctor, ciFailingChecks } from "../src/cli/doctor.js";
 import { decisionChecks } from "../src/cli/doctorDecisions.js";
 import { computeBodyHash, writeDecision, decisionsDir, type DecisionRecord } from "../src/store/decisions.js";
 
@@ -145,5 +146,59 @@ describe("doctor decision checks", () => {
     const budget = decisionChecks(dir).find((c) => c.id === "decisions_budget")!;
     expect(budget.ok).toBe(false);
     expect(budget.detail).toMatch(/101/);
+  });
+});
+
+function git(args: string[], cwd = dir): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+describe("doctor --ci exit codes", () => {
+  it("exits 0 without --ci even with non-critical checks failing (hooks missing, no index)", async () => {
+    // No .reposkein/, no .git/hooks — 'indexed' is critical so this repo
+    // fails outright; use an indexed-but-hookless repo to isolate the
+    // ci-only-failure case instead.
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), `{"id":"rs1:r:Function:a.py#f@0"}\n`);
+    const code = await runDoctor(dir, { json: true });
+    expect(code).toBe(0); // hooks_installed is non-critical outside --ci
+  });
+
+  it("exits non-zero under --ci when hooks are missing, even though the repo is otherwise healthy", async () => {
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), `{"id":"rs1:r:Function:a.py#f@0"}\n`);
+    const code = await runDoctor(dir, { json: true, ci: true });
+    expect(code).toBe(1);
+  });
+
+  it("exits 0 under --ci when hooks are installed, the graph is fresh, and there's no legacy summaries.jsonl", async () => {
+    git(["init", "-q"]);
+    git(["config", "user.email", "test@example.com"]);
+    git(["config", "user.name", "test"]);
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "init"]);
+    mkdirSync(join(dir, ".git", "hooks"), { recursive: true });
+    writeFileSync(join(dir, ".git", "hooks", "pre-commit"), "#!/bin/sh\n# reposkein-managed\nexit 0\n");
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), `{"id":"rs1:r:Function:a.py#f@0"}\n`);
+    const code = await runDoctor(dir, { json: true, ci: true });
+    expect(code).toBe(0);
+  });
+
+  it("accepts a bare boolean for `json` (pre-existing call signature)", async () => {
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), `{"id":"rs1:r:Function:a.py#f@0"}\n`);
+    const code = await runDoctor(dir, true);
+    expect(code).toBe(0);
+  });
+
+  it("ciFailingChecks lists only non-ok CI_FAIL_IDS checks", async () => {
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), `{"id":"rs1:r:Function:a.py#f@0"}\n`);
+    const report = await runChecks(dir);
+    const failing = ciFailingChecks(report).map((c) => c.id);
+    expect(failing).toContain("hooks_installed");
+    expect(failing).not.toContain("indexed"); // critical, not a CI_FAIL_IDS member
   });
 });

--- a/mcp/test/doctor.test.ts
+++ b/mcp/test/doctor.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { runChecks, resolveDoctorRepoPath, runDoctor, ciFailingChecks } from "../src/cli/doctor.js";
 import { decisionChecks } from "../src/cli/doctorDecisions.js";
 import { computeBodyHash, writeDecision, decisionsDir, type DecisionRecord } from "../src/store/decisions.js";
+import { writeIndexedAtMarker } from "../src/store/indexedAt.js";
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "rs-doctor-")); });
@@ -182,6 +183,7 @@ describe("doctor --ci exit codes", () => {
     writeFileSync(join(dir, ".git", "hooks", "pre-commit"), "#!/bin/sh\n# reposkein-managed\nexit 0\n");
     mkdirSync(join(dir, ".reposkein"), { recursive: true });
     writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), `{"id":"rs1:r:Function:a.py#f@0"}\n`);
+    writeIndexedAtMarker(dir); // records current HEAD as the indexed-at commit
     const code = await runDoctor(dir, { json: true, ci: true });
     expect(code).toBe(0);
   });

--- a/mcp/test/doctorFreshness.test.ts
+++ b/mcp/test/doctorFreshness.test.ts
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hooksCheck, graphStaleCheck } from "../src/cli/doctorFreshness.js";
-import { writeIndexedAtMarker } from "../src/store/indexedAt.js";
+import { writeIndexedAtMarker, indexedAtPath } from "../src/store/indexedAt.js";
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "rs-freshness-")); });
@@ -184,5 +184,42 @@ describe("graphStaleCheck (content-based: recorded indexed-at SHA vs. HEAD)", ()
     } finally {
       rmSync(cloneDir, { recursive: true, force: true });
     }
+  });
+
+  it("closes the false-fail loop: a hook-maintained marker (no mcp-side index call at all) " +
+     "stays fresh across multiple commits", () => {
+    // Simulates the real hook workflow end-to-end at the doctor layer:
+    // pre-commit indexes the about-to-be-committed tree, post-commit then
+    // writes HEAD (the new commit) to the marker — modeled here by writing
+    // nodes.jsonl + the marker right after each commit, exactly like the
+    // Rust post-commit hook does, without ever calling the mcp-side
+    // `reposkein-mcp index` / `writeIndexedAtMarker` from a *different*
+    // commit's context. Before the hooks existed, this sequence would have
+    // gone stale after the very first commit (pre-commit indexed, nothing
+    // ever advanced the marker) — that's the false-fail loop being closed.
+    initRepo();
+    mkdirSync(join(dir, ".reposkein", "local"), { recursive: true });
+
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit 1"]);
+    // pre-commit's index run + post-commit's marker write, simulated:
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
+    writeFileSync(indexedAtPath(dir), headSha() + "\n");
+    expect(graphStaleCheck(dir).ok).toBe(true);
+
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 2\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit 2"]);
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
+    writeFileSync(indexedAtPath(dir), headSha() + "\n");
+    expect(graphStaleCheck(dir).ok).toBe(true);
+
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 3\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit 3"]);
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
+    writeFileSync(indexedAtPath(dir), headSha() + "\n");
+    expect(graphStaleCheck(dir).ok).toBe(true);
   });
 });

--- a/mcp/test/doctorFreshness.test.ts
+++ b/mcp/test/doctorFreshness.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hooksCheck, graphStaleCheck } from "../src/cli/doctorFreshness.js";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "rs-freshness-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+function git(args: string[], cwd = dir): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function initRepo(): void {
+  git(["init", "-q"]);
+  git(["config", "user.email", "test@example.com"]);
+  git(["config", "user.name", "test"]);
+}
+
+describe("hooksCheck", () => {
+  it("fails when .git/hooks/pre-commit is absent", () => {
+    const c = hooksCheck(dir);
+    expect(c.id).toBe("hooks_installed");
+    expect(c.ok).toBe(false);
+    expect(c.critical).toBe(false);
+    expect(c.detail).toMatch(/no \.git\/hooks\/pre-commit/);
+  });
+
+  it("fails when pre-commit exists but wasn't installed by RepoSkein (no marker)", () => {
+    mkdirSync(join(dir, ".git", "hooks"), { recursive: true });
+    writeFileSync(join(dir, ".git", "hooks", "pre-commit"), "#!/bin/sh\necho hi\n");
+    const c = hooksCheck(dir);
+    expect(c.ok).toBe(false);
+    expect(c.detail).toMatch(/not installed by RepoSkein/);
+  });
+
+  it("passes when the reposkein-managed marker is present", () => {
+    mkdirSync(join(dir, ".git", "hooks"), { recursive: true });
+    writeFileSync(join(dir, ".git", "hooks", "pre-commit"), "#!/bin/sh\n# reposkein-managed\nexit 0\n");
+    const c = hooksCheck(dir);
+    expect(c.ok).toBe(true);
+  });
+});
+
+describe("graphStaleCheck", () => {
+  it("fails (not stale-flavored) when nodes.jsonl is entirely missing", () => {
+    const c = graphStaleCheck(dir);
+    expect(c.id).toBe("graph_stale");
+    expect(c.ok).toBe(false);
+    expect(c.detail).toMatch(/never indexed/);
+  });
+
+  it("skips cleanly (ok) when there's no git history to compare against", () => {
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
+    const c = graphStaleCheck(dir);
+    expect(c.ok).toBe(true);
+    expect(c.detail).toMatch(/no git history/);
+  });
+
+  it("flags nodes.jsonl older than the last relevant commit as stale", () => {
+    initRepo();
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "add a.py"]);
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    const nodesPath = join(dir, ".reposkein", "nodes.jsonl");
+    writeFileSync(nodesPath, "{}\n");
+    // Backdate the graph file well before the commit above.
+    const old = new Date(Date.now() - 60 * 60 * 1000);
+    utimesSync(nodesPath, old, old);
+    const c = graphStaleCheck(dir);
+    expect(c.ok).toBe(false);
+    expect(c.detail).toMatch(/older than the last commit/);
+    expect(c.fix).toMatch(/reposkein-mcp index/);
+  });
+
+  it("passes when nodes.jsonl is newer than the last relevant commit", () => {
+    initRepo();
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "add a.py"]);
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n"); // written just now
+    const c = graphStaleCheck(dir);
+    expect(c.ok).toBe(true);
+  });
+
+  it("a commit touching only .reposkein/ (e.g. a summary) doesn't mark the graph stale", () => {
+    initRepo();
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "add a.py"]);
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
+    const c1 = graphStaleCheck(dir);
+    expect(c1.ok).toBe(true);
+    // A later commit that only touches .reposkein/ shouldn't retroactively
+    // make the (unchanged, still-fresh) graph read as stale.
+    writeFileSync(join(dir, ".reposkein", "summaries.jsonl"), "{}\n");
+    git(["add", ".reposkein/summaries.jsonl"]);
+    git(["commit", "-qm", "agent summary"]);
+    const c2 = graphStaleCheck(dir);
+    expect(c2.ok).toBe(true);
+  });
+});

--- a/mcp/test/doctorFreshness.test.ts
+++ b/mcp/test/doctorFreshness.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hooksCheck, graphStaleCheck } from "../src/cli/doctorFreshness.js";
+import { writeIndexedAtMarker } from "../src/store/indexedAt.js";
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "rs-freshness-")); });
@@ -13,10 +14,14 @@ function git(args: string[], cwd = dir): void {
   execFileSync("git", args, { cwd, stdio: "ignore" });
 }
 
-function initRepo(): void {
-  git(["init", "-q"]);
-  git(["config", "user.email", "test@example.com"]);
-  git(["config", "user.name", "test"]);
+function initRepo(cwd = dir): void {
+  git(["init", "-q"], cwd);
+  git(["config", "user.email", "test@example.com"], cwd);
+  git(["config", "user.name", "test"], cwd);
+}
+
+function headSha(cwd = dir): string {
+  return execFileSync("git", ["-C", cwd, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
 }
 
 describe("hooksCheck", () => {
@@ -44,65 +49,140 @@ describe("hooksCheck", () => {
   });
 });
 
-describe("graphStaleCheck", () => {
-  it("fails (not stale-flavored) when nodes.jsonl is entirely missing", () => {
+describe("graphStaleCheck (content-based: recorded indexed-at SHA vs. HEAD)", () => {
+  it("fails (never-indexed flavor) when nodes.jsonl is entirely missing", () => {
     const c = graphStaleCheck(dir);
     expect(c.id).toBe("graph_stale");
     expect(c.ok).toBe(false);
     expect(c.detail).toMatch(/never indexed/);
   });
 
-  it("skips cleanly (ok) when there's no git history to compare against", () => {
+  it("fails when nodes.jsonl exists but no indexed-at SHA was ever recorded", () => {
     mkdirSync(join(dir, ".reposkein"), { recursive: true });
     writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
     const c = graphStaleCheck(dir);
-    expect(c.ok).toBe(true);
-    expect(c.detail).toMatch(/no git history/);
-  });
-
-  it("flags nodes.jsonl older than the last relevant commit as stale", () => {
-    initRepo();
-    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
-    git(["add", "a.py"]);
-    git(["commit", "-qm", "add a.py"]);
-    mkdirSync(join(dir, ".reposkein"), { recursive: true });
-    const nodesPath = join(dir, ".reposkein", "nodes.jsonl");
-    writeFileSync(nodesPath, "{}\n");
-    // Backdate the graph file well before the commit above.
-    const old = new Date(Date.now() - 60 * 60 * 1000);
-    utimesSync(nodesPath, old, old);
-    const c = graphStaleCheck(dir);
     expect(c.ok).toBe(false);
-    expect(c.detail).toMatch(/older than the last commit/);
+    expect(c.detail).toMatch(/no recorded indexed-at commit/);
     expect(c.fix).toMatch(/reposkein-mcp index/);
   });
 
-  it("passes when nodes.jsonl is newer than the last relevant commit", () => {
-    initRepo();
-    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
-    git(["add", "a.py"]);
-    git(["commit", "-qm", "add a.py"]);
+  it("skips cleanly (ok) when there's no git HEAD to compare against, even with a recorded SHA", () => {
+    // No git repo at all: writeIndexedAtMarker itself is a no-op (best-effort),
+    // so simulate a stray/manually-copied marker file instead.
+    mkdirSync(join(dir, ".reposkein", "local"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "local", "indexed-at"), "deadbeef\n");
     mkdirSync(join(dir, ".reposkein"), { recursive: true });
-    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n"); // written just now
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
     const c = graphStaleCheck(dir);
     expect(c.ok).toBe(true);
+    expect(c.detail).toMatch(/no git HEAD/);
   });
 
-  it("a commit touching only .reposkein/ (e.g. a summary) doesn't mark the graph stale", () => {
+  it("passes when the recorded SHA matches current HEAD", () => {
     initRepo();
     writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
     git(["add", "a.py"]);
     git(["commit", "-qm", "add a.py"]);
     mkdirSync(join(dir, ".reposkein"), { recursive: true });
     writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
-    const c1 = graphStaleCheck(dir);
-    expect(c1.ok).toBe(true);
-    // A later commit that only touches .reposkein/ shouldn't retroactively
-    // make the (unchanged, still-fresh) graph read as stale.
-    writeFileSync(join(dir, ".reposkein", "summaries.jsonl"), "{}\n");
-    git(["add", ".reposkein/summaries.jsonl"]);
-    git(["commit", "-qm", "agent summary"]);
-    const c2 = graphStaleCheck(dir);
-    expect(c2.ok).toBe(true);
+    writeIndexedAtMarker(dir);
+    const c = graphStaleCheck(dir);
+    expect(c.ok).toBe(true);
+    expect(c.detail).toContain(headSha().slice(0, 7));
+  });
+
+  it("fails when the recorded SHA no longer matches HEAD (commits landed since the last index)", () => {
+    initRepo();
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit A"]);
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
+    writeIndexedAtMarker(dir); // records commit A
+    const shaA = headSha();
+
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 2\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit B"]);
+    const shaB = headSha();
+    expect(shaB).not.toBe(shaA);
+
+    const c = graphStaleCheck(dir);
+    expect(c.ok).toBe(false);
+    expect(c.detail).toContain(shaA.slice(0, 7));
+    expect(c.detail).toContain(shaB.slice(0, 7));
+    expect(c.fix).toMatch(/reposkein-mcp index/);
+  });
+
+  it("reviewer repro: index at commit A, advance to commit B, clone fresh -> doctor --ci FAILS " +
+     "(the mtime heuristic this replaced could not catch this: a fresh checkout stamps every " +
+     "file with 'now', which is always >= any past commit's timestamp)", () => {
+    // Origin repo: commit A, indexed at A.
+    initRepo();
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit A"]);
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
+    writeIndexedAtMarker(dir);
+    const shaA = headSha();
+
+    // Advance to commit B — a real code change after the last index.
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 2\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit B"]);
+    const shaB = headSha();
+    expect(shaB).not.toBe(shaA);
+
+    // A REAL `git clone` of the origin. .reposkein/ was never committed (it's
+    // gitignored scratch/derived output), so the clone starts with none of it —
+    // this is the realistic shape of "a teammate/CI clones this repo".
+    const cloneDir = mkdtempSync(join(tmpdir(), "rs-freshness-clone-"));
+    try {
+      execFileSync("git", ["clone", "-q", dir, cloneDir]);
+      expect(headSha(cloneDir)).toBe(shaB);
+
+      // Simulate the realistic "stale index carried forward" failure mode
+      // (a CI cache restoring a prior run's .reposkein/, a copied artifact,
+      // etc.): the fresh clone ends up with nodes.jsonl + the OLD indexed-at
+      // marker (from commit A) written into it — necessarily with a mtime of
+      // "now", i.e. well after commit B. This is exactly the case where the
+      // old mtime-based check would have read as fresh (mtime "now" >=
+      // lastCommitMs) despite the graph being genuinely stale.
+      mkdirSync(join(cloneDir, ".reposkein", "local"), { recursive: true });
+      writeFileSync(join(cloneDir, ".reposkein", "nodes.jsonl"), "{}\n");
+      writeFileSync(join(cloneDir, ".reposkein", "local", "indexed-at"), shaA + "\n");
+
+      const c = graphStaleCheck(cloneDir);
+      expect(c.ok).toBe(false);
+      expect(c.detail).toContain(shaA.slice(0, 7));
+      expect(c.detail).toContain(shaB.slice(0, 7));
+    } finally {
+      rmSync(cloneDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reviewer repro (simplest form): a bare fresh clone with no .reposkein/ at all also fails", () => {
+    initRepo();
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit A"]);
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "{}\n");
+    writeIndexedAtMarker(dir);
+
+    writeFileSync(join(dir, "a.py"), "def f():\n    return 2\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit B"]);
+
+    const cloneDir = mkdtempSync(join(tmpdir(), "rs-freshness-clone-"));
+    try {
+      execFileSync("git", ["clone", "-q", dir, cloneDir]);
+      const c = graphStaleCheck(cloneDir);
+      expect(c.ok).toBe(false);
+      expect(c.detail).toMatch(/never indexed/);
+    } finally {
+      rmSync(cloneDir, { recursive: true, force: true });
+    }
   });
 });

--- a/mcp/test/fetchBinary.test.ts
+++ b/mcp/test/fetchBinary.test.ts
@@ -3,6 +3,7 @@ import { writeFileSync, unlinkSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createHash, randomBytes } from "node:crypto";
+import { EnvHttpProxyAgent } from "undici";
 import {
   platformKey,
   assetName,
@@ -13,6 +14,10 @@ import {
   verifyDigest,
   packageRoot,
   _resetDigestCache,
+  isSupportedPlatform,
+  cargoInstallFallbackMessage,
+  proxyDispatcher,
+  _resetProxyDispatcherCache,
 } from "../src/indexer/fetchBinary.js";
 
 describe("fetchBinary mapping", () => {
@@ -35,6 +40,74 @@ describe("fetchBinary mapping", () => {
     expect(releaseUrl("1.2.3", "linux-x64")).toBe(
       "https://github.com/reposkein/reposkein/releases/download/v1.2.3/reposkein-indexer-linux-x64"
     );
+  });
+});
+
+describe("isSupportedPlatform / cargoInstallFallbackMessage", () => {
+  it("matches platformKey's supported set", () => {
+    expect(isSupportedPlatform("darwin", "arm64")).toBe(true);
+    expect(isSupportedPlatform("linux", "x64")).toBe(true);
+    expect(isSupportedPlatform("darwin", "x64")).toBe(false);
+    expect(isSupportedPlatform("win32", "arm64")).toBe(false);
+  });
+  it("cargo-install fallback message names the platform, cargo, and REPOSKEIN_INDEXER_BIN", () => {
+    const msg = cargoInstallFallbackMessage("darwin", "x64");
+    expect(msg).toContain("darwin-x64");
+    expect(msg).toMatch(/cargo install/);
+    expect(msg).toContain("REPOSKEIN_INDEXER_BIN");
+  });
+});
+
+describe("proxyDispatcher", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const PROXY_KEYS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"];
+  beforeEach(() => {
+    for (const k of PROXY_KEYS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    _resetProxyDispatcherCache();
+  });
+  afterEach(() => {
+    for (const k of PROXY_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    _resetProxyDispatcherCache();
+  });
+
+  it("returns undefined (no dispatcher) when no proxy env var is set", () => {
+    expect(proxyDispatcher()).toBeUndefined();
+  });
+
+  it("returns an EnvHttpProxyAgent when HTTPS_PROXY is set", () => {
+    process.env.HTTPS_PROXY = "http://proxy.local:8080";
+    _resetProxyDispatcherCache();
+    const d = proxyDispatcher();
+    expect(d).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("also honors lowercase http_proxy", () => {
+    process.env.http_proxy = "http://proxy.local:8080";
+    _resetProxyDispatcherCache();
+    expect(proxyDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+  });
+
+  it("caches the dispatcher across calls within a process", () => {
+    process.env.HTTPS_PROXY = "http://proxy.local:8080";
+    _resetProxyDispatcherCache();
+    const first = proxyDispatcher();
+    const second = proxyDispatcher();
+    expect(first).toBe(second);
+  });
+
+  it("_resetProxyDispatcherCache lets a changed env var take effect", () => {
+    expect(proxyDispatcher()).toBeUndefined();
+    process.env.HTTPS_PROXY = "http://proxy.local:8080";
+    // Without reset, the cached "no proxy" (undefined) sticks.
+    expect(proxyDispatcher()).toBeUndefined();
+    _resetProxyDispatcherCache();
+    expect(proxyDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
   });
 });
 

--- a/mcp/test/indexedAt.test.ts
+++ b/mcp/test/indexedAt.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { indexedAtPath, writeIndexedAtMarker, readIndexedAtSha } from "../src/store/indexedAt.js";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "rs-indexedat-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+function git(args: string[]): void {
+  execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+}
+
+describe("indexedAtPath", () => {
+  it("points at .reposkein/local/indexed-at", () => {
+    expect(indexedAtPath(dir)).toBe(join(dir, ".reposkein", "local", "indexed-at"));
+  });
+});
+
+describe("readIndexedAtSha", () => {
+  it("returns null when never recorded", () => {
+    expect(readIndexedAtSha(dir)).toBeNull();
+  });
+
+  it("returns null for a blank file", () => {
+    mkdirSync(join(dir, ".reposkein", "local"), { recursive: true });
+    writeFileSync(indexedAtPath(dir), "   \n");
+    expect(readIndexedAtSha(dir)).toBeNull();
+  });
+
+  it("reads a recorded SHA, trimmed", () => {
+    mkdirSync(join(dir, ".reposkein", "local"), { recursive: true });
+    writeFileSync(indexedAtPath(dir), "abc123\n");
+    expect(readIndexedAtSha(dir)).toBe("abc123");
+  });
+});
+
+describe("writeIndexedAtMarker", () => {
+  it("records the current git HEAD", () => {
+    git(["init", "-q"]);
+    git(["config", "user.email", "t@example.com"]);
+    git(["config", "user.name", "t"]);
+    writeFileSync(join(dir, "a.py"), "x = 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "init"]);
+    const sha = execFileSync("git", ["-C", dir, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+
+    writeIndexedAtMarker(dir);
+    expect(readIndexedAtSha(dir)).toBe(sha);
+    // Written under .reposkein/local/ — the gitignored per-machine scratch dir.
+    expect(existsSync(indexedAtPath(dir))).toBe(true);
+    expect(readFileSync(indexedAtPath(dir), "utf8")).toBe(sha + "\n");
+  });
+
+  it("overwrites the previous SHA on a later call", () => {
+    git(["init", "-q"]);
+    git(["config", "user.email", "t@example.com"]);
+    git(["config", "user.name", "t"]);
+    writeFileSync(join(dir, "a.py"), "x = 1\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit A"]);
+    writeIndexedAtMarker(dir);
+    const shaA = readIndexedAtSha(dir);
+
+    writeFileSync(join(dir, "a.py"), "x = 2\n");
+    git(["add", "a.py"]);
+    git(["commit", "-qm", "commit B"]);
+    writeIndexedAtMarker(dir);
+    const shaB = readIndexedAtSha(dir);
+
+    expect(shaB).not.toBe(shaA);
+  });
+
+  it("is a silent no-op outside a git repo (no marker written, doesn't throw)", () => {
+    expect(() => writeIndexedAtMarker(dir)).not.toThrow();
+    expect(readIndexedAtSha(dir)).toBeNull();
+  });
+});

--- a/mcp/test/init.test.ts
+++ b/mcp/test/init.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { skillTargetPath, mcpConfigSnippet, ciWorkflowTargetPath, ciWorkflowTemplate, writeCiWorkflow, detectJoinMode, runInit } from "../src/cli/init.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { skillTargetPath, mcpConfigSnippet, ciWorkflowTargetPath, ciWorkflowTemplate, writeCiWorkflow, detectJoinMode, runInit, ensureLocalConfigGitignored } from "../src/cli/init.js";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync as wf, readdirSync } from "node:fs";
 import { tmpdir as osTmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
@@ -18,6 +18,50 @@ describe("init helpers", () => {
     const snip = JSON.parse(mcpConfigSnippet("/repo"));
     expect(snip.mcpServers.reposkein.command).toBe("reposkein-mcp");
     expect(snip.mcpServers.reposkein.env.REPOSKEIN_REPO_PATH).toBe("/repo");
+  });
+});
+
+describe("ensureLocalConfigGitignored", () => {
+  it("creates .gitignore with .mcp.json, opencode.json and .cursor/mcp.json when absent", () => {
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-gitignore-"));
+    try {
+      ensureLocalConfigGitignored(dir);
+      const gitignore = readFileSync(pathJoin(dir, ".gitignore"), "utf8");
+      expect(gitignore).toContain(".mcp.json");
+      expect(gitignore).toContain("opencode.json");
+      expect(gitignore).toContain(".cursor/mcp.json");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("appends only the missing entries to an existing .gitignore, preserving its content", () => {
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-gitignore-"));
+    try {
+      wf(pathJoin(dir, ".gitignore"), "node_modules\n.mcp.json\n");
+      ensureLocalConfigGitignored(dir);
+      const gitignore = readFileSync(pathJoin(dir, ".gitignore"), "utf8");
+      expect(gitignore).toContain("node_modules");
+      expect(gitignore).toContain("opencode.json");
+      expect(gitignore).toContain(".cursor/mcp.json");
+      // Only one .mcp.json line (already present before the call).
+      expect(gitignore.split("\n").filter((l) => l.trim() === ".mcp.json").length).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is idempotent — a second call adds nothing new", () => {
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-gitignore-"));
+    try {
+      ensureLocalConfigGitignored(dir);
+      const after1 = readFileSync(pathJoin(dir, ".gitignore"), "utf8");
+      ensureLocalConfigGitignored(dir);
+      const after2 = readFileSync(pathJoin(dir, ".gitignore"), "utf8");
+      expect(after2).toBe(after1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -130,10 +174,23 @@ describe("runInit — unsupported platform continues instead of failing", () => 
 });
 
 describe("runInit — join mode agent config + dry-run + backup", () => {
-  it("--dry-run plans a write without touching disk, then a real run creates it", async () => {
+  const origPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
+  const origArch = Object.getOwnPropertyDescriptor(process, "arch")!;
+  const savedBin = process.env.REPOSKEIN_INDEXER_BIN;
+
+  beforeEach(() => {
     delete process.env.REPOSKEIN_INDEXER_BIN;
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     Object.defineProperty(process, "arch", { value: "x64", configurable: true }); // unsupported → no bin needed
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "platform", origPlatform);
+    Object.defineProperty(process, "arch", origArch);
+    if (savedBin === undefined) delete process.env.REPOSKEIN_INDEXER_BIN;
+    else process.env.REPOSKEIN_INDEXER_BIN = savedBin;
+  });
+
+  it("--dry-run plans a write without touching disk, then a real run creates it", async () => {
     const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-init-dry-"));
     try {
       const dry = await runInit(dir, { join: true, agents: ["claude"], dryRun: true, agentWriteOpts: { exec: noCliExec } });
@@ -148,9 +205,6 @@ describe("runInit — join mode agent config + dry-run + backup", () => {
   });
 
   it("is idempotent end-to-end: a second real run reports the file as already up to date (no duplicate/second .bak)", async () => {
-    delete process.env.REPOSKEIN_INDEXER_BIN;
-    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
-    Object.defineProperty(process, "arch", { value: "x64", configurable: true });
     const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-init-idem-"));
     try {
       await runInit(dir, { join: true, agents: ["claude", "opencode"], agentWriteOpts: { exec: noCliExec } });
@@ -233,5 +287,17 @@ gated("reposkein-mcp init (smoke)", () => {
     if (existsSync(bundledSkillPath())) {
       e2(existsSync(stp(dir))).toBe(true);
     }
+  });
+
+  it2("real join-mode run: hooksOk gitignores the per-machine MCP config files", async () => {
+    // A second init on the same dir, forced into join mode, exercises the
+    // ensureLocalConfigGitignored() call on the actual hooksOk===true path
+    // (not just the unit-tested function in isolation).
+    const code = await runInit(dir, { join: true, agents: ["claude"], agentWriteOpts: { exec: () => ({ status: 1, stdout: "", stderr: "" }) } });
+    e2(code).toBe(0);
+    const gitignore = readFileSync(pathJoin(dir, ".gitignore"), "utf8");
+    e2(gitignore).toContain(".mcp.json");
+    e2(gitignore).toContain("opencode.json");
+    e2(gitignore).toContain(".cursor/mcp.json");
   });
 });

--- a/mcp/test/init.test.ts
+++ b/mcp/test/init.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { skillTargetPath, mcpConfigSnippet, ciWorkflowTargetPath, ciWorkflowTemplate, writeCiWorkflow } from "../src/cli/init.js";
-import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync as wf } from "node:fs";
+import { skillTargetPath, mcpConfigSnippet, ciWorkflowTargetPath, ciWorkflowTemplate, writeCiWorkflow, detectJoinMode, runInit } from "../src/cli/init.js";
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync as wf, readdirSync } from "node:fs";
 import { tmpdir as osTmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
+import { execFileSync } from "node:child_process";
+import type { Exec, ExecResult } from "../src/cli/agentAdapters.js";
 // Re-exported under distinct names below purely so the second describe block
 // (the pre-existing gated `runInit` smoke test) can keep its own reads.
 
@@ -16,6 +18,150 @@ describe("init helpers", () => {
     const snip = JSON.parse(mcpConfigSnippet("/repo"));
     expect(snip.mcpServers.reposkein.command).toBe("reposkein-mcp");
     expect(snip.mcpServers.reposkein.env.REPOSKEIN_REPO_PATH).toBe("/repo");
+  });
+});
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+const noCliExec: Exec = () => ({ status: 1, stdout: "", stderr: "not found" });
+
+describe("detectJoinMode", () => {
+  it("false when .reposkein/meta.json doesn't exist", () => {
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-join-"));
+    try {
+      expect(detectJoinMode(dir)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("false when meta.json exists on disk but is not yet committed (first-time setup)", () => {
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-join-"));
+    try {
+      git(["init", "-q"], dir);
+      mkdirSync(pathJoin(dir, ".reposkein"));
+      wf(pathJoin(dir, ".reposkein", "meta.json"), '{"repo_id":"abc"}');
+      expect(detectJoinMode(dir)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("true when meta.json is committed (a real join)", () => {
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-join-"));
+    try {
+      git(["init", "-q"], dir);
+      git(["config", "user.email", "t@example.com"], dir);
+      git(["config", "user.name", "t"], dir);
+      mkdirSync(pathJoin(dir, ".reposkein"));
+      wf(pathJoin(dir, ".reposkein", "meta.json"), '{"repo_id":"abc"}');
+      git(["add", ".reposkein/meta.json"], dir);
+      git(["commit", "-qm", "add reposkein config"], dir);
+      expect(detectJoinMode(dir)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("false outside a git repo entirely (no crash)", () => {
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-join-"));
+    try {
+      mkdirSync(pathJoin(dir, ".reposkein"));
+      wf(pathJoin(dir, ".reposkein", "meta.json"), '{"repo_id":"abc"}');
+      expect(detectJoinMode(dir)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runInit — unsupported platform continues instead of failing", () => {
+  const origPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
+  const origArch = Object.getOwnPropertyDescriptor(process, "arch")!;
+  const savedBin = process.env.REPOSKEIN_INDEXER_BIN;
+
+  function forcePlatform(platform: string, arch: string): void {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    Object.defineProperty(process, "arch", { value: arch, configurable: true });
+  }
+  function restorePlatform(): void {
+    Object.defineProperty(process, "platform", origPlatform);
+    Object.defineProperty(process, "arch", origArch);
+    if (savedBin === undefined) delete process.env.REPOSKEIN_INDEXER_BIN;
+    else process.env.REPOSKEIN_INDEXER_BIN = savedBin;
+  }
+
+  it("returns 0, skips hooks/index, and still writes agent config in join mode (darwin-x64)", async () => {
+    delete process.env.REPOSKEIN_INDEXER_BIN;
+    forcePlatform("darwin", "x64");
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-init-unsup-"));
+    try {
+      const code = await runInit(dir, {
+        join: true,
+        agents: ["claude"],
+        agentWriteOpts: { exec: noCliExec },
+      });
+      expect(code).toBe(0);
+      expect(existsSync(pathJoin(dir, ".git", "hooks", "pre-commit"))).toBe(false);
+      expect(existsSync(pathJoin(dir, ".reposkein", "nodes.jsonl"))).toBe(false);
+      expect(existsSync(pathJoin(dir, ".mcp.json"))).toBe(true);
+      const doc = JSON.parse(readFileSync(pathJoin(dir, ".mcp.json"), "utf8"));
+      expect(doc.mcpServers.reposkein.command).toBe("reposkein-mcp");
+    } finally {
+      restorePlatform();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 0 on win32-arm64 too", async () => {
+    delete process.env.REPOSKEIN_INDEXER_BIN;
+    forcePlatform("win32", "arm64");
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-init-unsup-"));
+    try {
+      const code = await runInit(dir, { join: true, agents: ["claude"], agentWriteOpts: { exec: noCliExec } });
+      expect(code).toBe(0);
+    } finally {
+      restorePlatform();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runInit — join mode agent config + dry-run + backup", () => {
+  it("--dry-run plans a write without touching disk, then a real run creates it", async () => {
+    delete process.env.REPOSKEIN_INDEXER_BIN;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    Object.defineProperty(process, "arch", { value: "x64", configurable: true }); // unsupported → no bin needed
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-init-dry-"));
+    try {
+      const dry = await runInit(dir, { join: true, agents: ["claude"], dryRun: true, agentWriteOpts: { exec: noCliExec } });
+      expect(dry).toBe(0);
+      expect(existsSync(pathJoin(dir, ".mcp.json"))).toBe(false);
+      const real = await runInit(dir, { join: true, agents: ["claude"], agentWriteOpts: { exec: noCliExec } });
+      expect(real).toBe(0);
+      expect(existsSync(pathJoin(dir, ".mcp.json"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is idempotent end-to-end: a second real run reports the file as already up to date (no duplicate/second .bak)", async () => {
+    delete process.env.REPOSKEIN_INDEXER_BIN;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    Object.defineProperty(process, "arch", { value: "x64", configurable: true });
+    const dir = mkdtempSync(pathJoin(osTmpdir(), "rs-init-idem-"));
+    try {
+      await runInit(dir, { join: true, agents: ["claude", "opencode"], agentWriteOpts: { exec: noCliExec } });
+      const mcpAfterFirst = readFileSync(pathJoin(dir, ".mcp.json"), "utf8");
+      await runInit(dir, { join: true, agents: ["claude", "opencode"], agentWriteOpts: { exec: noCliExec } });
+      expect(readFileSync(pathJoin(dir, ".mcp.json"), "utf8")).toBe(mcpAfterFirst);
+      const backups = readdirSync(dir).filter((f: string) => f.endsWith(".bak"));
+      expect(backups).toEqual([]); // nothing changed on re-run, so nothing was backed up
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -59,8 +205,7 @@ describe("init --ci (writeCiWorkflow)", () => {
 });
 
 import { describe as d2, it as it2, expect as e2, beforeAll, afterAll } from "vitest";
-import { execFileSync } from "node:child_process";
-import { runInit, skillTargetPath as stp, bundledSkillPath } from "../src/cli/init.js";
+import { skillTargetPath as stp, bundledSkillPath } from "../src/cli/init.js";
 
 const gated = process.env.REPOSKEIN_INDEXER_BIN ? d2 : d2.skip;
 

--- a/mcp/test/teamConfig.test.ts
+++ b/mcp/test/teamConfig.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readTeamPagesUrl } from "../src/store/teamConfig.js";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "rs-teamcfg-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+function writeConfig(toml: string): void {
+  mkdirSync(join(dir, ".reposkein"), { recursive: true });
+  writeFileSync(join(dir, ".reposkein", "config.toml"), toml);
+}
+
+describe("readTeamPagesUrl", () => {
+  it("returns null when config.toml doesn't exist", () => {
+    expect(readTeamPagesUrl(dir)).toBeNull();
+  });
+
+  it("returns null when there's no [team] section", () => {
+    writeConfig('schema_version = 1\n[languages]\nenabled = ["python"]\n');
+    expect(readTeamPagesUrl(dir)).toBeNull();
+  });
+
+  it("returns null when [team] exists but pages_url is absent", () => {
+    writeConfig("[team]\nname = \"platform\"\n");
+    expect(readTeamPagesUrl(dir)).toBeNull();
+  });
+
+  it("reads pages_url from [team]", () => {
+    writeConfig('[team]\npages_url = "https://reposkein.github.io/example"\n');
+    expect(readTeamPagesUrl(dir)).toBe("https://reposkein.github.io/example");
+  });
+
+  it("handles single-quoted values and a trailing comment", () => {
+    writeConfig("[team]\npages_url = 'https://example.com/repo' # published via CI\n");
+    expect(readTeamPagesUrl(dir)).toBe("https://example.com/repo");
+  });
+
+  it("ignores pages_url outside the [team] section", () => {
+    writeConfig('pages_url = "https://not-team.example"\n[team]\n');
+    expect(readTeamPagesUrl(dir)).toBeNull();
+  });
+
+  it("only reads within [team] even when other sections follow", () => {
+    writeConfig(
+      '[team]\npages_url = "https://reposkein.github.io/example"\n\n[neo4j]\nuri = "neo4j://localhost:7687"\n'
+    );
+    expect(readTeamPagesUrl(dir)).toBe("https://reposkein.github.io/example");
+  });
+
+  it("stops applying [team] once a later section starts", () => {
+    writeConfig('[team]\nname = "x"\n\n[other]\npages_url = "https://leaked.example"\n');
+    expect(readTeamPagesUrl(dir)).toBeNull();
+  });
+});

--- a/mcp/test/viewExport.test.ts
+++ b/mcp/test/viewExport.test.ts
@@ -8,6 +8,7 @@ import {
   injectGraphDataScript,
   parseViewArgs,
   runExport,
+  resolveServerRepoMeta,
   vizDistDir,
 } from "../src/cli/view.js";
 
@@ -148,7 +149,7 @@ describe("buildGraphDataJs (bake metadata + temporal + federation)", () => {
     const js = buildGraphDataJs("demo", "n\n", "e\n");
     const json = js.replace(/^window\.__REPOSKEIN_GRAPH__ = /, "").replace(/;\n$/, "");
     const payload = JSON.parse(json) as { meta: { commitSha: null; builtAt: null; repoUrl: null } };
-    expect(payload.meta).toEqual({ commitSha: null, builtAt: null, repoUrl: null });
+    expect(payload.meta).toEqual({ commitSha: null, builtAt: null, repoUrl: null, pagesUrl: null });
   });
 
   it("bakes the temporal co-change map (same shape /api/temporal returns)", () => {
@@ -238,7 +239,7 @@ gated("runExport (integration: bakes sha + temporal + federation)", () => {
       const payload = JSON.parse(
         js.replace(/^window\.__REPOSKEIN_GRAPH__ = /, "").replace(/;\n$/, ""),
       ) as {
-        meta: { commitSha: string; repoUrl: string; builtAt: string };
+        meta: { commitSha: string; repoUrl: string; builtAt: string; pagesUrl: string | null };
         cochange: Record<string, unknown>;
         manifest: { federated: unknown[] };
       };
@@ -246,6 +247,7 @@ gated("runExport (integration: bakes sha + temporal + federation)", () => {
         commitSha: "deadbeef",
         repoUrl: "https://github.com/o/r",
         builtAt: "2026-08-20T00:00:00.000Z",
+        pagesUrl: null,
       });
       // A one-commit repo has no co-change pairs, but the temporal code path
       // must have run without throwing (proves getTemporal was actually called).
@@ -316,6 +318,80 @@ gated("runExport (integration: bakes sha + temporal + federation)", () => {
       ]);
       expect(payload.federatedText[0]!.repoId).toBe("widgets");
       expect(payload.federatedText[0]!.nodesText).toContain("rs1:widgets:file:x.ts");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("bakes pagesUrl from the repo's [team] config.toml when not explicitly overridden", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rs-export-"));
+    try {
+      mkdirSync(join(dir, ".reposkein"), { recursive: true });
+      writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "");
+      writeFileSync(join(dir, ".reposkein", "edges.jsonl"), "");
+      writeFileSync(
+        join(dir, ".reposkein", "config.toml"),
+        '[team]\npages_url = "https://reposkein.github.io/example"\n',
+      );
+      const outDir = join(dir, "_site");
+      await runExport(dir, "demo", outDir, {});
+      const js = readFileSync(join(outDir, "graph-data.js"), "utf8");
+      const payload = JSON.parse(
+        js.replace(/^window\.__REPOSKEIN_GRAPH__ = /, "").replace(/;\n$/, ""),
+      ) as { meta: { pagesUrl: string | null } };
+      expect(payload.meta.pagesUrl).toBe("https://reposkein.github.io/example");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("an explicit pagesUrl bake option overrides config.toml", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rs-export-"));
+    try {
+      mkdirSync(join(dir, ".reposkein"), { recursive: true });
+      writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), "");
+      writeFileSync(join(dir, ".reposkein", "edges.jsonl"), "");
+      writeFileSync(
+        join(dir, ".reposkein", "config.toml"),
+        '[team]\npages_url = "https://from-config.example"\n',
+      );
+      const outDir = join(dir, "_site");
+      await runExport(dir, "demo", outDir, { pagesUrl: "https://override.example" });
+      const js = readFileSync(join(outDir, "graph-data.js"), "utf8");
+      const payload = JSON.parse(
+        js.replace(/^window\.__REPOSKEIN_GRAPH__ = /, "").replace(/;\n$/, ""),
+      ) as { meta: { pagesUrl: string | null } };
+      expect(payload.meta.pagesUrl).toBe("https://override.example");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveServerRepoMeta", () => {
+  it("reads pagesUrl from [team] config.toml alongside the git-derived fields", () => {
+    const dir = mkdtempSync(join(tmpdir(), "rs-servermeta-"));
+    try {
+      mkdirSync(join(dir, ".reposkein"), { recursive: true });
+      writeFileSync(
+        join(dir, ".reposkein", "config.toml"),
+        '[team]\npages_url = "https://reposkein.github.io/example"\n',
+      );
+      const meta = resolveServerRepoMeta(dir);
+      expect(meta.pagesUrl).toBe("https://reposkein.github.io/example");
+      // Not a git repo — the git-derived fields degrade to null (pre-existing
+      // behavior); pagesUrl is independent of git.
+      expect(meta.commitSha).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("pagesUrl is null when config.toml has no [team] section", () => {
+    const dir = mkdtempSync(join(tmpdir(), "rs-servermeta-"));
+    try {
+      const meta = resolveServerRepoMeta(dir);
+      expect(meta.pagesUrl).toBeNull();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/viz/src/data/api.ts
+++ b/viz/src/data/api.ts
@@ -9,6 +9,12 @@ export interface RepoMeta {
   commitSha: string | null;
   builtAt: string | null;
   repoUrl: string | null;
+  /** `[team] pages_url` from `.reposkein/config.toml`, or null when unset —
+   *  the team's canonical/CI-published constellation link, distinct from
+   *  whatever local `view`/export a viewer happens to be looking at.
+   *  Optional (not just nullable) so a manifest baked by an older server
+   *  build — before this field existed — still parses. */
+  pagesUrl?: string | null;
 }
 
 export interface GraphManifest {

--- a/viz/src/data/badge.test.ts
+++ b/viz/src/data/badge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shortSha, relativeAge, badgeInfo } from "./badge";
+import { shortSha, relativeAge, badgeInfo, teamConstellationHref } from "./badge";
 
 describe("shortSha", () => {
   it("truncates to 7 chars", () => {
@@ -73,5 +73,34 @@ describe("badgeInfo", () => {
     const info = badgeInfo({ commitSha: "abc1234", builtAt: "2026-08-20T06:00:00.000Z", repoUrl: null }, now);
     expect(info?.href).toBeNull();
     expect(info?.label).toBe("graph @ abc1234 · 6h ago");
+  });
+});
+
+describe("teamConstellationHref", () => {
+  it("returns null when meta is null", () => {
+    expect(teamConstellationHref(null)).toBeNull();
+  });
+
+  it("returns null when pagesUrl is absent (older manifests without the field)", () => {
+    expect(teamConstellationHref({ commitSha: null, builtAt: null, repoUrl: null })).toBeNull();
+  });
+
+  it("returns null when pagesUrl is explicitly null (no [team] section)", () => {
+    expect(teamConstellationHref({ commitSha: null, builtAt: null, repoUrl: null, pagesUrl: null })).toBeNull();
+  });
+
+  it("returns null for a blank/whitespace-only pagesUrl", () => {
+    expect(teamConstellationHref({ commitSha: null, builtAt: null, repoUrl: null, pagesUrl: "   " })).toBeNull();
+  });
+
+  it("returns the trimmed pagesUrl when set", () => {
+    expect(
+      teamConstellationHref({
+        commitSha: null,
+        builtAt: null,
+        repoUrl: null,
+        pagesUrl: "  https://reposkein.github.io/example  ",
+      }),
+    ).toBe("https://reposkein.github.io/example");
   });
 });

--- a/viz/src/data/badge.ts
+++ b/viz/src/data/badge.ts
@@ -50,3 +50,12 @@ export function badgeInfo(meta: RepoMeta | null, now: number = Date.now()): Badg
   const href = meta.repoUrl ? `${meta.repoUrl}/commit/${meta.commitSha}` : null;
   return { label, href };
 }
+
+/** The header's "team constellation" link, or null when the repo has no
+ *  `[team] pages_url` configured (the common case — this is opt-in). Trims
+ *  whitespace and treats an empty string the same as absent, so a
+ *  hand-edited `pages_url = ""` doesn't render a dead link. */
+export function teamConstellationHref(meta: RepoMeta | null): string | null {
+  const url = meta?.pagesUrl?.trim();
+  return url ? url : null;
+}

--- a/viz/src/routes/Root.tsx
+++ b/viz/src/routes/Root.tsx
@@ -24,7 +24,7 @@ import { BRAND } from "../scene/encoding";
 import { pickNeighbor } from "../data/navigate";
 import { revealChainFor } from "../data/clientModel";
 import { resolveNodeFallback } from "../data/nodeFallback";
-import { badgeInfo } from "../data/badge";
+import { badgeInfo, teamConstellationHref } from "../data/badge";
 import { CaptureBridge, captureScreenshot } from "../scene/Screenshot";
 
 export function Root() {
@@ -274,6 +274,27 @@ function HeaderBar() {
           >
             Screenshot
           </button>
+        )}
+        {store.model && teamConstellationHref(store.model.repoMeta) && (
+          <a
+            href={teamConstellationHref(store.model.repoMeta)!}
+            target="_blank"
+            rel="noreferrer"
+            title="Open this team's published constellation (configured in .reposkein/config.toml [team] pages_url)"
+            style={{
+              padding: "2px 10px",
+              fontSize: 11,
+              borderRadius: 5,
+              border: `1px solid ${BRAND.amber}66`,
+              background: `${BRAND.amber}1f`,
+              color: BRAND.cream,
+              cursor: "pointer",
+              letterSpacing: 0.3,
+              textDecoration: "none",
+            }}
+          >
+            Team constellation ↗
+          </a>
         )}
         {store.model && <TourController />}
       </div>


### PR DESCRIPTION
New colleague onboarding is now: `git clone <repo> && cd <repo> && npx @reposkein/mcp init` — done.

## What changed
- **Join mode**: `init` detects committed `.reposkein/meta.json` → skips scaffolding, reuses repo identity, fetches the binary, installs hooks, indexes, then **auto-writes agent MCP config** (Claude Code CLI/.mcp.json, OpenCode, Cursor) via per-agent adapters — idempotent, `--dry-run`, timestamped backups, `--agents` override; malformed existing config is backed up and reported, never rewritten. Ends with a doctor summary.
- **Binary fetch hardening**: HTTPS_PROXY/NO_PROXY honored (undici EnvHttpProxyAgent); `REPOSKEIN_INDEXER_BIN` documented offline fallback; unsupported platforms (darwin-x64, win32-arm64) print a cargo-install fallback and *continue* the join instead of failing.
- **`doctor --ci`**: non-zero on stale graph / missing hooks / unsplit legacy summaries. Staleness is now content-based — a recorded indexed-at commit SHA, not mtime (the old heuristic was structurally blind after any fresh checkout; verified with a real `git clone` repro test). The managed git hooks maintain the marker themselves (post-commit records HEAD via a success-flag handshake with pre-commit; post-merge/post-checkout reindex then record), and every marker write is gated on the index actually succeeding — a failed reindex can never report fresh. Also fixed en route: post-merge/post-checkout previously never reindexed at all.
- **Docs**: INSTALL.md now opens with "Joining an existing RepoSkein repo" (3 commands); devcontainer `postCreateCommand` snippet.
- **viz**: header links the team's hosted constellation when `config.toml` declares `[team] pages_url`.

## Tests
mcp **699 passed, 18 skipped** (tsc clean) · viz **175 passed** (typecheck/lint clean) · indexer workspace green incl. real-binary hook e2e tests (fmt+clippy clean).

Linear: REP-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)