### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ All notable changes to RepoSkein. Format roughly follows
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-21
+
+### Added
+
+- **Zero-config repo resolution.** `reposkein-mcp` no longer needs
+  `REPOSKEIN_REPO_PATH` set up front: it walks up to the nearest ancestor
+  `.reposkein/`, or (workspace mode) walks down two levels for a single
+  unambiguous hit. New `list_repos` / `select_repo` MCP tools let an agent
+  enumerate and switch the session-active repo mid-connection — the fix for
+  "can't switch repos without a restart." (#44)
+- **Per-session usage stats.** Every MCP tool call is now logged to
+  `.reposkein/local/sessions/<session-id>.jsonl`, and `reposkein-mcp stats
+  [--last | --session <id> | --all] [--json]` reports calls by tool, top
+  queried nodes/files, ADRs/summaries written, and an estimated
+  context-tokens-saved-vs-grep figure. (#45)
+- **Merge-smooth summaries.** Committed summaries move from one
+  `summaries.jsonl` to sharded storage at `.reposkein/summaries/<xx>.jsonl`
+  (keyed by content hash), so two branches summarising different nodes no
+  longer collide on the same file. Tolerant readers survive merge conflict
+  markers and cross-source divergence, preserving the losing summary rather
+  than dropping it. The layout migration runs automatically the next time a
+  repo is indexed — no manual step. `reposkein-mcp doctor` gained checks for
+  unsplit legacy files and `.gitignore` rules that silently mask shards. (#46)
+- **Hosted constellation.** A reusable `publish-pages.yml` workflow
+  downloads a released `reposkein-indexer` binary instead of building from
+  source, asserts binary/repo schema compatibility via a new
+  `--schema-version` flag, and exports a staleness badge and durable deep
+  links (survives a federated `repo_id` change) into the published viewer.
+  `reposkein-mcp init --ci` writes the workflow template into a consuming
+  repo. (#47)
+- **One-command team join.** `reposkein-mcp init` now detects a fresh clone
+  of an already-`.reposkein`-committed repo and writes MCP config for
+  whichever agent(s) it finds (Claude Code, opencode, Cursor) instead of
+  printing a snippet to copy by hand. `doctor --ci` promotes drift checks to
+  a failing exit code for CI use, and the binary fetch is now proxy-aware
+  (`HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY`). (#48)
+- **⌘K command palette.** The viewer gains a keyboard-driven palette over
+  nodes and commands, fully keyboard-navigable and accessibility-correct.
+  (#51)
+
+### Changed
+
+- **Viewer stack: React 19 + React Three Fiber v9.** The Astrolabe redesign's
+  foundation — `@react-three/drei` v10, `@react-three/postprocessing` v3,
+  `three` 0.185, a `frameloop="demand"` render loop (every frame now has an
+  explicit trigger), and a store split so pointer-rate state no longer
+  re-renders the whole HUD. Verified pixel-equivalent against the previous
+  build; zero intended visual change. (#50)
+
+### Docs
+
+- **README and docs overhaul.** The README becomes a front door; `docs/`
+  gets a task-oriented index. (#49)
+
 ## [0.3.0] - 2026-08-20
 
 ### Added

--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -1083,7 +1083,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reposkein-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-indexer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "reposkein-core",
  "tree-sitter",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-csharp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-go"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-java"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-python"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-rust"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-ts"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-neo4j-io"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "neo4rs",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/lang-common", "crates/cli", "crates/lang-python", "crates/lang-ts", "crates/lang-rust", "crates/lang-go", "crates/lang-java", "crates/neo4j-io", "crates/lang-csharp"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/reposkein/reposkein"

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reposkein/mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Deterministic code-graph (GraphRAG) MCP server — give your AI agent callers/callees, change-impact, and semantic search over your repo instead of grep. 7 languages, zero-infra, git-native.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Cuts the release carrying the team-access + Astrolabe-foundation work (#44–#51). Bumps the Rust workspace and @reposkein/mcp in lockstep and adds the 0.4.0 changelog entry.

**Motivation:** GitHub Pages publishing is currently red — the new reusable publish workflow correctly refuses the v0.3.0 binary, which predates `--schema-version`. Tagging v0.4.0 builds binaries that satisfy the schema-compat gate, unblocking the hosted constellation.

Highlights: zero-config repo resolution + `list_repos`/`select_repo` (#44) · per-session usage stats + `stats` CLI (#45) · merge-smooth sharded summaries (#46) · hosted constellation workflow + staleness badge + durable deep links (#47) · one-command team join + `doctor --ci` (#48) · README/docs overhaul (#49) · viz React 19/R3F v9 foundation (#50) + ⌘K command palette (#51).

Verified: version lockstep green, indexer builds, core tests 139/139, mcp 699/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)