### PR TITLE
docs: README becomes a front door; docs/ gets a task-oriented index (REP-12, REP-19)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,13 @@ RepoSkein has **three hard invariants** — please don't break them:
 
 1. **Determinism.** `.reposkein/*.jsonl` must be a **byte-identical** function of the working-tree source — same code → same graph, on any machine. CI enforces this (`determinism_two_runs_byte_identical`, `cache_warm_run_is_byte_identical_to_cold`, the Neo4j `load → export` round-trip). No LLMs, clocks, randomness, or HashMap-iteration-order may influence the output. Anything derived/non-deterministic (embeddings, git history, cross-repo edges) lives under `.reposkein/local/` (gitignored).
 2. **Zero-infra by default.** It must work with **no database and no Docker** (the in-memory JSONL store). Don't make Neo4j or any service *required*.
-3. **Derived output stays out of git.** `nodes.jsonl` and `edges.jsonl` are rebuilt from the tree, so they are git-ignored and the MCP server builds them on demand. Only what an agent *authored* is committed: `.reposkein/summaries.jsonl`, alongside `meta.json` and `config.toml`. Determinism still matters for both — a re-index that reorders lines would churn the committed summaries file.
+3. **Derived output stays out of git.** `nodes.jsonl` and `edges.jsonl` are rebuilt from the tree, so they are git-ignored and the MCP server builds them on demand. Only what an agent *authored* is committed: `.reposkein/summaries/<xx>.jsonl` (sharded by a hash of the node id — see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)), `.reposkein/decisions/` (ADRs), alongside `meta.json` and `config.toml`. Determinism still matters for all of it — a re-index that reordered lines would churn committed files it shouldn't.
 
 Also: **Conventional Commits** (`feat:`, `fix:`, `docs:`, …), and **keep CI green** (`cargo test && cargo fmt --check && cargo clippy --all-targets -- -D warnings`; `npm test`).
 
 ## Dev setup
+
+Requirements: Rust (stable), Node 24. Docker only for the optional Neo4j backend.
 
 ```sh
 # Rust indexer
@@ -24,7 +26,18 @@ cd mcp && npm install && npm test && npm run build
 
 (Neo4j-gated tests skip without `NEO4J_PASSWORD`; that's expected.)
 
+To run a from-source build against a real agent instead of the npm package, wire it in with `command: node`, `args: [".../mcp/dist/index.js"]`, env `REPOSKEIN_REPO_PATH` + `REPOSKEIN_INDEXER_BIN`. Full test commands: `cd indexer && cargo test && cargo clippy --all-targets -- -D warnings`; `cd mcp && npm test`.
+
 ## Project layout
+
+```
+indexer/      Rust workspace: core, lang-{python,ts,rust,go,java,csharp}, lang-common, neo4j-io, cli
+mcp/          @reposkein/mcp — the TypeScript MCP server (tools + graph-store backends)
+mcp/bench/    benchmarks: retrieval efficiency (Track 1) + end-task SWE-bench harness (Track 2)
+skills/       reposkein-graph-rag + reposkein-setup — cross-agent skills (skills.sh)
+embed-server/ one-command local embedding server (voyage-4-nano) for hybrid semantic_find
+viz/          @reposkein/viz — the 3D constellation viewer SPA (served by `reposkein-mcp view`)
+```
 
 - `indexer/` — Rust workspace. `core` (graph model, deterministic serializer, resolver), `lang-*` (per-language Tree-sitter extractors), `lang-common` (shared helpers), `neo4j-io`, `cli`.
 - `mcp/` — the `@reposkein/mcp` TypeScript MCP server (tools + graph-store backends).

--- a/README.md
+++ b/README.md
@@ -3,25 +3,12 @@
 <!-- animated gradient name banner (deep-navy → teal → amber) -->
 <img src="https://capsule-render.vercel.app/api?type=waving&color=0:070A12,45:2DD4BF,100:F2B84B&height=200&section=header&text=RepoSkein&fontColor=EAE7DC&fontSize=72&fontAlignY=38&animation=fadeIn&desc=Thread%20your%20repo%20into%20agent-ready%20context&descSize=17&descAlignY=60" width="100%" alt="RepoSkein — thread your repo into agent-ready context" />
 
-<!-- animated typing tagline -->
-<a href="https://github.com/reposkein/reposkein">
-  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=600&size=21&pause=1200&color=2DD4BF&center=true&vCenter=true&width=780&height=38&lines=A+deterministic+code+graph+for+AI+agents;Navigate+structure%2C+not+grep-and-guess;7+languages+%C2%B7+zero-infra+%C2%B7+git-native;~8.4x+fewer+context+tokens+than+grep" alt="A deterministic code graph for AI agents" />
-</a>
-
-<br /><br />
-
 [![npm](https://img.shields.io/npm/v/@reposkein/mcp?style=for-the-badge&logo=npm&logoColor=EAE7DC&label=npm&labelColor=070A12&color=F2B84B)](https://www.npmjs.com/package/@reposkein/mcp)
 [![CI](https://img.shields.io/github/actions/workflow/status/reposkein/reposkein/ci.yml?style=for-the-badge&logo=githubactions&logoColor=EAE7DC&label=CI&labelColor=070A12&color=2DD4BF)](https://github.com/reposkein/reposkein/actions/workflows/ci.yml)
 [![release](https://img.shields.io/github/v/release/reposkein/reposkein?style=for-the-badge&logo=github&logoColor=EAE7DC&label=release&labelColor=070A12&color=2DD4BF)](https://github.com/reposkein/reposkein/releases)
 [![License](https://img.shields.io/badge/license-Apache_2.0-F2B84B?style=for-the-badge&labelColor=070A12)](./LICENSE)
-[![MCP](https://img.shields.io/badge/MCP-server-2DD4BF?style=for-the-badge&labelColor=070A12)](https://modelcontextprotocol.io)
 
-[![skills.sh](https://skills.sh/b/reposkein/reposkein)](https://skills.sh/reposkein/reposkein)
-&nbsp;[![Glama](https://glama.ai/mcp/servers/reposkein/reposkein/badges/score.svg)](https://glama.ai/mcp/servers/reposkein/reposkein)
-&nbsp;[![mcpservers.org](https://img.shields.io/badge/mcpservers.org-listed-2DD4BF?style=for-the-badge&labelColor=070A12)](https://mcpservers.org/servers/reposkein/reposkein)
-&nbsp;[![ghcr](https://img.shields.io/badge/ghcr.io-embed--server-F2B84B?style=for-the-badge&logo=docker&logoColor=EAE7DC&labelColor=070A12)](https://github.com/reposkein/reposkein/pkgs/container/reposkein-embed)
-
-[![🔭 Live demo](https://img.shields.io/badge/%F0%9F%94%AD_Live_demo-explore_the_graph-2DD4BF?style=for-the-badge&labelColor=070A12)](https://reposkein.github.io/reposkein/)
+<sub>Listed on: [skills.sh](https://skills.sh/reposkein/reposkein) · [Glama](https://glama.ai/mcp/servers/reposkein/reposkein) · [mcpservers.org](https://mcpservers.org/servers/reposkein/reposkein) · [ghcr.io](https://github.com/reposkein/reposkein/pkgs/container/reposkein-embed)</sub>
 
 **[🔭 Live demo →](https://reposkein.github.io/reposkein/)** — RepoSkein's own graph, rendered as an interactive 3D constellation in your browser.
 
@@ -47,33 +34,38 @@ It uses [Tree-sitter](https://tree-sitter.github.io/) to build a **deterministic
 | "Where do I even start?" | ranked entry-point functions by meaning, not filename |
 | "What usually changes with this file?" | co-change history from git |
 
+<a id="benchmarks"></a>
 > In a deterministic, no-LLM [benchmark](mcp/bench/), RepoSkein surfaces the right functions with a **mean ~8.4× fewer context tokens** than a grep-based agent on structural queries.
+
+<a id="usage--working-with-your-agent"></a><a id="mcp-tools"></a><a id="agent-skills"></a>
+The bundled `reposkein-graph-rag` skill drives a `semantic_find → get_context_profile → impact → get_temporal_context → write_semantic_summary → reindex_file` loop, so you just ask in plain language. Full workflow, an example interaction, and the tool-by-tool + CLI reference: **[`docs/TOOLS.md`](docs/TOOLS.md)**.
 
 ## Table of contents
 
+- [For teams](#for-teams)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
-- [Usage — working with your agent](#usage--working-with-your-agent)
 - [Supported languages](#supported-languages)
-- [How it works](#how-it-works)
-- [Visualize the graph — the constellation viewer](#visualize-the-graph--the-constellation-viewer)
-- [MCP tools](#mcp-tools)
-- [Optional: semantic embeddings](#optional-semantic-embeddings)
-- [Optional: Neo4j backend](#optional-neo4j-backend)
-- [Benchmarks](#benchmarks)
-- [Build from source](#build-from-source)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
-- [Acknowledgements](#acknowledgements)
-- [Contact](#contact)
 - [License](#license)
+
+## For teams
+
+Joining a repo that already has RepoSkein set up? One command, no questions asked:
+
+```sh
+git clone <repo-url> && cd <repo> && npx @reposkein/mcp init
+```
+
+`init` detects the committed `.reposkein/meta.json`, reuses its config, and wires up your agent's MCP config automatically. Publish a durable, shareable view of the graph with a [**hosted constellation**](docs/HOSTING.md) (GitHub Pages via `reposkein-mcp init --ci`) — and because summaries are committed to git, they're **shared team memory**: every teammate's agent starts from what previous agents already learned, not from scratch.
 
 ## Prerequisites
 
 - **Node.js 18+** — to run `npx @reposkein/mcp` (the indexer binary is fetched automatically).
 - **An MCP-capable agent** — [Claude Code](https://claude.com/claude-code), Cursor, Codex, Zed, etc.
 - A **git repository** to index (RepoSkein installs git hooks and reads git history for `get_temporal_context`).
-- *Optional:* **Docker** (only for the [embeddings server](#optional-semantic-embeddings) or the [Neo4j backend](#optional-neo4j-backend)); **Rust** (only to [build from source](#build-from-source)).
+- *Optional:* **Docker** (only for the [embeddings server](docs/EMBEDDINGS.md) or the [Neo4j backend](docs/NEO4J.md)); **Rust** (only to [build from source](CONTRIBUTING.md#dev-setup)).
 
 ## Installation
 
@@ -104,12 +96,12 @@ This downloads the indexer for your platform, installs git hooks + the navigatio
    `nodes.jsonl` and `edges.jsonl` are derived from your working tree and git-ignored — a clone rebuilds them on first use. Re-index after big changes with `reposkein-mcp index .` (or the agent's `reindex_file` tool).
 3. **Ask your agent** *"what calls this function?"* or *"what breaks if I change X?"* — it answers from the graph.
 
-> **Prefer to let your agent set it up?** Install the [skills](#agent-skills) and tell it to **run the `reposkein-setup` skill** — it installs, indexes, and verifies everything:
+> **Prefer to let your agent set it up?** Install the [skills](docs/TOOLS.md#agent-skills) and tell it to **run the `reposkein-setup` skill** — it installs, indexes, and verifies everything:
 > ```sh
 > npx skills add reposkein/reposkein --all
 > ```
 
-**Platforms:** prebuilt binaries for macOS (Apple Silicon), Linux (x64/arm64), and Windows (x64). Elsewhere, point `REPOSKEIN_INDEXER_BIN` at a [from-source](#build-from-source) build.
+**Platforms:** prebuilt binaries for macOS (Apple Silicon), Linux (x64/arm64), and Windows (x64). Elsewhere, point `REPOSKEIN_INDEXER_BIN` at a [from-source](CONTRIBUTING.md#dev-setup) build.
 
 ### Let your agent install it for you
 
@@ -119,212 +111,20 @@ For complex setups — multi-repo workspaces, Neo4j backend, the local embedding
 
 [`docs/INSTALL.md`](docs/INSTALL.md) is written for agents: it covers the decision tree (one repo vs workspace, JSONL vs Neo4j, lexical vs cloud vs local embeddings, which agent CLIs to wire), per-agent config schemas (`.mcp.json`, `opencode.json`, `.cursor/mcp.json`, Continue, Codex, Cline, …), the Apple-Silicon `mps` native embed-server recipe, and a troubleshooting table.
 
-## Usage — working with your agent
-
-You ask in plain language; the bundled **`reposkein-graph-rag`** skill drives the tools. The natural loop:
-
-1. **Find where to start** — `semantic_find("jwt auth validation")` ranks the right functions by meaning, no symbol name needed. → *"where's the rate limiter?"*
-2. **Understand it** — `get_context_profile` returns the node's callers + callees as ready-to-read prose (`hops: 2` widens, `federated: true` spans nested repos).
-3. **Before you change it** — `impact` lists transitive callers (what could break) split from the tests that cover it (what to run). → *"what breaks if I change `charge()`?"*
-4. **What moves with it** — `get_temporal_context` surfaces files that historically change together, plus churn and ownership. → *"what usually changes with the auth config?"*
-5. **Record what you learned** — `write_semantic_summary` attaches a 1–3 sentence note to the node, landing in `.reposkein/summaries/<xx>.jsonl` for you to commit for the next agent/teammate.
-6. **After editing** — `reindex_file` refreshes the graph for the changed file.
-
-<details>
-<summary><b>Example interaction</b></summary>
-
-```text
-You:    Refactor how we validate auth tokens — what's involved?
-
-Agent:  → semantic_find("validate auth token")        → resolves auth.validate_jwt
-        → get_context_profile(auth.validate_jwt)       → 3 callers, 2 callees (+ summaries)
-        → impact(auth.validate_jwt)                    → 6 impacted functions, 4 covering tests
-        → get_temporal_context("src/auth/jwt.py")      → co-changes with config/keys.py (conf 0.8)
-
-Agent:  "validate_jwt is called by the login, refresh, and middleware paths;
-         changing its signature touches 6 functions and 4 tests (test_jwt.py,
-         test_middleware.py, …). Heads up: jwt.py historically changes together
-         with config/keys.py — you'll likely need to update both."
-```
-
-> 🎥 A short screen recording is on the roadmap — see [Documentation](#documentation).
-</details>
-
-### Agent skills
-
-RepoSkein ships two cross-agent [Agent Skills](https://skills.sh) — `npx skills add reposkein/reposkein --all` installs both into Claude Code, Cursor, Codex, and 70+ agents:
-
-- **`reposkein-setup`** — installs RepoSkein in a repo and verifies it's running (binary → index → MCP reachability). Ask your agent to run it.
-- **`reposkein-graph-rag`** — teaches your agent *when* to use each tool (the loop above). `reposkein-mcp init` installs it automatically for Claude Code.
-
 ## Supported languages
 
-| Language | Definitions | Imports → edges | Cross-file calls |
-| --- | --- | --- | --- |
-| Python | functions, classes, methods, nested defs, vars | ✅ relative / absolute / aliased | import-resolved (`exact`) |
-| TypeScript / TSX | classes, interfaces, enums, methods, arrows | ✅ named / default / aliased / `* as ns` | import-resolved (`exact`) |
-| JavaScript / JSX | *(via the TS grammar)* | ✅ ES imports *(no CommonJS yet)* | import-resolved (`exact`) |
-| Rust | fns, structs, traits, enums, `impl` methods | ✅ `use` (groups, aliases, globs, `pub use` chains; workspace-aware) | import-resolved (`exact`) |
-| Go | funcs, methods (`Type.method`), structs, interfaces | *not yet (cross-package planned)* | same-package (same-dir); cross-package by name |
-| Java | classes, records, interfaces, enums, methods, constructors, fields | ✅ package-path *(no wildcard/static yet)* | import-resolved (`exact`) |
-| C# | classes, structs, records, interfaces, enums, methods, properties | *not yet (cross-namespace planned)* | same-dir; cross-namespace by name |
+Python, TypeScript, JavaScript, Rust, Go, Java, C# — with an honest per-language matrix of what resolves `exact` vs by-name vs `ambiguous`. Full table + the resolution rules: **[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#supported-languages)**. [Adding a language](CONTRIBUTING.md#adding-a-new-language) is a well-trodden path — contributions welcome.
 
-**What resolves — honestly.** Every edge carries a `resolution` (`exact` / `name_match` / `ambiguous`) + confidence, so your agent knows what to trust. Same-file calls, `self`/`this` methods, and **import-followed free-function calls resolve `exact`**. Python **module-alias calls** (`import foo as f; f.bar()`) resolve `exact` to the target module's function. **Cross-file INHERITS/IMPLEMENTS edges** are resolved repo-wide: import-followed bases resolve `exact` (confidence 1.0); unique same-directory or repo-wide bases resolve `name_match` (0.8/0.7); ambiguous bases are skipped to avoid false hierarchy edges — and bases that live in a **federated child repo** are stitched into cross-repo heritage edges at load time. Go's **struct/interface embedding** (`type Dog struct { Animal }`) is captured as INHERITS. Constructors emit a distinct **`INSTANTIATES`** edge (`new Foo()` in TS/Java/C#, `Foo { .. }` and `Foo::new()` in Rust, `Foo{}` / `&Foo{}` composite literals in Go, and Python `Foo()` whose name resolves to a class) so an agent can ask *who creates instances of this type* — resolved against the type index and skipped when ambiguous. The graph is **type-free by design** (deterministic, no compiler in the loop), but it does track types where it can do so soundly from source alone: when a local is assigned a constructor (`x = Foo(); x.bar()`), that **`x.bar()` resolves `exact`** to `Foo.bar` (intraprocedural receiver typing). Method calls on receivers it *can't* trace that way (parameters, fields, return values) **resolve by name** (≤ `name_match`), and overloaded calls are flagged `ambiguous`. Go and C# don't emit import edges yet, so their cross-package/namespace calls resolve by name (same-package/-directory calls *do* resolve). These limits are inherent to the zero-infra, type-free design; a deeper optional type-aware layer (SCIP) is gated on benchmark evidence. [Adding a language](CONTRIBUTING.md) is a well-trodden path — contributions welcome.
-
-## How it works
-
-```
- Your agent (Claude Code / Cursor / …)   ── guided by the reposkein skill
-        │  MCP
-        ▼
- @reposkein/mcp        semantic_find · get_context_profile · impact · get_temporal_context
-   (TypeScript)        read_cypher · write_semantic_summary · init_cpg_skeleton · reindex_file
-                       CLI: init · doctor · index · view
-        │ reads
-        ▼
- .reposkein/           ← nodes.jsonl + edges.jsonl: derived, git-ignored, rebuilt on demand
-                       summaries/<xx>.jsonl: what your agents authored — commit this
-        ▲ writes
-        │
- reposkein-indexer    Tree-sitter parse → stable IDs → canonical JSONL
-   (Rust)             + git hooks that keep the local graph in step with your tree
-```
-
-- **Structure is static.** The skeleton comes only from parsing — identical code produces a byte-identical graph (a CI-tested invariant), independent of who runs it.
-- **Meaning is just-in-time.** Summaries are written as the agent visits nodes; they're content-hash-stamped (so they flag stale when code changes) and committed to git.
-- **Derived stays out of git.** `nodes.jsonl` and `edges.jsonl` are a pure function of your working tree, so committing them buys nothing a re-index cannot rebuild while making every branch that touches code conflict with every other. Only `summaries/`, `meta.json` and `config.toml` are committed — and the summaries are sharded by a hash of the node id, so two branches summarising different code write different files and never meet in a merge.
-- **Local-first.** The JSONL on disk is the source of truth; the optional [Neo4j backend](#optional-neo4j-backend) is a reconstructable projection most users never need.
-
-### Cross-repo federation
-
-Got nested repositories (a monorepo of indexed repos)? RepoSkein discovers them, links them with `FEDERATES_TO`, and stitches **cross-repo call, import, and heritage edges** (`INHERITS`/`IMPLEMENTS` to a base in a child repo) at load time. Pass `federated: true` to traverse across repo boundaries. Federation edges are derived at load (never committed), so each repo stays independently deterministic.
-
-## Visualize the graph — the constellation viewer
-
-```sh
-reposkein-mcp view .          # opens http://127.0.0.1:<port> in your browser
-```
-
-`view` starts a **local, read-only, zero-infra** web app (React + three.js, bound to `127.0.0.1`) that renders your `.reposkein` graph as an interactive 3D astronomy-style **constellation**. There's no Neo4j and no external service — it reads the JSONL on disk directly and never mutates it. **[Try the live demo →](https://reposkein.github.io/reposkein/)** (RepoSkein viewing its own multi-language graph).
-
-The map is **deterministic**: a seeded force layout means the same graph always lays out the same way (cached in IndexedDB for instant reloads), and the layout is render-time only — it never touches the JSONL. Levels of detail map onto an astronomy metaphor — **Repository → Directory → File → Symbol** become **galaxy → constellation → solar-system → star** — so you zoom or click to expand a cluster (a brief supernova animation) and click a star to inspect it. Federation galaxies and agent-written summaries render when present.
-
-- **Legible** — per-edge-type colors + legend, importance-sized stars, adaptive labels, breadcrumb, per-language galaxy coloring, depth fog / bloom / nebula halos.
-- **Edges encode resolution** — color = edge type (`CALLS`/`IMPORTS`/`INHERITS`/`IMPLEMENTS`/`INSTANTIATES`), opacity = confidence (`exact`/`name_match`/`ambiguous`), and flow particles show call direction.
-- **Analytical** — one-click lenses (call graph / type hierarchy / imports / tests), an impact overlay (transitive callers + covering tests), a confidence-audit mode (see where the type-free resolver guesses), and a temporal-coupling overlay (git co-change).
-- **Explorable** — ranked search-to-fly, N-hop neighborhood focus, source peek in the detail panel (a path-guarded read-only file slice + an "Open in editor" `vscode://` link), keyboard nav (`/` search, `f` frame-all, arrows to hop neighbors, `Esc` back), a minimap, and PNG screenshot export.
-- **Guided tour** — a cinematic, deterministically-derived flythrough (overview → largest modules → busiest hub → type hierarchy → entry point) with captions.
-
-```sh
-reposkein-mcp view --export ./site .   # write a self-contained static site
-```
-
-`--export` bakes the graph into `graph-data.js` (as `window.__REPOSKEIN_GRAPH__`) and emits a **self-contained static site** — it works from `file://` or any static host with no server, which is exactly how the live demo above is published. Handy for sharing a snapshot, embedding in docs, or a project landing page.
-
-## MCP tools
-
-| Tool | What it does |
-| --- | --- |
-| `semantic_find` | find where to start — rank functions/classes by meaning (lexical BM25F; optional [embeddings](#optional-semantic-embeddings)) |
-| `get_context_profile` | resolve a function/class → its caller/callee neighborhood as ready-to-read prose |
-| `impact` | transitive callers split into impacted code vs covering tests |
-| `get_temporal_context` | git-derived co-change, churn, and ownership for a file |
-| `read_cypher` | read-only graph queries (writes rejected, results capped) |
-| `write_semantic_summary` | attach a hash-stamped summary to a node |
-| `init_cpg_skeleton` | build/rebuild the graph |
-| `reindex_file` | refresh after editing a file |
-
-The `reposkein-mcp` CLI adds **`init`** (set up a repo), **`doctor`** (health check), **`index`** (rebuild the graph), and **`view`** (the [constellation viewer](#visualize-the-graph--the-constellation-viewer); `--export <dir>` writes a self-contained static site).
-
-## Optional: semantic embeddings
-
-By default `semantic_find` is **deterministic and lexical** (BM25F — zero-infra, no keys). You can opt into a **hybrid** tier (lexical + embedding cosine, fused via RRF) for fuzzier queries. It's **default-off**, vectors are cached in `.reposkein/local/embeddings/` (gitignored, never committed), and it **falls back to lexical** automatically on any error. Set env vars on the MCP server and **pick one**:
-
-### A) Voyage AI — cloud, easiest, best for code
-
-[Get a key](https://dashboard.voyageai.com/), then:
-```sh
-REPOSKEIN_EMBED_PROVIDER=voyage
-VOYAGE_API_KEY=pa-...
-# optional: REPOSKEIN_EMBED_MODEL=voyage-code-3   # default — code-specialized
-```
-> Sends document strings (qualified names, signatures, summaries) to Voyage's API. Use B or C if you can't egress code.
-
-### B) Ollama — local, off-the-shelf, no key
-
-```sh
-ollama pull nomic-embed-text     # 768-dim (or mxbai-embed-large=1024, bge-m3=1024)
-```
-```sh
-REPOSKEIN_EMBED_PROVIDER=http
-REPOSKEIN_EMBED_URL=http://127.0.0.1:11434/v1/embeddings
-REPOSKEIN_EMBED_MODEL=nomic-embed-text
-REPOSKEIN_EMBED_DIMS=768          # must match the model
-```
-
-### C) Voyage's open model, self-hosted — offline + Voyage quality
-
-`voyage-4-nano` (Apache-2.0) is a custom Qwen3-based model Ollama can't run, so RepoSkein ships a prebuilt server. The image is **published to GHCR — public and multi-arch (amd64/arm64)** — so there's nothing to build:
-
-```sh
-docker run -p 8080:8080 -v reposkein-hf:/root/.cache/huggingface \
-  ghcr.io/reposkein/reposkein-embed          # auto-picks your architecture; first run downloads the model
-```
-```sh
-REPOSKEIN_EMBED_PROVIDER=http
-REPOSKEIN_EMBED_URL=http://127.0.0.1:8080/v1/embeddings
-REPOSKEIN_EMBED_MODEL=voyage-4-nano
-REPOSKEIN_EMBED_DIMS=1024         # must equal the server's EMBED_DIMS
-```
-
-Everything stays on your machine. The image is **CPU-only and runs with no NVIDIA GPU** on Apple Silicon / ARM unified-memory, x64 Linux, and Windows (CI builds + smoke-tests both arches). Docker can't use Apple's Metal/MPS — for that, run the server natively with `EMBED_DEVICE=mps`. Full details (root `docker compose up`, GPU, other models): [`embed-server/README.md`](embed-server/README.md).
-
-> `REPOSKEIN_EMBED_DIMS` on the client **must match** the model's output dimension, or cosine scoring is skipped.
-
-## Optional: Neo4j backend
-
-The zero-infra JSONL store is the default. Neo4j is an optional projection for very large graphs and raw Cypher at scale:
-
-```sh
-docker compose --profile neo4j up -d          # from the repo root
-NEO4J_PASSWORD=reposkeintest reposkein-indexer load .
-```
-Then set `REPOSKEIN_STORE=neo4j` + the `NEO4J_*` env vars on the MCP server. (`REPOSKEIN_STORE=auto`, the default, uses JSONL when present and falls back to Neo4j only if configured.)
-
-## Benchmarks
-
-Two tracks, both under [`mcp/bench/`](mcp/bench/):
-
-- **Track 1 — retrieval efficiency** (deterministic, no LLM): RepoSkein vs a grep agent on hand-labeled tasks → **mean ~8.4× fewer context tokens** on structural queries, at F0.5 = 1.00 vs grep 0.11–0.71. [Details.](mcp/bench/README.md)
-- **Track 2 — end-task** ([SWE-bench-Verified](mcp/bench/track2/README.md)): a minimal agent loop where the *only* difference is the navigation toolset (RepoSkein vs grep), graded on resolve-rate + tokens + turns. Built + unit-tested; the API+Docker run is opt-in.
-
-## Build from source
-
-Requirements: Rust (stable), Node 24. Docker only for the optional Neo4j backend.
-
-```sh
-cd indexer && cargo build --release        # → indexer/target/release/reposkein-indexer
-cd ../mcp  && npm install && npm run build
-```
-
-Wire it into your agent with `command: node`, `args: [".../mcp/dist/index.js"]`, env `REPOSKEIN_REPO_PATH` + `REPOSKEIN_INDEXER_BIN`. Tests: `cd indexer && cargo test && cargo clippy --all-targets -- -D warnings`; `cd mcp && npm test`.
-
-### Repository layout
-
-```
-indexer/      Rust workspace: core, lang-{python,ts,rust,go,java,csharp}, lang-common, neo4j-io, cli
-mcp/          @reposkein/mcp — the TypeScript MCP server (tools + graph-store backends)
-mcp/bench/    benchmarks: retrieval efficiency (Track 1) + end-task SWE-bench harness (Track 2)
-skills/       reposkein-graph-rag + reposkein-setup — cross-agent skills (skills.sh)
-embed-server/ one-command local embedding server (voyage-4-nano) for hybrid semantic_find
-viz/          @reposkein/viz — the 3D constellation viewer SPA (served by `reposkein-mcp view`)
-```
+<a id="how-it-works"></a><a id="cross-repo-federation"></a><a id="visualize-the-graph--the-constellation-viewer"></a><a id="optional-semantic-embeddings"></a><a id="optional-neo4j-backend"></a><a id="build-from-source"></a><a id="repository-layout"></a>
+**Going deeper:** [how the graph is built + cross-repo federation](docs/ARCHITECTURE.md) · [the constellation viewer](docs/VIEWER.md) · [semantic embeddings](docs/EMBEDDINGS.md) · [Neo4j backend](docs/NEO4J.md) · [building from source + repo layout](CONTRIBUTING.md).
 
 ## Documentation
 
+Full index, task-oriented: **[`docs/README.md`](docs/README.md)**.
+
 | Doc | What's in it |
 | --- | --- |
-| [`mcp/README.md`](mcp/README.md) | the `@reposkein/mcp` package — tools, config, env vars |
+| [`mcp/README.md`](mcp/README.md) | the `@reposkein/mcp` package — tools, config, env vars, session usage stats |
 | [`viz/README.md`](viz/README.md) | the `@reposkein/viz` constellation viewer — architecture, dev/build |
 | [`embed-server/README.md`](embed-server/README.md) | the local embedding server — Docker/GHCR, platforms, GPU |
 | [`mcp/bench/README.md`](mcp/bench/README.md) | Track 1 retrieval benchmark — method + results |
@@ -342,7 +142,7 @@ Contributions are welcome — bug fixes, new languages, docs. See **[CONTRIBUTIN
 - [Model Context Protocol](https://modelcontextprotocol.io) — the agent integration standard.
 - [Voyage AI](https://voyageai.com) — `voyage-code-3` and the open-weight `voyage-4-nano` powering the optional embeddings tier.
 - Discovery via [Glama](https://glama.ai/mcp/servers), [skills.sh](https://skills.sh), [mcpservers.org](https://mcpservers.org), and the awesome-mcp community lists.
-- README header by [capsule-render](https://github.com/kyechan99/capsule-render) + [readme-typing-svg](https://github.com/DenverCoder1/readme-typing-svg).
+- README header by [capsule-render](https://github.com/kyechan99/capsule-render).
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The bundled `reposkein-graph-rag` skill drives a `semantic_find → get_context_
 - [Supported languages](#supported-languages)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
+- [Acknowledgements](#acknowledgements)
+- [Contact](#contact)
 - [License](#license)
 
 ## For teams

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,62 @@
+# How RepoSkein works
+
+For humans.
+
+Moved out of the [README](../README.md) so the front door stays short — this
+covers how the graph is built and resolved, how summaries stay merge-smooth,
+cross-repo federation, and the full per-language support matrix.
+
+## How it works
+
+```
+ Your agent (Claude Code / Cursor / …)   ── guided by the reposkein skill
+        │  MCP
+        ▼
+ @reposkein/mcp        semantic_find · get_context_profile · impact · get_temporal_context
+   (TypeScript)        read_cypher · write_semantic_summary · init_cpg_skeleton · reindex_file
+                       CLI: init · doctor · index · view
+        │ reads
+        ▼
+ .reposkein/           ← nodes.jsonl + edges.jsonl: derived, git-ignored, rebuilt on demand
+                       summaries/<xx>.jsonl: what your agents authored — commit this
+        ▲ writes
+        │
+ reposkein-indexer    Tree-sitter parse → stable IDs → canonical JSONL
+   (Rust)             + git hooks that keep the local graph in step with your tree
+```
+
+- **Structure is static.** The skeleton comes only from parsing — identical code produces a byte-identical graph (a CI-tested invariant), independent of who runs it.
+- **Meaning is just-in-time.** Summaries are written as the agent visits nodes; they're content-hash-stamped (so they flag stale when code changes) and committed to git.
+- **Derived stays out of git.** `nodes.jsonl` and `edges.jsonl` are a pure function of your working tree, so committing them buys nothing a re-index cannot rebuild while making every branch that touches code conflict with every other. Only `summaries/`, `meta.json` and `config.toml` are committed — and the summaries are sharded by a hash of the node id, so two branches summarising different code write different files and never meet in a merge.
+- **Local-first.** The JSONL on disk is the source of truth; the optional [Neo4j backend](NEO4J.md) is a reconstructable projection most users never need.
+
+Full detail on the shard scheme, merge behavior, and upgrading an existing repo off a single-file `summaries.jsonl`: [`INSTALL.md` §4.2](INSTALL.md#42-merge-behaviour-for-reposkein).
+
+### Architecture decisions (ADRs)
+
+Decisions your agent (or you) record with `record_decision` live as one committed JSON file per decision at `.reposkein/decisions/<date>-<slug>.json` — file-per-decision for the same reason summaries are sharded: parallel branches never merge-conflict on a forge. Decisions anchor to graph nodes and paths, so `get_context_profile` and `impact` surface the decisions governing a piece of code, and `semantic_find` includes them in its corpus for "why" questions. Full tool reference: [`docs/TOOLS.md`](TOOLS.md#architecture-decisions-adrs).
+
+### Cross-repo federation
+
+Got nested repositories (a monorepo of indexed repos)? RepoSkein discovers them, links them with `FEDERATES_TO`, and stitches **cross-repo call, import, and heritage edges** (`INHERITS`/`IMPLEMENTS` to a base in a child repo) at load time. Pass `federated: true` to traverse across repo boundaries. Federation edges are derived at load (never committed), so each repo stays independently deterministic.
+
+## Supported languages
+
+| Language | Definitions | Imports → edges | Cross-file calls |
+| --- | --- | --- | --- |
+| Python | functions, classes, methods, nested defs, vars | ✅ relative / absolute / aliased | import-resolved (`exact`) |
+| TypeScript / TSX | classes, interfaces, enums, methods, arrows | ✅ named / default / aliased / `* as ns` | import-resolved (`exact`) |
+| JavaScript / JSX | *(via the TS grammar)* | ✅ ES imports *(no CommonJS yet)* | import-resolved (`exact`) |
+| Rust | fns, structs, traits, enums, `impl` methods | ✅ `use` (groups, aliases, globs, `pub use` chains; workspace-aware) | import-resolved (`exact`) |
+| Go | funcs, methods (`Type.method`), structs, interfaces | *not yet (cross-package planned)* | same-package (same-dir); cross-package by name |
+| Java | classes, records, interfaces, enums, methods, constructors, fields | ✅ package-path *(no wildcard/static yet)* | import-resolved (`exact`) |
+| C# | classes, structs, records, interfaces, enums, methods, properties | *not yet (cross-namespace planned)* | same-dir; cross-namespace by name |
+
+**What resolves — honestly.** Every edge carries a `resolution` (`exact` / `name_match` / `ambiguous`) + confidence, so your agent knows what to trust. Same-file calls, `self`/`this` methods, and **import-followed free-function calls resolve `exact`**. Python **module-alias calls** (`import foo as f; f.bar()`) resolve `exact` to the target module's function. **Cross-file INHERITS/IMPLEMENTS edges** are resolved repo-wide: import-followed bases resolve `exact` (confidence 1.0); unique same-directory or repo-wide bases resolve `name_match` (0.8/0.7); ambiguous bases are skipped to avoid false hierarchy edges — and bases that live in a **federated child repo** are stitched into cross-repo heritage edges at load time. Go's **struct/interface embedding** (`type Dog struct { Animal }`) is captured as INHERITS. Constructors emit a distinct **`INSTANTIATES`** edge (`new Foo()` in TS/Java/C#, `Foo { .. }` and `Foo::new()` in Rust, `Foo{}` / `&Foo{}` composite literals in Go, and Python `Foo()` whose name resolves to a class) so an agent can ask *who creates instances of this type* — resolved against the type index and skipped when ambiguous. The graph is **type-free by design** (deterministic, no compiler in the loop), but it does track types where it can do so soundly from source alone: when a local is assigned a constructor (`x = Foo(); x.bar()`), that **`x.bar()` resolves `exact`** to `Foo.bar` (intraprocedural receiver typing). Method calls on receivers it *can't* trace that way (parameters, fields, return values) **resolve by name** (≤ `name_match`), and overloaded calls are flagged `ambiguous`. Go and C# don't emit import edges yet, so their cross-package/namespace calls resolve by name (same-package/-directory calls *do* resolve). These limits are inherent to the zero-infra, type-free design; a deeper optional type-aware layer (SCIP) is gated on benchmark evidence. [Adding a language](../CONTRIBUTING.md#adding-a-new-language) is a well-trodden path — contributions welcome.
+
+## See also
+
+- [`../README.md`](../README.md) — the front door.
+- [`TOOLS.md`](TOOLS.md) — the MCP tool + CLI reference.
+- [`VIEWER.md`](VIEWER.md) — the constellation viewer.
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — dev setup, invariants, adding a language.

--- a/docs/EMBEDDINGS.md
+++ b/docs/EMBEDDINGS.md
@@ -1,0 +1,53 @@
+# Semantic embeddings
+
+For humans.
+
+Moved out of the [README](../README.md) so the front door stays short.
+
+By default `semantic_find` is **deterministic and lexical** (BM25F — zero-infra, no keys). You can opt into a **hybrid** tier (lexical + embedding cosine, fused via RRF) for fuzzier queries. It's **default-off**, vectors are cached in `.reposkein/local/embeddings/` (gitignored, never committed), and it **falls back to lexical** automatically on any error. Set env vars on the MCP server and **pick one**:
+
+## A) Voyage AI — cloud, easiest, best for code
+
+[Get a key](https://dashboard.voyageai.com/), then:
+```sh
+REPOSKEIN_EMBED_PROVIDER=voyage
+VOYAGE_API_KEY=pa-...
+# optional: REPOSKEIN_EMBED_MODEL=voyage-code-3   # default — code-specialized
+```
+> Sends document strings (qualified names, signatures, summaries) to Voyage's API. Use B or C if you can't egress code.
+
+## B) Ollama — local, off-the-shelf, no key
+
+```sh
+ollama pull nomic-embed-text     # 768-dim (or mxbai-embed-large=1024, bge-m3=1024)
+```
+```sh
+REPOSKEIN_EMBED_PROVIDER=http
+REPOSKEIN_EMBED_URL=http://127.0.0.1:11434/v1/embeddings
+REPOSKEIN_EMBED_MODEL=nomic-embed-text
+REPOSKEIN_EMBED_DIMS=768          # must match the model
+```
+
+## C) Voyage's open model, self-hosted — offline + Voyage quality
+
+`voyage-4-nano` (Apache-2.0) is a custom Qwen3-based model Ollama can't run, so RepoSkein ships a prebuilt server. The image is **published to GHCR — public and multi-arch (amd64/arm64)** — so there's nothing to build:
+
+```sh
+docker run -p 8080:8080 -v reposkein-hf:/root/.cache/huggingface \
+  ghcr.io/reposkein/reposkein-embed          # auto-picks your architecture; first run downloads the model
+```
+```sh
+REPOSKEIN_EMBED_PROVIDER=http
+REPOSKEIN_EMBED_URL=http://127.0.0.1:8080/v1/embeddings
+REPOSKEIN_EMBED_MODEL=voyage-4-nano
+REPOSKEIN_EMBED_DIMS=1024         # must equal the server's EMBED_DIMS
+```
+
+Everything stays on your machine. The image is **CPU-only and runs with no NVIDIA GPU** on Apple Silicon / ARM unified-memory, x64 Linux, and Windows (CI builds + smoke-tests both arches). Docker can't use Apple's Metal/MPS — for that, run the server natively with `EMBED_DEVICE=mps`. Full details (root `docker compose up`, GPU, other models): [`../embed-server/README.md`](../embed-server/README.md).
+
+> `REPOSKEIN_EMBED_DIMS` on the client **must match** the model's output dimension, or cosine scoring is skipped.
+
+## See also
+
+- [`INSTALL.md` §3](INSTALL.md) — the agent-facing decision tree (off / cloud / local) with defaults to suggest.
+- [`../embed-server/README.md`](../embed-server/README.md) — the local embedding server package.

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -1,5 +1,7 @@
 # Host your constellation
 
+For humans.
+
 RepoSkein's viewer can export a **self-contained static site** — the graph
 is baked into `graph-data.js`, so the exported folder needs no server, no
 Neo4j, and no network access. That makes it easy to publish a durable,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,5 +1,7 @@
 # RepoSkein — Agent Install Guide
 
+Agent-executable — also readable by humans.
+
 > **For agents:** the user pasted this document because they want you to install [RepoSkein](https://github.com/reposkein/reposkein) in their repo (or a workspace containing several repos). RepoSkein is a deterministic code-graph MCP server. **Read this whole document first.** Then ask the user the question-tree in §1, then execute §2–§7 in order. The minimal happy path is `npx @reposkein/mcp init` per git repo — everything else is optional.
 >
 > **For humans:** prefer the [README](../README.md) for usage. This file is for handing off to an agent ("here, install it for me, ask me what I need").
@@ -315,7 +317,7 @@ The MCP server runs over stdio. The command is `reposkein-mcp` (global) or `npx 
 
 | Var | Required | Notes |
 |---|---|---|
-| `REPOSKEIN_REPO_PATH` | **Yes** for repo-scoped tools | Absolute path. One MCP server entry = one repo path. |
+| `REPOSKEIN_REPO_PATH` | No — recommended for a single-repo config | Absolute path, pins resolution for that server entry. Without it the server resolves the repo from its cwd (nearest ancestor with `.reposkein/`, or a workspace scan — see `list_repos`/`select_repo` in [`docs/TOOLS.md`](TOOLS.md)); still set it explicitly when the server's cwd won't match the repo (most agent-launched configs). |
 | `REPOSKEIN_STORE` | No | `auto` (default — JSONL if present else Neo4j), `jsonl`, `neo4j`. |
 | `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD` | If `REPOSKEIN_STORE=neo4j` or `auto`-with-Neo4j | — |
 | `REPOSKEIN_EMBED_PROVIDER` | If §1-Q3 ≠ off | `voyage`, `http`, or unset for lexical-only. |
@@ -348,7 +350,7 @@ Write `<repo>/.mcp.json`:
 }
 ```
 
-Drop any block whose feature the user didn't enable. `REPOSKEIN_REPO_PATH` is the only required key.
+Drop any block whose feature the user didn't enable. No key is strictly required — `REPOSKEIN_REPO_PATH` is optional (see §6 table) — but set it explicitly for any config an agent writes on the user's behalf, since the server's cwd at launch is rarely the repo root.
 
 > **Gitignore `.mcp.json` / `opencode.json`.** They hold absolute machine paths and a local `NEO4J_PASSWORD`, so they are per-machine and must not be committed. `reposkein-mcp init` adds them to `.gitignore` for you; if you write them by hand, do the same. What is shared from `.reposkein/` is `meta.json`, `config.toml`, `.gitignore`, `.gitattributes`, `summaries/` and `decisions/` (§4.2).
 
@@ -477,7 +479,8 @@ npx skills add reposkein/reposkein --all
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `REPOSKEIN_REPO_PATH (or REPOSKEIN_REPO_ID) must be set` | The env var is missing from the MCP server entry. | Add it to the agent's MCP config (§6). |
+| `No RepoSkein repo found (checked the current directory, its ancestors, and its immediate subdirectories for .reposkein/)` | Resolution failed: no `REPOSKEIN_REPO_PATH`, no `.reposkein/` in the server's cwd or its ancestors/children. | Run `reposkein-mcp init` in the target repo, call `list_repos` to see what was discovered, or set `REPOSKEIN_REPO_PATH` to its root (§6). |
+| `Multiple RepoSkein repos were found … and none is selected` | Workspace mode found 2+ sibling repos with none selected. | Call `list_repos`, then `select_repo` with one of its `path`/`name` values. |
 | `npm install -g @reposkein/mcp` succeeds but no `reposkein-indexer` binary | Postinstall fetch failed. | Re-run `npm install -g @reposkein/mcp --force` with network access. Else point `REPOSKEIN_INDEXER_BIN` at a [from-source build](https://github.com/reposkein/reposkein#build-from-source). |
 | Binary fetch hangs or fails behind a corporate firewall | No proxy configured for the download. | Set `HTTPS_PROXY` (and `NO_PROXY` for internal hosts) — see §2 — or set `REPOSKEIN_INDEXER_BIN` to skip the fetch entirely. |
 | `TypeError: create_causal_mask() got an unexpected keyword argument 'input_embeds'` | Native embed-server with `transformers >= 5.0`. | `uv pip install 'transformers>=4.51,<5'` and restart. |

--- a/docs/NEO4J.md
+++ b/docs/NEO4J.md
@@ -1,0 +1,18 @@
+# Neo4j backend
+
+For humans.
+
+Moved out of the [README](../README.md) so the front door stays short.
+
+The zero-infra JSONL store is the default. Neo4j is an optional projection for very large graphs and raw Cypher at scale:
+
+```sh
+docker compose --profile neo4j up -d          # from the repo root
+NEO4J_PASSWORD=reposkeintest reposkein-indexer load .
+```
+Then set `REPOSKEIN_STORE=neo4j` + the `NEO4J_*` env vars on the MCP server. (`REPOSKEIN_STORE=auto`, the default, uses JSONL when present and falls back to Neo4j only if configured.)
+
+## See also
+
+- [`INSTALL.md` §2](INSTALL.md) — the agent-facing decision tree for JSONL vs Neo4j, including env vars for a non-Docker Neo4j instance.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — why JSONL, not Neo4j, is the source of truth.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# RepoSkein docs
+
+For humans.
+
+Task-oriented index of everything under `docs/`. Package-level docs
+(`mcp/`, `viz/`, `embed-server/`, benchmarks) live next to their code — see
+the [root README's Documentation table](../README.md#documentation).
+
+## Getting started / joining a team
+
+- **Setting up a new repo, workspace, or agent config?** → [`INSTALL.md`](INSTALL.md) — written for agents to execute: a question tree (§1) covering one repo vs workspace, JSONL vs Neo4j, embeddings tier, and which agent CLIs to wire, then step-by-step setup (§2–§7) and troubleshooting (§9).
+- **Joining a repo that already has RepoSkein set up?** → [`INSTALL.md` §0](INSTALL.md#0-joining-an-existing-reposkein-repo) — the one-command `git clone && cd && npx @reposkein/mcp init` path (auto-detects and wires up your agent's config).
+- **Publishing a shareable, always-current view of the graph?** → [`HOSTING.md`](HOSTING.md) — GitHub Pages via `reposkein-mcp init --ci`, or any other static host.
+
+## Using it day to day
+
+- **What tools does the agent have, and how does it use them?** → [`TOOLS.md`](TOOLS.md) — the agent workflow, an example interaction, the full MCP tool reference, the `reposkein-mcp` CLI reference, and Architecture Decision Records (ADRs).
+- **Visualizing the graph?** → [`VIEWER.md`](VIEWER.md) — the 3D constellation viewer (`reposkein-mcp view`), its lenses/overlays, and static export.
+- **Wiring up semantic search?** → [`EMBEDDINGS.md`](EMBEDDINGS.md) — the optional hybrid embeddings tier: cloud (Voyage), local (Ollama), or self-hosted (`voyage-4-nano`).
+- **Scaling past the default store?** → [`NEO4J.md`](NEO4J.md) — the optional Neo4j backend, for very large graphs or raw Cypher.
+
+## Understanding the system
+
+- **How is the graph built, resolved, and kept merge-smooth?** → [`ARCHITECTURE.md`](ARCHITECTURE.md) — the indexer/MCP pipeline, summary sharding, cross-repo federation, and the full per-language support matrix.
+- **Recording or reviewing a design decision?** → [`TOOLS.md` — Architecture decisions (ADRs)](TOOLS.md#architecture-decisions-adrs) — how `record_decision` et al. anchor to the graph, and `reposkein-mcp adr export/import` for human-readable review.
+
+## History
+
+- **Migrations** — [`migrations/`](migrations/): [`2026-08-06-stop-committing-derived-graph.md`](migrations/2026-08-06-stop-committing-derived-graph.md) (moving `nodes.jsonl`/`edges.jsonl` out of git).
+- **Policies** — [`policies/`](policies/): [`bulk-resummarization-sweeps.md`](policies/bulk-resummarization-sweeps.md) (why bulk summary rewrites must run serialized on `main`).
+
+## See also
+
+- [`../README.md`](../README.md) — the project front door.
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — dev setup, invariants, adding a language.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,89 @@
+# MCP tools
+
+For humans and agents.
+
+Moved out of the [README](../README.md) so the front door stays short — everything an agent does with RepoSkein, tool by tool, plus the CLI.
+
+## The agent workflow
+
+You ask in plain language; the bundled **`reposkein-graph-rag`** skill drives the tools. The natural loop:
+
+1. **Find where to start** — `semantic_find("jwt auth validation")` ranks the right functions by meaning, no symbol name needed. → *"where's the rate limiter?"*
+2. **Understand it** — `get_context_profile` returns the node's callers + callees as ready-to-read prose (`hops: 2` widens, `federated: true` spans nested repos).
+3. **Before you change it** — `impact` lists transitive callers (what could break) split from the tests that cover it (what to run). → *"what breaks if I change `charge()`?"*
+4. **What moves with it** — `get_temporal_context` surfaces files that historically change together, plus churn and ownership. → *"what usually changes with the auth config?"*
+5. **Record what you learned** — `write_semantic_summary` attaches a 1–3 sentence note to the node, landing in `.reposkein/summaries/<xx>.jsonl` for you to commit for the next agent/teammate.
+6. **After editing** — `reindex_file` refreshes the graph for the changed file.
+
+**Multi-repo workspace?** Start with `list_repos` to see what RepoSkein discovered, then `select_repo` (by `path` or `name`) before calling the tools above — only needed when more than one sibling repo is found with none selected. Single-repo setups need no selection: resolution is zero-config (see [`ARCHITECTURE.md`](ARCHITECTURE.md#how-it-works) / [`../mcp/README.md`](../mcp/README.md#repo-resolution-zero-config)).
+
+<details>
+<summary><b>Example interaction</b></summary>
+
+```text
+You:    Refactor how we validate auth tokens — what's involved?
+
+Agent:  → semantic_find("validate auth token")        → resolves auth.validate_jwt
+        → get_context_profile(auth.validate_jwt)       → 3 callers, 2 callees (+ summaries)
+        → impact(auth.validate_jwt)                    → 6 impacted functions, 4 covering tests
+        → get_temporal_context("src/auth/jwt.py")      → co-changes with config/keys.py (conf 0.8)
+
+Agent:  "validate_jwt is called by the login, refresh, and middleware paths;
+         changing its signature touches 6 functions and 4 tests (test_jwt.py,
+         test_middleware.py, …). Heads up: jwt.py historically changes together
+         with config/keys.py — you'll likely need to update both."
+```
+
+</details>
+
+### Agent skills
+
+RepoSkein ships two cross-agent [Agent Skills](https://skills.sh) — `npx skills add reposkein/reposkein --all` installs both into Claude Code, Cursor, Codex, and 70+ agents:
+
+- **`reposkein-setup`** — installs RepoSkein in a repo and verifies it's running (binary → index → MCP reachability). Ask your agent to run it.
+- **`reposkein-graph-rag`** — teaches your agent *when* to use each tool (the loop above), including when to record a decision. `reposkein-mcp init` installs it automatically for Claude Code.
+
+## Tool reference
+
+| Tool | What it does |
+| --- | --- |
+| `list_repos` | enumerate the repos discovered by resolution — path, name, cheap node/edge counts. One entry in single-repo mode; workspace mode lists every sibling repo found. |
+| `select_repo` | set the session-active repo (by `path` or `name` from `list_repos`) for every repo-scoped tool below, for the rest of the connection. |
+| `semantic_find` | find where to start — rank functions/classes by meaning (lexical BM25F; optional [embeddings](EMBEDDINGS.md)). "Why" questions also surface `Decision` rows — follow up with `get_decision`. |
+| `get_context_profile` | resolve a function/class → its caller/callee neighborhood as ready-to-read prose, plus up to 5 governing decisions. |
+| `impact` | transitive callers split into impacted code vs covering tests, plus governing decisions over the target and impacted rows. |
+| `get_temporal_context` | git-derived co-change, churn, and ownership for a file. |
+| `read_cypher` | read-only graph queries (writes rejected, results capped at 200 rows / 64KB). |
+| `write_semantic_summary` | attach a hash-stamped summary to a node. |
+| `init_cpg_skeleton` | build/rebuild the graph. |
+| `reindex_file` | refresh after editing a file. |
+| `record_decision` | record an Architecture Decision Record (ADR) anchored to the graph nodes/paths it governs; lands as `proposed` by default; pass `supersedes` to replace an earlier decision. |
+| `set_decision_status` | change an ADR's lifecycle status: `proposed→accepted`, `proposed→rejected`, `accepted→deprecated` (`superseded` only happens via `record_decision`'s `supersedes`). |
+| `reaffirm_decision` | re-stamp an ADR's anchors after verifying the changed code still conforms, clearing staleness without superseding. |
+| `list_decisions` | list ADRs (id, title, status, anchor drift counts), filterable by status, anchor, or free-text. |
+| `get_decision` | full ADR record: context, decision, consequences, alternatives, live anchor states, and the supersession chain. |
+
+## CLI reference
+
+| Command | What it does |
+| --- | --- |
+| `reposkein-mcp init [path]` | set up a repo — indexer, git hooks, skill, initial graph. `--ci` also writes the GitHub Pages publish workflow ([`HOSTING.md`](HOSTING.md)); on a repo joined from a committed `.reposkein/meta.json`, auto-detects and writes local agent MCP config instead of printing a snippet. |
+| `reposkein-mcp doctor [path]` | health check (indexer binary, index, repo id, hooks, graph freshness). `--json` for machine output; `--ci` additionally fails on a stale graph, missing hooks, or an unsplit legacy `summaries.jsonl`. |
+| `reposkein-mcp index [path]` | (re)build the committed graph. |
+| `reposkein-mcp view [path]` | open the [constellation viewer](VIEWER.md) (`--export <dir>` for a static site). |
+| `reposkein-mcp stats [path]` | session usage report — calls by tool, top queried nodes/files, ADRs/summaries written, session duration, and an estimated context-tokens-saved-vs-grep number. |
+| `reposkein-mcp adr export/import [path] [dir]` | see [Architecture decisions](#architecture-decisions-adrs) below. |
+
+## Architecture decisions (ADRs)
+
+Decisions recorded via `record_decision` (and friends, above) live as one committed JSON file per decision at `.reposkein/decisions/<date>-<slug>.json` — file-per-decision so parallel branches never merge-conflict on a forge, the same lesson the [summary shards](INSTALL.md#42-merge-behaviour-for-reposkein) apply. Each has a portable `adr:<date>-<slug>` id, an immutable body (`body_hash`-stamped), and anchors — graph nodes or path prefixes the decision governs — whose state (`current`/`stale`/`moved`/`orphaned`) is recovered via content-hash matching as code changes around them.
+
+`reposkein-mcp doctor` validates the decision log (parse failures, duplicate ids, tampered `body_hash`, dangling/cyclic supersession) as a non-critical, degrade-don't-block check.
+
+For human review or interop with `adr-tools` / `log4brains` / `Backstage`, `reposkein-mcp adr export [path] [dir]` renders the committed records to Nygard-format markdown under `docs/adr/` (derived — the JSON records stay the system of record). `reposkein-mcp adr import [path] [dir]` reads an existing Nygard/MADR-style markdown ADR log the other direction, creating unanchored records a human can later reaffirm.
+
+## See also
+
+- [`../README.md`](../README.md) — the front door.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — how the graph these tools query is built.
+- [`../mcp/README.md`](../mcp/README.md) — the `@reposkein/mcp` package: full config/env var reference, session usage stats detail.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -36,6 +36,8 @@ Agent:  "validate_jwt is called by the login, refresh, and middleware paths;
 
 </details>
 
+> 🎥 A short screen recording is on the roadmap — see [Documentation](../README.md#documentation).
+
 ### Agent skills
 
 RepoSkein ships two cross-agent [Agent Skills](https://skills.sh) — `npx skills add reposkein/reposkein --all` installs both into Claude Code, Cursor, Codex, and 70+ agents:

--- a/docs/VIEWER.md
+++ b/docs/VIEWER.md
@@ -1,0 +1,36 @@
+# Constellation viewer
+
+For humans.
+
+Moved out of the [README](../README.md) so the front door stays short.
+
+```sh
+reposkein-mcp view .          # opens http://127.0.0.1:<port> in your browser
+```
+
+`view` starts a **local, read-only, zero-infra** web app (React + three.js, bound to `127.0.0.1`) that renders your `.reposkein` graph as an interactive 3D astronomy-style **constellation**. There's no Neo4j and no external service — it reads the JSONL on disk directly and never mutates it. **[Try the live demo →](https://reposkein.github.io/reposkein/)** (RepoSkein viewing its own multi-language graph).
+
+The map is **deterministic**: a seeded force layout means the same graph always lays out the same way (cached in IndexedDB for instant reloads), and the layout is render-time only — it never touches the JSONL. Levels of detail map onto an astronomy metaphor — **Repository → Directory → File → Symbol** become **galaxy → constellation → solar-system → star** — so you zoom or click to expand a cluster (a brief supernova animation) and click a star to inspect it. Federation galaxies and agent-written summaries render when present.
+
+- **Legible** — per-edge-type colors + legend, importance-sized stars, adaptive labels, breadcrumb, per-language galaxy coloring, depth fog / bloom / nebula halos.
+- **Edges encode resolution** — color = edge type (`CALLS`/`IMPORTS`/`INHERITS`/`IMPLEMENTS`/`INSTANTIATES`), opacity = confidence (`exact`/`name_match`/`ambiguous`), and flow particles show call direction.
+- **Analytical** — one-click lenses (call graph / type hierarchy / imports / tests), an impact overlay (transitive callers + covering tests), a confidence-audit mode (see where the type-free resolver guesses), and a temporal-coupling overlay (git co-change).
+- **Explorable** — ranked search-to-fly, N-hop neighborhood focus, source peek in the detail panel (a path-guarded read-only file slice + an "Open in editor" `vscode://` link), keyboard nav (`/` search, `f` frame-all, arrows to hop neighbors, `Esc` back), a minimap, and PNG screenshot export.
+- **Guided tour** — a cinematic, deterministically-derived flythrough (overview → largest modules → busiest hub → type hierarchy → entry point) with captions.
+
+```sh
+reposkein-mcp view --export ./site .   # write a self-contained static site
+```
+
+`--export` bakes the graph into `graph-data.js` (as `window.__REPOSKEIN_GRAPH__`) and emits a **self-contained static site** — it works from `file://` or any static host with no server, which is exactly how the live demo above is published. Handy for sharing a snapshot, embedding in docs, or a project landing page.
+
+## Publishing a durable link
+
+Want a shareable, always-current URL instead of a one-off export? See [`HOSTING.md`](HOSTING.md) — GitHub Pages via `reposkein-mcp init --ci`, or any other static host.
+
+## See also
+
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — how the graph underneath the viewer is built.
+- [`HOSTING.md`](HOSTING.md) — publishing an exported constellation.
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md#working-on-the-viewer-viz) — working on `viz/` itself.
+- [`../viz/README.md`](../viz/README.md) — the `@reposkein/viz` package (architecture, dev/build).

--- a/docs/migrations/2026-08-06-stop-committing-derived-graph.md
+++ b/docs/migrations/2026-08-06-stop-committing-derived-graph.md
@@ -1,5 +1,10 @@
 # Migration: stop committing the derived RepoSkein graph
 
+For humans. Historical — describes a past migration; the single-file
+`summaries.jsonl` it introduces below was itself later replaced by sharded
+`summaries/<xx>.jsonl` (see [`../INSTALL.md` §4.2](../INSTALL.md#42-merge-behaviour-for-reposkein)
+for the current scheme and the follow-up migration off this file).
+
 Status: plan only. Nothing here has been executed.
 Written: 2026-08-06.
 Applies to: any repository that already has `.reposkein/nodes.jsonl` and

--- a/docs/policies/bulk-resummarization-sweeps.md
+++ b/docs/policies/bulk-resummarization-sweeps.md
@@ -1,5 +1,7 @@
 # Policy: bulk re-summarization sweeps run serialized on `main`
 
+For humans and agents.
+
 Status: active.
 Written: 2026-08-20.
 Applies to: any repository committing `.reposkein/summaries/`.


### PR DESCRIPTION
The README was information-overloaded. It is now a front door (98 prose lines, was ~350+): what/why → live demo → agent-asks table → quickstart → For teams → pointers. Depth moved — verbatim, zero information loss (reviewer-audited byte-for-byte) — into `docs/`.

## What changed
- **README**: one badge row + "Listed on" footer; kept the agent-asks/RepoSkein-answers table and 3-command quickstart; new **For teams** section (join = `npx @reposkein/mcp init`, hosted constellation, summaries as shared team memory). Every removed heading keeps its old anchor via explicit `<a id>` shims — inbound links don't break.
- **New docs**: `docs/TOOLS.md` (15-tool catalog + usage walkthrough), `docs/EMBEDDINGS.md`, `docs/NEO4J.md`, `docs/ARCHITECTURE.md`, `docs/VIEWER.md`; build-from-source merged into `CONTRIBUTING.md`.
- **docs/README.md index**: task-oriented map of every doc (join, tools, viewer, hosting, embeddings, neo4j, architecture, decisions, migrations, policies). Every doc opens with an audience line (human / agent-executable).
- **Accuracy sweep**: moved content updated, not copied — reflects zero-config repo resolution, sharded summaries, `stats`, the join flow; retired mechanisms appear only in past-tense migration context.
- Scripted link+anchor check across all changed markdown: zero broken.

Linear: REP-12, REP-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)