### PR TITLE
feat(viz): Astrolabe V5 polish — coach mark, responsive chrome, a11y floor, tokens, ledger cleanup (REP-22)

### DIFF
--- a/mcp/src/cli/view.ts
+++ b/mcp/src/cli/view.ts
@@ -128,7 +128,26 @@ function githubHttpsUrl(remote: string): string | null {
   return null;
 }
 
-function buildManifest(repoId: string, repoRoot: string, meta: RepoBakeMeta): string {
+/** Counts records in a `.jsonl` file's text: one non-blank line, one record.
+ *  Tolerates a trailing newline (the common case) and any stray blank lines
+ *  without over- or under-counting. Shared by the live manifest and the
+ *  static-export bake (REP-22 polish: both used to hardcode `{ nodes: 0,
+ *  edges: 0 }` with a "the client re-derives" comment — true for the live
+ *  worker path, but the baked `graph-data.js` payload is also a document
+ *  other tooling may read directly, so a real count belongs in it too). */
+function countJsonlRecords(text: string): number {
+  if (!text) return 0;
+  let count = 0;
+  for (const line of text.split("\n")) if (line.trim().length > 0) count++;
+  return count;
+}
+
+function buildManifest(
+  repoId: string,
+  repoRoot: string,
+  meta: RepoBakeMeta,
+  counts: { nodes: number; edges: number },
+): string {
   return JSON.stringify({
     root: {
       repoId,
@@ -144,7 +163,7 @@ function buildManifest(repoId: string, repoRoot: string, meta: RepoBakeMeta): st
       repoRoot,
     },
     federated: [], // M1: single repo. Federation deferred to M3.
-    counts: { nodes: 0, edges: 0 }, // counts are advisory; the client re-derives.
+    counts,
     meta,
   });
 }
@@ -188,9 +207,14 @@ export function makeViewHandler(repoPath: string, repoId: string) {
   const distDir = vizDistDir();
 
   const repoRoot = resolve(repoPath);
-  // Computed once (shells out to git) — cheap and stable for the server's
-  // lifetime; recomputing per-request would add a git spawn to every load.
+  // Computed once (shells out to git / reads the JSONL files) — cheap and
+  // stable for the server's lifetime; recomputing per-request would add a
+  // git spawn and two file reads to every /api/graph hit.
   const repoMeta = resolveServerRepoMeta(repoPath);
+  const counts = {
+    nodes: existsSync(nodesPath) ? countJsonlRecords(readFileSync(nodesPath, "utf8")) : 0,
+    edges: existsSync(edgesPath) ? countJsonlRecords(readFileSync(edgesPath, "utf8")) : 0,
+  };
 
   return function handler(req: IncomingMessage, res: ServerResponse): void {
     const rawUrl = req.url ?? "/";
@@ -199,7 +223,7 @@ export function makeViewHandler(repoPath: string, repoId: string) {
 
     // --- API routes ---
     if (url === "/api/graph") {
-      sendGzip(res, buildManifest(repoId, repoRoot, repoMeta), "application/json; charset=utf-8");
+      sendGzip(res, buildManifest(repoId, repoRoot, repoMeta, counts), "application/json; charset=utf-8");
       return;
     }
 
@@ -462,7 +486,7 @@ export function buildGraphDataJs(
         nodesUrl: "",
         edgesUrl: "",
       })),
-      counts: { nodes: 0, edges: 0 },
+      counts: { nodes: countJsonlRecords(nodesText), edges: countJsonlRecords(edgesText) },
     },
     nodesText,
     edgesText,

--- a/mcp/test/viewExport.test.ts
+++ b/mcp/test/viewExport.test.ts
@@ -33,6 +33,24 @@ describe("buildGraphDataJs (static export baking)", () => {
     expect(payload.manifest.federated).toEqual([]);
   });
 
+  it("populates manifest.counts from the real node/edge line counts (fix round 2 / REP-22 polish — was hardcoded 0/0)", () => {
+    const js = buildGraphDataJs(
+      "demo",
+      '{"id":"a"}\n{"id":"b"}\n{"id":"c"}\n',
+      '{"from":"a","to":"b"}\n',
+    );
+    const json = js.replace(/^window\.__REPOSKEIN_GRAPH__ = /, "").replace(/;\n$/, "");
+    const payload = JSON.parse(json) as { manifest: { counts: { nodes: number; edges: number } } };
+    expect(payload.manifest.counts).toEqual({ nodes: 3, edges: 1 });
+  });
+
+  it("counts tolerate a missing trailing newline and ignore stray blank lines", () => {
+    const js = buildGraphDataJs("demo", '{"id":"a"}\n\n{"id":"b"}', "");
+    const json = js.replace(/^window\.__REPOSKEIN_GRAPH__ = /, "").replace(/;\n$/, "");
+    const payload = JSON.parse(json) as { manifest: { counts: { nodes: number; edges: number } } };
+    expect(payload.manifest.counts).toEqual({ nodes: 2, edges: 0 });
+  });
+
   it("does NOT bake an absolute repoRoot (shared export, no leak)", () => {
     const js = buildGraphDataJs("demo", "n\n", "e\n");
     expect(js).not.toContain("repoRoot");

--- a/viz/src/data/breadcrumbPath.test.ts
+++ b/viz/src/data/breadcrumbPath.test.ts
@@ -243,3 +243,34 @@ describe("breadcrumbMaxVisibleForWidth (fix round 1, #2)", () => {
     expect(breadcrumbMaxVisibleForWidth(360)).toBe(3);
   });
 });
+
+/** `inspectorOpen=true` (fix round 2 / REP-22 polish, review finding #5 —
+ *  previously untested directly, only exercised indirectly through
+ *  StatusBar.test.tsx's integration test). Reserves the Inspector's own
+ *  360px column + 3 gutters (396px) before doing the same width-tier lookup,
+ *  so the SAME width collapses one tier sooner whenever the drawer is open. */
+describe("breadcrumbMaxVisibleForWidth — inspectorOpen reserves the drawer's column", () => {
+  it("the exact scenario this fixed: 1280px shows everything with no selection, but tiers down to 4 with one", () => {
+    expect(breadcrumbMaxVisibleForWidth(1280)).toBe(Infinity);
+    expect(breadcrumbMaxVisibleForWidth(1280, true)).toBe(4);
+  });
+
+  it("the SAME raw width can land in a different tier purely based on inspectorOpen", () => {
+    expect(breadcrumbMaxVisibleForWidth(1024, false)).toBe(Infinity);
+    expect(breadcrumbMaxVisibleForWidth(1024, true)).toBe(3); // 1024-396=628, below the 640 tier
+  });
+
+  it("still reaches Infinity once the raw width is wide enough to absorb the reservation", () => {
+    expect(breadcrumbMaxVisibleForWidth(1419, true)).toBeLessThan(Infinity);
+    expect(breadcrumbMaxVisibleForWidth(1420, true)).toBe(Infinity); // 1420-396=1024
+  });
+
+  it("the 640-tier boundary shifts by exactly the reservation too", () => {
+    expect(breadcrumbMaxVisibleForWidth(1035, true)).toBe(3); // 1035-396=639
+    expect(breadcrumbMaxVisibleForWidth(1036, true)).toBe(4); // 1036-396=640
+  });
+
+  it("defaults to false (inspectorOpen is optional) — same as never passing it", () => {
+    expect(breadcrumbMaxVisibleForWidth(1280)).toBe(breadcrumbMaxVisibleForWidth(1280, false));
+  });
+});

--- a/viz/src/data/breadcrumbPath.test.ts
+++ b/viz/src/data/breadcrumbPath.test.ts
@@ -3,7 +3,15 @@ import { buildModel } from "./model";
 import { fromWorker, type ClientModel } from "./clientModel";
 import type { WorkerResult } from "./worker/graph.worker";
 import type { RawGraph } from "./types";
-import { cameraCrumbs, resolveBreadcrumb, selectionCrumbs, collapseCrumbsForDisplay, breadcrumbMaxVisibleForWidth, type Crumb } from "./breadcrumbPath";
+import {
+  cameraCrumbs,
+  resolveBreadcrumb,
+  selectionCrumbs,
+  collapseCrumbsForDisplay,
+  breadcrumbMaxVisibleForWidth,
+  dedupeAdjacentCrumbLabels,
+  type Crumb,
+} from "./breadcrumbPath";
 
 /** Nested repo → dir "src" → dir "src/util" → file "src/util/a.ts" → symbol
  *  "run", so ancestor chains have real depth to assert on. Mirrors the
@@ -140,13 +148,19 @@ describe("resolveBreadcrumb (the status bar's single entry point)", () => {
   it("uses the selection chain when a node is selected, ignoring the camera hint", () => {
     const model = nestedModel();
     const crumbs = resolveBreadcrumb(model, FILE_NODE_ID, UTIL_DIR_KEY);
-    expect(crumbs.map((c) => c.label)).toEqual(["r", "r", "src", "util", "a.ts"]);
+    // The adjacent "r"/"r" pair (galaxy + its same-named implicit root dir —
+    // see nestedModel's docstring) is folded into one crumb (fix round 2 /
+    // REP-22 polish: "repo + root galaxy both 'reposkein'" read as a bug).
+    expect(crumbs.map((c) => c.label)).toEqual(["r", "src", "util", "a.ts"]);
+    // The fold keeps the DEEPER of the two same-labelled crumbs' key, so
+    // clicking it still navigates to the more specific (root dir) scope.
+    expect(crumbs[0]!.key).toBe("dir:r:.");
   });
 
   it("falls back to the camera-nearest cluster chain when nothing is selected", () => {
     const model = nestedModel();
     const crumbs = resolveBreadcrumb(model, null, UTIL_DIR_KEY);
-    expect(crumbs.map((c) => c.label)).toEqual(["r", "r", "src", "util"]);
+    expect(crumbs.map((c) => c.label)).toEqual(["r", "src", "util"]);
   });
 
   it("is never empty: no selection and no camera sample yet still returns the root", () => {
@@ -154,6 +168,31 @@ describe("resolveBreadcrumb (the status bar's single entry point)", () => {
     const crumbs = resolveBreadcrumb(model, null, null);
     expect(crumbs.length).toBeGreaterThan(0);
     expect(crumbs[0]!.key).toBe(model.rootKey);
+  });
+});
+
+describe("dedupeAdjacentCrumbLabels (fix round 2 / REP-22 polish)", () => {
+  it("folds a run of adjacent same-label crumbs into one, keeping the deepest key", () => {
+    const chain = [crumb("reposkein"), { key: "dir:root", label: "reposkein", clickable: true }, crumb("src")];
+    expect(dedupeAdjacentCrumbLabels(chain)).toEqual([
+      { key: "dir:root", label: "reposkein", clickable: true },
+      crumb("src"),
+    ]);
+  });
+
+  it("is a no-op when no two adjacent crumbs share a label", () => {
+    const chain = [crumb("reposkein"), crumb("src"), crumb("util")];
+    expect(dedupeAdjacentCrumbLabels(chain)).toEqual(chain);
+  });
+
+  it("does not fold NON-adjacent duplicates (only adjacent runs collapse)", () => {
+    const chain = [crumb("a"), crumb("b"), crumb("a")];
+    expect(dedupeAdjacentCrumbLabels(chain)).toEqual(chain);
+  });
+
+  it("leaves an empty or single-crumb chain untouched", () => {
+    expect(dedupeAdjacentCrumbLabels([])).toEqual([]);
+    expect(dedupeAdjacentCrumbLabels([crumb("a")])).toEqual([crumb("a")]);
   });
 });
 

--- a/viz/src/data/breadcrumbPath.ts
+++ b/viz/src/data/breadcrumbPath.ts
@@ -61,7 +61,15 @@ export function cameraCrumbs(model: ClientModel, nearestKey: string | null): Cru
 }
 
 /** The single entry point the status bar's breadcrumb renders: selection
- *  takes priority; camera-nearest is the persistent fallback. Never empty. */
+ *  takes priority; camera-nearest is the persistent fallback. Never empty.
+ *
+ *  Adjacent crumbs with the IDENTICAL label are folded into one (fix round 2 /
+ *  REP-22 polish): a repo whose top-level directory shares the repo's own name
+ *  (a common layout) renders a root galaxy crumb and a directory crumb that
+ *  say the exact same word — "reposkein · reposkein" reads as a rendering bug,
+ *  not as two distinct levels. The fold keeps the DEEPER crumb's key (so
+ *  clicking it still navigates to the more specific scope) and just the one
+ *  label. */
 export function resolveBreadcrumb(
   model: ClientModel,
   selectedId: string | null,
@@ -70,7 +78,25 @@ export function resolveBreadcrumb(
   const crumbs = selectedId
     ? selectionCrumbs(model, selectedId)
     : cameraCrumbs(model, nearestClusterKey);
-  return crumbs.length > 0 ? crumbs : [{ key: model.rootKey, label: model.repoId, clickable: false }];
+  const deduped = dedupeAdjacentCrumbLabels(crumbs);
+  return deduped.length > 0
+    ? deduped
+    : [{ key: model.rootKey, label: model.repoId, clickable: false }];
+}
+
+/** Folds runs of adjacent crumbs sharing the same displayed LABEL into one,
+ *  keeping the last (deepest) crumb's `key`/`clickable` — clicking the folded
+ *  crumb still navigates to the more specific of the two scopes. Pure, so the
+ *  "repo root galaxy and its same-named top directory" case is unit-testable
+ *  without a real model. */
+export function dedupeAdjacentCrumbLabels(crumbs: Crumb[]): Crumb[] {
+  const out: Crumb[] = [];
+  for (const c of crumbs) {
+    const prev = out[out.length - 1];
+    if (prev && prev.label === c.label) out[out.length - 1] = c;
+    else out.push(c);
+  }
+  return out;
 }
 
 /** A synthetic, inert "…" crumb — never clickable, never confused with a real
@@ -96,6 +122,12 @@ export function collapseCrumbsForDisplay(crumbs: Crumb[], maxVisible: number): C
   return [head, { key: ELLIPSIS_KEY, label: "…", clickable: false }, ...tail];
 }
 
+/** The Inspector's own width + the gutters `LayerShell`'s `layerPlacement`
+ *  reserves around it (kept in sync with that module's `INSPECTOR_W`/
+ *  `GUTTER` — duplicated rather than imported so this stays a leaf, React-free
+ *  module; `StatusBar.test.tsx` pins the two numbers agreeing). */
+const INSPECTOR_RESERVED_PX = 360 + 12 * 3;
+
 /** How many breadcrumb segments to show at a given bar (== viewport) width,
  *  in px. The bar is `fixed inset-x-0`, so viewport width IS the bar's
  *  width — no ResizeObserver needed. Wide bars show the whole chain; narrow
@@ -104,10 +136,21 @@ export function collapseCrumbsForDisplay(crumbs: Crumb[], maxVisible: number): C
  *  the FIRST thing to give ground as the bar narrows, before the left
  *  section drops anything — its threshold (1024) is wider than the left
  *  section's widest drop threshold (768) — see StatusBar.tsx's tier
- *  comment). */
-export function breadcrumbMaxVisibleForWidth(width: number): number {
-  if (width >= 1024) return Infinity;
-  if (width >= 640) return 4;
+ *  comment).
+ *
+ *  `inspectorOpen` (fix round 2 / REP-22 polish — "crumbs over-truncate at
+ *  1280 with inspector open"): a live selection makes `selectionCrumbs`
+ *  append a synthetic leaf crumb the camera-nearest fallback never has, so
+ *  the SAME viewport width has to fit one more segment exactly when the
+ *  drawer is also on screen. Tiers tuned for the general case therefore
+ *  under-collapsed right when both were true at once. Treating an open
+ *  Inspector as `INSPECTOR_RESERVED_PX` narrower — the same number
+ *  `layerPlacement` reserves for it — fixes that without a second set of
+ *  breakpoints to keep in sync by hand. */
+export function breadcrumbMaxVisibleForWidth(width: number, inspectorOpen = false): number {
+  const effective = inspectorOpen ? width - INSPECTOR_RESERVED_PX : width;
+  if (effective >= 1024) return Infinity;
+  if (effective >= 640) return 4;
   return 3;
 }
 

--- a/viz/src/data/encodingVars.ts
+++ b/viz/src/data/encodingVars.ts
@@ -74,3 +74,15 @@ export function edgeTypeColorVar(type: string): string {
 export function languageColorVar(language: string, known: boolean): string {
   return cssVar(languageVarName(language, known));
 }
+
+/** `"danger"` → `"--color-status-danger"` (see `scene/encoding.ts`'s
+ *  `STATUS_META`). No slugging needed — the three status keys are already
+ *  CSS-safe identifiers. */
+export function statusVarName(status: "ok" | "warn" | "danger"): string {
+  return `--color-status-${status}`;
+}
+
+/** `statusColorVar("danger")` → `"var(--color-status-danger)"`. */
+export function statusColorVar(status: "ok" | "warn" | "danger"): string {
+  return cssVar(statusVarName(status));
+}

--- a/viz/src/data/keymap.ts
+++ b/viz/src/data/keymap.ts
@@ -77,6 +77,21 @@ export const KEYMAP: KeymapGroup[] = [
       { keys: ["click empty space"], description: "Deselect (never collapses, never moves the camera)", binding: null },
     ],
   },
+  {
+    // Astrolabe V5 §2 (responsive): every pointer gesture above already
+    // fires from POINTER events (react-three-fiber's onClick/onPointerDown),
+    // which browsers dispatch for touch the same as for a mouse — a tap IS a
+    // click here, nothing touch-specific had to be wired up. This group only
+    // spells that out in touch vocabulary so a tablet/phone viewer isn't left
+    // guessing whether "click" applies to them.
+    title: "Touch",
+    bindings: [
+      { keys: ["tap"], description: "Same as click — inspect a star, expand or collapse a cluster", binding: null },
+      { keys: ["tap empty space"], description: "Deselect", binding: null },
+      { keys: ["drag"], description: "Orbit (one finger)", binding: null },
+      { keys: ["pinch"], description: "Zoom (two fingers)", binding: null },
+    ],
+  },
 ];
 
 /** Every distinct global `KeyboardEvent.key` the keymap claims is bound. */

--- a/viz/src/index.css
+++ b/viz/src/index.css
@@ -72,6 +72,17 @@
   }
 }
 
+@keyframes rs-sheet-in {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @keyframes rs-spin {
   to {
     transform: rotate(360deg);
@@ -88,4 +99,19 @@
     opacity: 1;
     transform: scale(1.12);
   }
+}
+
+/* Focus rings (Astrolabe V5 a11y pass). One global rule beats auditing every
+ * interactive element by hand — and, being UNLAYERED (Tailwind's utilities
+ * live inside the `@layer` block above), it wins the cascade over any
+ * `focus:outline-*` utility regardless of specificity, so it can't be
+ * silently shadowed by one.
+ *
+ * `:focus-visible`, never bare `:focus` — the requirement is a ring on
+ * KEYBOARD focus, not on every mouse click that happens to land focus on a
+ * button. Browsers apply their own `:focus-visible` heuristic (roughly:
+ * keyboard/programmatic focus, not a pointer click) so this needs no JS. */
+:focus-visible {
+  outline: 2px solid var(--color-brand-teal);
+  outline-offset: 2px;
 }

--- a/viz/src/panels/CoachMark.tsx
+++ b/viz/src/panels/CoachMark.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { dismissCoachMark, isCoachMarkDismissed } from "./coachMarkState";
+import { useOpenLayer } from "./layerState";
+
+/** First-run coach mark (Astrolabe V5 §1). A SINGLE dismissible hint — not a
+ *  multi-step onboarding tour (the brief is explicit about that boundary) —
+ *  pointing a first-time viewer at the two entry points that unlock
+ *  everything else: ⌘K for search/navigation/commands, `?` for the full
+ *  keymap (including the touch equivalents, for a viewer on a tablet/phone).
+ *
+ *  Shows ONCE per browser: dismissal persists via `localStorage`
+ *  (`coachMarkState.ts`), read on mount, so a returning viewer — or the same
+ *  viewer on a later visit — never sees it again. Small and out of the way:
+ *  bottom-center, just above the status bar, the same visual weight as a
+ *  toast rather than a modal that blocks the scene.
+ *
+ *  Mounted by Root only once the graph is `ready` (there is nothing to
+ *  navigate to before then), and hides itself — without dismissing — while a
+ *  summoned layer is open, so it can never paint over the Help overlay it is
+ *  itself pointing a viewer toward. */
+export function CoachMark() {
+  const [visible, setVisible] = useState(false);
+  const layerOpen = useOpenLayer() !== null;
+
+  useEffect(() => {
+    if (!isCoachMarkDismissed()) setVisible(true);
+  }, []);
+
+  if (!visible || layerOpen) return null;
+
+  function dismiss() {
+    dismissCoachMark();
+    setVisible(false);
+  }
+
+  return (
+    <div
+      role="status"
+      data-testid="coach-mark"
+      className="pointer-events-auto fixed inset-x-0 bottom-9 z-[101] mx-auto flex w-fit items-center gap-2 rounded-full border border-[rgba(148,163,207,0.22)] bg-[color-mix(in_srgb,var(--color-brand-navy)_92%,white_4%)] px-3 py-1.5 text-[12px] text-[var(--color-brand-cream)] shadow-[0_8px_24px_-10px_rgba(0,0,0,0.6)] motion-safe:animate-[rs-layer-in_180ms_ease-out] motion-reduce:animate-none"
+    >
+      <span className="flex items-center gap-1.5 opacity-90">
+        <Kbd>⌘K</Kbd> to navigate <span aria-hidden="true" className="opacity-50">·</span>{" "}
+        <Kbd>?</Kbd> for keys
+      </span>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss hint"
+        className="shrink-0 opacity-60 hover:opacity-100"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded-[5px] border border-[rgba(148,163,207,0.22)] bg-white/5 px-1.5 font-mono text-[11px] opacity-90">
+      {children}
+    </kbd>
+  );
+}

--- a/viz/src/panels/CoachMark.tsx
+++ b/viz/src/panels/CoachMark.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { dismissCoachMark, isCoachMarkDismissed } from "./coachMarkState";
 import { useOpenLayer } from "./layerState";
+import { useToasts } from "./toastState";
 
 /** First-run coach mark (Astrolabe V5 §1). A SINGLE dismissible hint — not a
  *  multi-step onboarding tour (the brief is explicit about that boundary) —
@@ -16,17 +17,20 @@ import { useOpenLayer } from "./layerState";
  *
  *  Mounted by Root only once the graph is `ready` (there is nothing to
  *  navigate to before then), and hides itself — without dismissing — while a
- *  summoned layer is open, so it can never paint over the Help overlay it is
- *  itself pointing a viewer toward. */
+ *  summoned layer OR a toast is on screen (fix round 1: bottom-9 z-101 vs.
+ *  Toasts' bottom-10 z-150 sit close enough to genuinely overlap), so it can
+ *  never paint under the Help overlay or a toast it is itself pointing a
+ *  viewer toward. */
 export function CoachMark() {
   const [visible, setVisible] = useState(false);
   const layerOpen = useOpenLayer() !== null;
+  const toastVisible = useToasts().length > 0;
 
   useEffect(() => {
     if (!isCoachMarkDismissed()) setVisible(true);
   }, []);
 
-  if (!visible || layerOpen) return null;
+  if (!visible || layerOpen || toastVisible) return null;
 
   function dismiss() {
     dismissCoachMark();
@@ -47,7 +51,7 @@ export function CoachMark() {
         type="button"
         onClick={dismiss}
         aria-label="Dismiss hint"
-        className="shrink-0 opacity-60 hover:opacity-100"
+        className="shrink-0 opacity-70 hover:opacity-100"
       >
         ✕
       </button>

--- a/viz/src/panels/CommandPalette.test.tsx
+++ b/viz/src/panels/CommandPalette.test.tsx
@@ -335,6 +335,22 @@ describe("CommandPalette — no-results state", () => {
     expect(live?.textContent).toMatch(/No matches for/);
   });
 
+  it("aria-expanded on the combobox reflects whether there are results (fix round 2 / REP-22 polish — was hardcoded true)", async () => {
+    const model = graphModel();
+    const { store } = makeStore({ model });
+    currentStore = store;
+    await openPalette();
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "graph" } });
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.change(input, { target: { value: "zzzznotfound" } });
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.change(input, { target: { value: "graph" } });
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+  });
+
   it("announces the result count via the aria-live region when results exist", async () => {
     const model = graphModel();
     const { store } = makeStore({ model });

--- a/viz/src/panels/CommandPalette.tsx
+++ b/viz/src/panels/CommandPalette.tsx
@@ -378,7 +378,7 @@ export function CommandPalette() {
         className="fixed left-1/2 top-[12%] z-[201] flex max-h-[70vh] w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 flex-col overflow-hidden rounded-[10px] border border-[rgba(148,163,207,0.14)] bg-[color-mix(in_srgb,var(--color-brand-navy)_96%,white_4%)] text-[13px] text-[var(--color-brand-cream)] shadow-[0_16px_48px_-12px_rgba(0,0,0,0.55)] backdrop-blur-md"
       >
         <div className="flex shrink-0 items-center gap-2 border-b border-[rgba(148,163,207,0.14)] px-3 py-2.5">
-          <span aria-hidden="true" className="text-[13px] opacity-50">
+          <span aria-hidden="true" className="text-[13px] opacity-70">
             ⌘K
           </span>
           <label htmlFor={`${uid}-input`} className="sr-only">
@@ -463,7 +463,7 @@ export function CommandPalette() {
           {statusMessage}
         </div>
 
-        <div className="flex h-9 shrink-0 items-center gap-3 border-t border-[rgba(148,163,207,0.14)] px-3 text-[11px] opacity-55">
+        <div className="flex h-9 shrink-0 items-center gap-3 border-t border-[rgba(148,163,207,0.14)] px-3 text-[11px] opacity-70">
           <span className="hidden items-center gap-1 sm:inline-flex">
             <Kbd>↑</Kbd>
             <Kbd>↓</Kbd> navigate
@@ -563,7 +563,7 @@ function Row({
       >
         <span className="min-w-0 flex-1">
           <span className="block truncate text-[13px] font-medium">{row.cmd.label}</span>
-          {subtitle && <span className="block truncate text-[11px] opacity-55">{subtitle}</span>}
+          {subtitle && <span className="block truncate text-[11px] opacity-70">{subtitle}</span>}
         </span>
         {row.cmd.kbd && <Kbd>{row.cmd.kbd}</Kbd>}
       </div>
@@ -593,7 +593,7 @@ function Row({
       <span className="min-w-0 flex-1">
         <span className="block truncate text-[13px] font-medium">{row.name}</span>
         {row.filePath && (
-          <span className="block truncate font-mono text-[11px] opacity-55">{row.filePath}</span>
+          <span className="block truncate font-mono text-[11px] opacity-70">{row.filePath}</span>
         )}
       </span>
       {confidence < 1 && <ConfidenceBadge value={confidence} />}

--- a/viz/src/panels/CommandPalette.tsx
+++ b/viz/src/panels/CommandPalette.tsx
@@ -388,7 +388,7 @@ export function CommandPalette() {
             ref={inputRef}
             id={`${uid}-input`}
             role="combobox"
-            aria-expanded="true"
+            aria-expanded={!noResults}
             aria-controls={listboxId}
             aria-activedescendant={activeRowId}
             aria-autocomplete="list"
@@ -396,7 +396,7 @@ export function CommandPalette() {
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={onInputKeyDown}
             placeholder="Search or type > for commands…"
-            className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--color-brand-cream)] placeholder:opacity-45 focus:outline-none"
+            className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--color-brand-cream)] placeholder:opacity-70 focus:outline-none"
           />
           {filesOnly && (
             <button
@@ -420,7 +420,7 @@ export function CommandPalette() {
             {!noResults &&
               grouped.map(({ group, rows }) => (
                 <div key={group} role="group" aria-label={GROUP_LABEL[group]} className="mb-1 last:mb-0">
-                  <p className="px-2 pb-1 pt-1.5 text-[10px] font-medium uppercase tracking-wider opacity-45">
+                  <p className="px-2 pb-1 pt-1.5 text-[10px] font-medium uppercase tracking-wider opacity-70">
                     {GROUP_LABEL[group]}
                   </p>
                   {rows.map((row) => {
@@ -500,7 +500,7 @@ function NoResults({
       <p className="text-[13px] font-medium">
         {isCommandMode ? `No commands match "${query.slice(1).trim()}"` : `No matches for "${query}"`}
       </p>
-      <p className="mt-1 max-w-xs text-[11px] opacity-60">
+      <p className="mt-1 max-w-xs text-[11px] opacity-70">
         {isCommandMode
           ? "Check the spelling, or clear the > prefix to search symbols and files too."
           : "Check the spelling, try fewer words, or narrow the search to files only."}
@@ -605,7 +605,7 @@ function ConfidenceBadge({ value }: { value: number }) {
   return (
     <span
       title={`Touched by a low-confidence edge (${Math.round(value * 100)}%)`}
-      className="shrink-0 rounded-full border border-[rgba(255,180,84,0.4)] bg-[rgba(255,180,84,0.16)] px-1.5 py-0.5 text-[10px] font-medium text-[#ffd9a0] tabular-nums"
+      className="shrink-0 rounded-full border border-[color-mix(in_srgb,var(--color-brand-amber)_45%,transparent)] bg-[color-mix(in_srgb,var(--color-brand-amber)_16%,transparent)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-brand-amber)] tabular-nums"
     >
       {Math.round(value * 100)}%
     </span>

--- a/viz/src/panels/ErrorScreen.tsx
+++ b/viz/src/panels/ErrorScreen.tsx
@@ -8,14 +8,20 @@ import { useStore } from "../state/store";
  *  Retry re-runs the SAME load path as the first attempt: `retryLoad()` bumps
  *  the nonce that StoreProvider's loader effect keys on, so a fresh worker
  *  repeats fetch → parse → layout. There is no second retry-only code path to
- *  diverge from the real one. */
+ *  diverge from the real one.
+ *
+ *  OPAQUE, NOT BLURRED (Astrolabe V5 a11y pass): this screen replaces the
+ *  entire app while it's up — there is no scene content behind it worth
+ *  blurring, and (per V3 §6's own rule) a `backdrop-blur` is for TRANSIENT
+ *  surfaces. An error screen can sit on a viewer's monitor for as long as the
+ *  underlying failure persists, which is the opposite of transient. */
 export function ErrorScreen({ message }: { message: string }) {
   const store = useStore();
   return (
     <div
       role="alert"
       data-testid="error-screen"
-      className="pointer-events-auto fixed inset-0 z-[135] flex flex-col items-center justify-center gap-3 bg-[color-mix(in_srgb,var(--color-brand-navy)_82%,transparent)] px-6 text-center backdrop-blur-sm"
+      className="pointer-events-auto fixed inset-0 z-[135] flex flex-col items-center justify-center gap-3 bg-[var(--color-brand-navy)] px-6 text-center"
     >
       <p className="text-[15px] font-medium text-[var(--color-brand-cream)]">
         Couldn&apos;t chart the constellation
@@ -34,7 +40,7 @@ export function ErrorScreen({ message }: { message: string }) {
       >
         Retry
       </button>
-      <p className="max-w-md text-[11px] leading-relaxed opacity-45">
+      <p className="max-w-md text-[11px] leading-relaxed opacity-70">
         The graph is read from <span className="font-mono">.reposkein</span> — if this keeps
         failing, re-run the indexer and reload.
       </p>

--- a/viz/src/panels/FiltersPopover.tsx
+++ b/viz/src/panels/FiltersPopover.tsx
@@ -165,7 +165,7 @@ function CouplingToggle() {
         full
       />
       {on && !fetched && (
-        <p className="mt-1 text-[11px] opacity-50">Reading git history…</p>
+        <p className="mt-1 text-[11px] opacity-70">Reading git history…</p>
       )}
       {noData && (
         <p className="mt-1 text-[11px] leading-relaxed text-[var(--color-brand-amber)]">
@@ -190,12 +190,12 @@ function Field({
   return (
     <section className="mb-3 last:mb-0">
       <div className="flex items-baseline justify-between gap-2">
-        <h3 className="text-[11px] font-medium uppercase tracking-wider opacity-50">{label}</h3>
+        <h3 className="text-[11px] font-medium uppercase tracking-wider opacity-70">{label}</h3>
         {value !== undefined && (
-          <span className="font-mono text-[11px] tabular-nums opacity-60">{value}</span>
+          <span className="font-mono text-[11px] tabular-nums opacity-70">{value}</span>
         )}
       </div>
-      {hint && <p className="mb-1.5 mt-0.5 text-[11px] leading-tight opacity-45">{hint}</p>}
+      {hint && <p className="mb-1.5 mt-0.5 text-[11px] leading-tight opacity-70">{hint}</p>}
       {children}
     </section>
   );
@@ -229,7 +229,7 @@ function ColorChip({
       title={on ? `${label} — click to hide` : `${label} — click to show`}
       style={on ? { color: colorVar, borderColor: colorVar } : undefined}
       className={`min-h-6 rounded-full border px-2 py-0.5 text-[11px] transition-colors ${
-        on ? "bg-white/5" : "border-[rgba(148,163,207,0.18)] opacity-40"
+        on ? "bg-white/5" : "border-[rgba(148,163,207,0.18)] opacity-70"
       }`}
     >
       {label}

--- a/viz/src/panels/HelpOverlay.tsx
+++ b/viz/src/panels/HelpOverlay.tsx
@@ -23,7 +23,7 @@ export function HelpOverlay() {
       <div className="max-h-[min(70vh,34rem)] overflow-y-auto p-3">
         {KEYMAP.map((group) => (
           <section key={group.title} className="mb-3 last:mb-0">
-            <h3 className="mb-1.5 text-[11px] font-medium uppercase tracking-wider opacity-45">
+            <h3 className="mb-1.5 text-[11px] font-medium uppercase tracking-wider opacity-70">
               {group.title}
             </h3>
             <dl className="flex flex-col gap-1">

--- a/viz/src/panels/Inspector.test.tsx
+++ b/viz/src/panels/Inspector.test.tsx
@@ -438,6 +438,13 @@ describe("Inspector — action row mirrors the palette commands", () => {
     expect(screen.getByText("● 2 impacted")).toBeTruthy();
     expect(screen.getByText("● 1 covering test")).toBeTruthy();
     expect(screen.getByText("3 nodes")).toBeTruthy();
+    // Status-token identity (fix round 2 / REP-22 polish, mirrors
+    // colorIdentity.test.tsx): these used to be literal hexes (#ff8a73/
+    // #74ff8e) with no relationship to anything else on screen. They must
+    // now reference the SAME generated tokens `scene/encoding.ts`'s
+    // `STATUS_META` produces — never a hardcoded color again.
+    expect(screen.getByText("● 2 impacted").style.color).toBe("var(--color-status-danger)");
+    expect(screen.getByText("● 1 covering test").style.color).toBe("var(--color-status-ok)");
   });
 });
 
@@ -446,6 +453,57 @@ describe("Inspector — opaque, not blurred (V3 §6)", () => {
     currentStore = makeStore({ model: tinyModel(), selected: SEL }).store;
     render(<Inspector />);
     expect(screen.getByTestId("inspector").className).not.toMatch(/backdrop-blur/);
+  });
+});
+
+/** Astrolabe V5 §2 (responsive <900px): below `BP_INSPECTOR_SHEET` there is no
+ *  360px column to spare, so the drawer becomes a fixed-height BOTTOM SHEET
+ *  instead — full width, docked above the status bar, close button intact.
+ *  Drag-to-resize/collapse are explicitly out of scope (a fixed-height sheet
+ *  with a close button is what the brief asks for). */
+describe("Inspector — responsive bottom-sheet mode below 900px", () => {
+  const ORIGINAL_INNER_WIDTH = window.innerWidth;
+  function setViewportWidth(width: number) {
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: width });
+    fireEvent(window, new Event("resize"));
+  }
+  afterEach(() => setViewportWidth(ORIGINAL_INNER_WIDTH));
+
+  it("is a right-docked drawer at 1024px (well above the breakpoint)", () => {
+    setViewportWidth(1024);
+    currentStore = makeStore({ model: tinyModel(), selected: SEL }).store;
+    render(<Inspector />);
+    const el = screen.getByTestId("inspector");
+    expect(el.getAttribute("data-mode")).toBe("drawer");
+    expect(el.className).toContain("right-0");
+    expect(el.className).toContain("w-[360px]");
+    expect(el.className).not.toContain("inset-x-0");
+  });
+
+  it("becomes a full-width bottom sheet at 700px (below the breakpoint)", () => {
+    setViewportWidth(700);
+    currentStore = makeStore({ model: tinyModel(), selected: SEL }).store;
+    render(<Inspector />);
+    const el = screen.getByTestId("inspector");
+    expect(el.getAttribute("data-mode")).toBe("sheet");
+    expect(el.className).toContain("inset-x-0");
+    expect(el.className).toContain("bottom-7"); // still clears the 28px status bar
+    expect(el.className).not.toContain("w-[360px]");
+    // Structure is unchanged: header, body, footer — including the close
+    // button — are exactly the same in either mode.
+    expect(screen.getByLabelText("Close inspector")).toBeTruthy();
+    expect(screen.getByTestId("inspector-impact")).toBeTruthy();
+  });
+
+  it("switches mode live on resize, without losing the selection", () => {
+    setViewportWidth(1024);
+    currentStore = makeStore({ model: tinyModel(), selected: SEL }).store;
+    render(<Inspector />);
+    expect(screen.getByTestId("inspector").getAttribute("data-mode")).toBe("drawer");
+
+    setViewportWidth(500);
+    expect(screen.getByTestId("inspector").getAttribute("data-mode")).toBe("sheet");
+    expect(screen.getByTestId("inspector-name")).toBeTruthy();
   });
 });
 

--- a/viz/src/panels/Inspector.tsx
+++ b/viz/src/panels/Inspector.tsx
@@ -16,11 +16,12 @@ import {
 import { useStore } from "../state/store";
 import { MAX_FOCUS_DEPTH, MIN_FOCUS_DEPTH } from "../data/neighborhood";
 import { buildMinConfidenceIndex, nodeConfidence } from "../data/nodeConfidence";
-import { nodeKindColorVar } from "../data/encodingVars";
+import { nodeKindColorVar, statusColorVar } from "../data/encodingVars";
 import { nodeKindGlyph } from "../data/nodeGlyph";
 import { fetchSource, type SourceSlice } from "../data/api";
 import { isStaticMode } from "../data/staticMode";
 import { keyScopeProps } from "./globalKeys";
+import { useViewportWidth, BP_INSPECTOR_SHEET } from "./viewport";
 import type { NodeRecord } from "../data/model";
 
 interface IncidentRow {
@@ -63,11 +64,20 @@ const COLUMN_HEADER: Record<ColumnId, string> = {
  *  edges, source peek, semantic summary) → action footer (fixed). The footer is
  *  pinned so Impact / Focus are reachable without scrolling past a long summary,
  *  and every action there dispatches the SAME store action its command-palette
- *  twin does (`state/commands.ts`) — one code path, two entry points. */
+ *  twin does (`state/commands.ts`) — one code path, two entry points.
+ *
+ *  RESPONSIVE <900px (Astrolabe V5 §2): there is no 360px column to spare on a
+ *  narrow/tablet viewport, so below `BP_INSPECTOR_SHEET` the drawer becomes a
+ *  fixed-height BOTTOM SHEET instead — full width, docked above the status
+ *  bar, with the same header/body/footer structure and the same close button.
+ *  Drag-to-resize / drag-to-collapse are explicitly out of scope (brief: "a
+ *  fixed-height sheet with close is fine"). */
 export function Inspector() {
   const store = useStore();
   const model = store.model;
   const rec = model && store.selected ? model.records.get(store.selected) : null;
+  const width = useViewportWidth();
+  const sheet = width < BP_INSPECTOR_SHEET;
 
   // Drawer only exists on a live selection (see docstring): no empty state.
   if (!model || !rec) return null;
@@ -76,7 +86,12 @@ export function Inspector() {
     <aside
       aria-label={`Inspector — ${rec.name || rec.id}`}
       data-testid="inspector"
-      className="pointer-events-auto fixed right-0 top-0 bottom-7 z-[110] flex w-[360px] max-w-[calc(100vw-1rem)] flex-col border-l border-[rgba(148,163,207,0.18)] bg-[color-mix(in_srgb,var(--color-brand-navy)_96%,white_3%)] text-[13px] text-[var(--color-brand-cream)] shadow-[-12px_0_32px_-16px_rgba(0,0,0,0.8)] motion-safe:animate-[rs-drawer-in_180ms_ease-out]"
+      data-mode={sheet ? "sheet" : "drawer"}
+      className={
+        sheet
+          ? "pointer-events-auto fixed inset-x-0 bottom-7 z-[110] flex h-[45vh] max-h-[420px] flex-col border-t border-[rgba(148,163,207,0.18)] bg-[color-mix(in_srgb,var(--color-brand-navy)_96%,white_3%)] text-[13px] text-[var(--color-brand-cream)] shadow-[0_-12px_32px_-16px_rgba(0,0,0,0.8)] motion-safe:animate-[rs-sheet-in_180ms_ease-out]"
+          : "pointer-events-auto fixed right-0 top-0 bottom-7 z-[110] flex w-[360px] max-w-[calc(100vw-1rem)] flex-col border-l border-[rgba(148,163,207,0.18)] bg-[color-mix(in_srgb,var(--color-brand-navy)_96%,white_3%)] text-[13px] text-[var(--color-brand-cream)] shadow-[-12px_0_32px_-16px_rgba(0,0,0,0.8)] motion-safe:animate-[rs-drawer-in_180ms_ease-out]"
+      }
     >
       <IdentityHeader rec={rec} />
       <div className="min-h-0 flex-1 overflow-y-auto px-3 py-2.5">
@@ -124,7 +139,7 @@ function IdentityHeader({ rec }: { rec: NodeRecord }) {
           type="button"
           onClick={() => store.select(null)}
           aria-label="Close inspector"
-          className="min-h-6 min-w-6 shrink-0 text-[13px] opacity-50 hover:opacity-100"
+          className="min-h-6 min-w-6 shrink-0 text-[13px] opacity-70 hover:opacity-100"
         >
           ✕
         </button>
@@ -154,7 +169,7 @@ function IdentityHeader({ rec }: { rec: NodeRecord }) {
         <p
           data-testid="inspector-path"
           title={`${rec.filePath}${lines}`}
-          className="mt-1.5 truncate font-mono text-[11px] opacity-65"
+          className="mt-1.5 truncate font-mono text-[11px] opacity-70"
         >
           {rec.filePath}
           {lines}
@@ -182,7 +197,7 @@ function Overview({ rec }: { rec: NodeRecord }) {
       <dl className="flex flex-col gap-1">
         {rows.map((r) => (
           <div key={r.label} className="flex items-baseline gap-2">
-            <dt className="w-24 shrink-0 text-[11px] uppercase tracking-wide opacity-45">
+            <dt className="w-24 shrink-0 text-[11px] uppercase tracking-wide opacity-70">
               {r.label}
             </dt>
             <dd
@@ -326,7 +341,7 @@ function IncidentEdges() {
   return (
     <Section title={`Incident edges (${incident.length})`}>
       {incident.length === 0 ? (
-        <p className="text-[11px] opacity-50">No relationship edges touch this node.</p>
+        <p className="text-[11px] opacity-70">No relationship edges touch this node.</p>
       ) : (
         <table
           data-testid="inspector-edges"
@@ -359,7 +374,7 @@ function IncidentEdges() {
                         type="button"
                         data-testid={`inspector-sort-${h.column.id}`}
                         onClick={h.column.getToggleSortingHandler()}
-                        className="flex w-full items-center gap-0.5 px-1 py-1 text-left text-[11px] uppercase tracking-wide opacity-60 hover:opacity-100"
+                        className="flex w-full items-center gap-0.5 px-1 py-1 text-left text-[11px] uppercase tracking-wide opacity-70 hover:opacity-100"
                       >
                         {COLUMN_HEADER[h.column.id as ColumnId]}
                         <span aria-hidden="true" className="opacity-70">
@@ -385,16 +400,16 @@ function IncidentEdges() {
                   onFocus={() => setActiveRow(i)}
                   onClick={() => store.revealAndSelect(r.neighborId, { fly: true })}
                   onKeyDown={(e) => onRowKeyDown(e, i, r.neighborId)}
-                  className="cursor-pointer border-b border-[rgba(148,163,207,0.1)] hover:bg-white/5 focus:bg-white/10 focus:outline focus:outline-1 focus:outline-[var(--color-brand-amber)]"
+                  className="cursor-pointer border-b border-[rgba(148,163,207,0.1)] hover:bg-white/5 focus-visible:bg-white/10"
                 >
-                  <td className="px-1 py-1 font-mono opacity-60">
+                  <td className="px-1 py-1 font-mono opacity-70">
                     {r.direction === "out" ? "→" : "←"}
                   </td>
                   <td className="px-1 py-1 opacity-80">{r.type}</td>
                   <td className="max-w-[7rem] truncate px-1 py-1" title={r.neighbor}>
                     {r.neighbor}
                   </td>
-                  <td className="px-1 py-1 opacity-60">{r.resolution}</td>
+                  <td className="px-1 py-1 opacity-70">{r.resolution}</td>
                   <td className="px-1 py-1 font-mono tabular-nums opacity-70">
                     {r.confidence.toFixed(2)}
                   </td>
@@ -462,15 +477,15 @@ function SourcePeek({ rec, repoRoot }: { rec: NodeRecord; repoRoot: string | nul
           Open in editor ↗
         </a>
       )}
-      {state === "loading" && <p className="text-[11px] opacity-50">Loading source…</p>}
-      {state === "missing" && <p className="text-[11px] opacity-50">Source unavailable.</p>}
+      {state === "loading" && <p className="text-[11px] opacity-70">Loading source…</p>}
+      {state === "missing" && <p className="text-[11px] opacity-70">Source unavailable.</p>}
       {slice && (
         <pre className="m-0 max-h-56 overflow-auto rounded-[6px] border border-[rgba(148,163,207,0.16)] bg-black/35 px-2 py-1.5 font-mono text-[11px] leading-relaxed opacity-90">
           {slice.lines.map((line, i) => {
             const lineNo = slice.start + i;
             return (
               <div key={lineNo} className="flex whitespace-pre">
-                <span className="inline-block w-10 shrink-0 select-none pr-2.5 text-right opacity-40">
+                <span className="inline-block w-10 shrink-0 select-none pr-2.5 text-right opacity-70">
                   {lineNo}
                 </span>
                 <span className="flex-1">{line || " "}</span>
@@ -495,7 +510,7 @@ function SummarySection({ rec }: { rec: NodeRecord }) {
   return (
     <Section title="Semantic summary">
       {!rec.semanticSummary ? (
-        <p className="text-[11px] opacity-50">No summary yet — agents write these as they explore.</p>
+        <p className="text-[11px] opacity-70">No summary yet — agents write these as they explore.</p>
       ) : (
         <div>
           {stale && (
@@ -564,7 +579,7 @@ function ActionRow() {
       </div>
 
       <div className="mt-2 flex items-center gap-1.5">
-        <span className="text-[11px] uppercase tracking-wide opacity-45">Depth</span>
+        <span className="text-[11px] uppercase tracking-wide opacity-70">Depth</span>
         {Array.from({ length: MAX_FOCUS_DEPTH - MIN_FOCUS_DEPTH + 1 }, (_, i) => {
           const d = MIN_FOCUS_DEPTH + i;
           const on = store.focusDepth === d;
@@ -579,7 +594,7 @@ function ActionRow() {
               className={`min-h-6 min-w-6 rounded-[5px] border font-mono text-[11px] transition-colors ${
                 on
                   ? "border-[color-mix(in_srgb,var(--color-brand-teal)_55%,transparent)] bg-[color-mix(in_srgb,var(--color-brand-teal)_16%,transparent)] text-[var(--color-brand-teal)]"
-                  : "border-[rgba(148,163,207,0.2)] opacity-65 hover:opacity-100"
+                  : "border-[rgba(148,163,207,0.2)] opacity-70 hover:opacity-100"
               }`}
             >
               {d}
@@ -595,8 +610,8 @@ function ActionRow() {
 
       {impactOn && (
         <p className="mt-1.5 flex gap-3 font-mono text-[11px] tabular-nums">
-          <span className="text-[#ff8a73]">● {impacted} impacted</span>
-          <span className="text-[#74ff8e]">
+          <span style={{ color: statusColorVar("danger") }}>● {impacted} impacted</span>
+          <span style={{ color: statusColorVar("ok") }}>
             ● {covering} covering test{covering === 1 ? "" : "s"}
           </span>
         </p>
@@ -639,7 +654,7 @@ function ActionButton({
 function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section className="mb-3 last:mb-0">
-      <h3 className="mb-1 text-[11px] font-medium uppercase tracking-wider opacity-45">{title}</h3>
+      <h3 className="mb-1 text-[11px] font-medium uppercase tracking-wider opacity-70">{title}</h3>
       {children}
     </section>
   );

--- a/viz/src/panels/LayerShell.tsx
+++ b/viz/src/panels/LayerShell.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, type ReactNode } from "react";
 import { useStoreState } from "../state/store";
 import { hideLayer, type LayerId } from "./layerState";
 import { isCommandPaletteOpen } from "./paletteOpenState";
+import { useViewportWidth, BP_LAYER_FULL_WIDTH } from "./viewport";
 
 /** Where a layer sits horizontally. Vertical placement is uniform (`bottom-9`,
  *  clearing the 28px status bar), so only this varies. */
@@ -36,8 +37,20 @@ const GUTTER = "0.75rem"; // = right-3 / left-3
  *  regression.
  *
  *  Pure and exported so the geometry is unit-testable without measuring a
- *  layout jsdom doesn't compute. */
-export function layerPlacement(dock: LayerDock, inspectorOpen: boolean): string {
+ *  layout jsdom doesn't compute.
+ *
+ *  `fullWidthSheet` (Astrolabe V5 §2, responsive <640px): overrides dock/
+ *  inspector-column reasoning entirely. Below `BP_LAYER_FULL_WIDTH` there is
+ *  no room left over for ANY docked width (184px–30rem, per layer) — and the
+ *  Inspector is itself a full-bleed bottom sheet down here, so there is no
+ *  column to reserve either. Every layer becomes one full-width bottom sheet
+ *  regardless of its normal `dock`. */
+export function layerPlacement(
+  dock: LayerDock,
+  inspectorOpen: boolean,
+  fullWidthSheet = false,
+): string {
+  if (fullWidthSheet) return "bottom-9 inset-x-3 max-w-none";
   // Room a layer may occupy: the viewport minus its own two gutters, and minus
   // the Inspector's column once that is on screen.
   const maxW = inspectorOpen
@@ -90,6 +103,12 @@ export function LayerShell({
 }) {
   const state = useStoreState();
   const rootRef = useRef<HTMLDivElement>(null);
+  const viewportWidth = useViewportWidth();
+  // Astrolabe V5 §2: below this width EVERY layer becomes a full-width bottom
+  // sheet, overriding its normal dock/width entirely (see `layerPlacement`'s
+  // docstring) — so the caller's desired `width` class is dropped too; the
+  // sheet placement already governs width on its own.
+  const fullWidthSheet = viewportWidth < BP_LAYER_FULL_WIDTH;
 
   // The Inspector mounts on a live selection of a node that exists in the
   // graph, so mirror that exact condition rather than just `selected !== null`
@@ -141,15 +160,16 @@ export function LayerShell({
       data-layer={id}
       data-testid={`layer-${id}`}
       data-inspector-open={inspectorOpen}
-      className={`pointer-events-auto fixed z-[120] ${layerPlacement(dock, inspectorOpen)} ${width} motion-safe:animate-[rs-layer-in_140ms_ease-out] overflow-hidden rounded-[10px] border border-[rgba(148,163,207,0.2)] bg-[color-mix(in_srgb,var(--color-brand-navy)_88%,white_4%)] text-[13px] text-[var(--color-brand-cream)] shadow-[0_12px_36px_-12px_rgba(0,0,0,0.7)] backdrop-blur-md`}
+      data-full-width-sheet={fullWidthSheet}
+      className={`pointer-events-auto fixed z-[120] ${layerPlacement(dock, inspectorOpen, fullWidthSheet)} ${fullWidthSheet ? "" : width} motion-safe:animate-[rs-layer-in_140ms_ease-out] overflow-hidden rounded-[10px] border border-[rgba(148,163,207,0.2)] bg-[color-mix(in_srgb,var(--color-brand-navy)_88%,white_4%)] text-[13px] text-[var(--color-brand-cream)] shadow-[0_12px_36px_-12px_rgba(0,0,0,0.7)] backdrop-blur-md`}
     >
       <div className="flex h-7 items-center justify-between border-b border-[rgba(148,163,207,0.16)] px-2.5">
-        <span className="text-[11px] font-medium uppercase tracking-wider opacity-55">{title}</span>
+        <span className="text-[11px] font-medium uppercase tracking-wider opacity-70">{title}</span>
         <button
           type="button"
           onClick={() => hideLayer()}
           aria-label={`Close ${title}`}
-          className="min-h-5 min-w-5 text-[11px] opacity-55 hover:opacity-100"
+          className="min-h-5 min-w-5 text-[11px] opacity-70 hover:opacity-100"
         >
           ✕
         </button>

--- a/viz/src/panels/LayerShell.tsx
+++ b/viz/src/panels/LayerShell.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, type ReactNode } from "react";
 import { useStoreState } from "../state/store";
 import { hideLayer, type LayerId } from "./layerState";
 import { isCommandPaletteOpen } from "./paletteOpenState";
-import { useViewportWidth, BP_LAYER_FULL_WIDTH } from "./viewport";
+import { useViewportWidth, BP_INSPECTOR_SHEET, BP_LAYER_FULL_WIDTH } from "./viewport";
 
 /** Where a layer sits horizontally. Vertical placement is uniform (`bottom-9`,
  *  clearing the 28px status bar), so only this varies. */
@@ -24,16 +24,29 @@ const GUTTER = "0.75rem"; // = right-3 / left-3
  *  unreachable.
  *
  *  Fixed by reserving the drawer's column rather than by nudging pixels: when
- *  the Inspector is mounted, right-docked layers shift left by its full width
- *  plus a gutter, and centered ones re-center inside the remaining region. The
- *  `max-w` clamp is the other half — without it a layer wider than the
- *  remaining space (the help overlay wants 30rem) would simply overflow back
- *  across the drawer.
+ *  the Inspector is mounted AND rendering as a drawer, right-docked layers
+ *  shift left by its full width plus a gutter, and centered ones re-center
+ *  inside the remaining region. The `max-w` clamp is the other half —
+ *  without it a layer wider than the remaining space (the help overlay wants
+ *  30rem) would simply overflow back across the drawer.
  *
- *  Scoped to `md:` (≥768px) deliberately, which is exactly the width the brief
- *  specifies. Below it the Inspector is `max-w-[calc(100vw-1rem)]` — nearly the
- *  whole screen — so there is no column left to reserve; a transient,
- *  Esc-dismissable layer overlaying it there is the correct outcome, not a
+ *  `reserveInspectorColumn` — NOT a media query (fix round 2 / REP-22 fix
+ *  round 1, review finding #1). This used to be an `inspectorOpen` boolean
+ *  applied through Tailwind's `md:` (768px) prefix, and Inspector.tsx
+ *  independently switches to a full-width bottom sheet below
+ *  `BP_INSPECTOR_SHEET` (900px) — two different breakpoints deciding the SAME
+ *  question ("is there a drawer to avoid?") could only agree by accident.
+ *  Between 768–899px with a selection, the drawer had already become a
+ *  bottom sheet (no column to avoid) while this module's `md:` class still
+ *  fired, so every layer sat needlessly shifted/narrowed for a drawer that
+ *  wasn't there.
+ *
+ *  The fix: the caller computes this flag in JS from the SAME
+ *  `BP_INSPECTOR_SHEET` constant (`viewport.ts`) Inspector.tsx reads — one
+ *  source of truth, no independent CSS breakpoint to drift out of sync
+ *  again. Below `BP_INSPECTOR_SHEET` the Inspector is a bottom sheet (no
+ *  column to reserve regardless of selection); a transient, Esc-dismissable
+ *  layer sharing the screen with it there is the correct outcome, not a
  *  regression.
  *
  *  Pure and exported so the geometry is unit-testable without measuring a
@@ -47,18 +60,16 @@ const GUTTER = "0.75rem"; // = right-3 / left-3
  *  regardless of its normal `dock`. */
 export function layerPlacement(
   dock: LayerDock,
-  inspectorOpen: boolean,
+  reserveInspectorColumn: boolean,
   fullWidthSheet = false,
 ): string {
   if (fullWidthSheet) return "bottom-9 inset-x-3 max-w-none";
   // Room a layer may occupy: the viewport minus its own two gutters, and minus
-  // the Inspector's column once that is on screen.
-  const maxW = inspectorOpen
-    ? `max-w-[calc(100vw-${GUTTER}*2)] md:max-w-[calc(100vw-${INSPECTOR_W}-${GUTTER}*3)]`
+  // the Inspector's column when (and only when) it's actually a drawer.
+  const maxW = reserveInspectorColumn
+    ? `max-w-[calc(100vw-${INSPECTOR_W}-${GUTTER}*3)]`
     : `max-w-[calc(100vw-${GUTTER}*2)]`;
-  const right = inspectorOpen
-    ? `right-3 md:right-[calc(${INSPECTOR_W}+${GUTTER})]`
-    : "right-3";
+  const right = reserveInspectorColumn ? `right-[calc(${INSPECTOR_W}+${GUTTER})]` : "right-3";
   // `mx-auto` with BOTH insets set centers the box inside them, so a centered
   // layer automatically re-centers in whatever region is left over.
   const horizontal = dock === "center" ? `left-3 ${right} mx-auto` : right;
@@ -119,6 +130,14 @@ export function LayerShell({
     state.selected !== null &&
     state.model?.records.has(state.selected) === true;
 
+  // Reserve the drawer's column ONLY when the Inspector is actually
+  // rendering as a right-docked drawer — open AND wide enough that
+  // Inspector.tsx itself chose drawer mode over its <900px bottom sheet.
+  // Both this module and Inspector.tsx read the SAME `BP_INSPECTOR_SHEET`
+  // constant from `viewport.ts`, so the two can never independently drift
+  // the way a second, hardcoded breakpoint here once did (fix round 1).
+  const reserveInspectorColumn = inspectorOpen && viewportWidth >= BP_INSPECTOR_SHEET;
+
   // The tour flag, read from a listener that must not be re-created per
   // dispatch (same ref pattern as StatusBar's Esc handler).
   const tourRef = useRef(state.tour);
@@ -160,8 +179,9 @@ export function LayerShell({
       data-layer={id}
       data-testid={`layer-${id}`}
       data-inspector-open={inspectorOpen}
+      data-reserve-inspector-column={reserveInspectorColumn}
       data-full-width-sheet={fullWidthSheet}
-      className={`pointer-events-auto fixed z-[120] ${layerPlacement(dock, inspectorOpen, fullWidthSheet)} ${fullWidthSheet ? "" : width} motion-safe:animate-[rs-layer-in_140ms_ease-out] overflow-hidden rounded-[10px] border border-[rgba(148,163,207,0.2)] bg-[color-mix(in_srgb,var(--color-brand-navy)_88%,white_4%)] text-[13px] text-[var(--color-brand-cream)] shadow-[0_12px_36px_-12px_rgba(0,0,0,0.7)] backdrop-blur-md`}
+      className={`pointer-events-auto fixed z-[120] ${layerPlacement(dock, reserveInspectorColumn, fullWidthSheet)} ${fullWidthSheet ? "" : width} motion-safe:animate-[rs-layer-in_140ms_ease-out] overflow-hidden rounded-[10px] border border-[rgba(148,163,207,0.2)] bg-[color-mix(in_srgb,var(--color-brand-navy)_88%,white_4%)] text-[13px] text-[var(--color-brand-cream)] shadow-[0_12px_36px_-12px_rgba(0,0,0,0.7)] backdrop-blur-md`}
     >
       <div className="flex h-7 items-center justify-between border-b border-[rgba(148,163,207,0.16)] px-2.5">
         <span className="text-[11px] font-medium uppercase tracking-wider opacity-70">{title}</span>

--- a/viz/src/panels/LegendSheet.tsx
+++ b/viz/src/panels/LegendSheet.tsx
@@ -72,7 +72,7 @@ export function LegendSheet() {
           </Group>
         )}
 
-        <p className="mt-2 border-t border-[rgba(148,163,207,0.14)] pt-2 text-[11px] leading-relaxed opacity-50">
+        <p className="mt-2 border-t border-[rgba(148,163,207,0.14)] pt-2 text-[11px] leading-relaxed opacity-70">
           Edge opacity = confidence · halo tint = language · star size = degree
         </p>
       </div>
@@ -83,7 +83,7 @@ export function LegendSheet() {
 function Group({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <section className="mb-2.5 last:mb-0">
-      <h3 className="mb-1 text-[11px] font-medium uppercase tracking-wider opacity-45">{label}</h3>
+      <h3 className="mb-1 text-[11px] font-medium uppercase tracking-wider opacity-70">{label}</h3>
       <ul className="flex flex-col gap-1">{children}</ul>
     </section>
   );

--- a/viz/src/panels/MinimapLayer.tsx
+++ b/viz/src/panels/MinimapLayer.tsx
@@ -136,7 +136,7 @@ export function MinimapLayer() {
           aria-label="Overview map of the visible constellation — click to recenter"
           className="block h-[120px] w-[168px] cursor-crosshair select-none rounded-[4px]"
         />
-        <p className="mt-1.5 text-[11px] leading-tight opacity-45">
+        <p className="mt-1.5 text-[11px] leading-tight opacity-70">
           Visible clusters · <span className="text-[var(--color-brand-teal)]">frame</span> = viewport
         </p>
       </div>

--- a/viz/src/panels/StatusBar.test.tsx
+++ b/viz/src/panels/StatusBar.test.tsx
@@ -198,6 +198,13 @@ describe("StatusBar — breadcrumb crumb clicks", () => {
     const model = tinyModel();
     const { store, actions } = makeStore({ model, selected: "rs1:acmerepo:sym:lib/a.ts#run@0" });
     currentStore = store;
+    // Explicit wide viewport: this is a click-behaviour test, not a
+    // width-tier one, but the Inspector is open (a node is selected) — and
+    // the breadcrumb tier now reserves the drawer's own width when it is
+    // (fix round 2 / REP-22 polish), so leaving this at jsdom's implicit
+    // default (1024, which sits exactly on the OLD un-reserved boundary)
+    // would exercise that reservation by accident. 1280 has headroom either way.
+    setViewportWidth(1280);
     render(<StatusBar />);
 
     fireEvent.click(screen.getByTitle("lib"));

--- a/viz/src/panels/StatusBar.tsx
+++ b/viz/src/panels/StatusBar.tsx
@@ -21,10 +21,14 @@ import {
 import { openLayer, toggleLayer, useOpenLayer, type LayerId } from "./layerState";
 import { pushToast } from "./toastState";
 import { TourLaunchButton } from "./TourController";
+import { useViewportWidth } from "./viewport";
 
 const BAR = "h-7 text-[13px] text-[var(--color-brand-cream)]";
 const MONO = "font-mono";
-const DIM = "opacity-60";
+/** Secondary chrome text. 70% is the contrast floor for chrome text at 11px+
+ *  on an opaque surface (Astrolabe V5 a11y pass) — below that, cream-on-navy
+ *  no longer clears a comfortable read at this size. */
+const DIM = "opacity-70";
 /** Minimum hit area for every clickable pill in the bar — the bar itself is
  *  only 28px tall, so this is close to the ceiling of what fits, but it must
  *  hold regardless of how narrow the viewport gets (fix round 1, `#2`:
@@ -45,22 +49,6 @@ const TAP = "min-h-6 min-w-6";
 const BP_HIDE_STALENESS = 768;
 const BP_HIDE_COUNTS = 640;
 const BP_COLLAPSE_CHIPS = 480;
-
-/** The viewport width, updated on resize. The bar is `fixed inset-x-0`, so
- *  viewport width IS the bar's own width — no ResizeObserver on the footer
- *  element needed. SSR-safe default (this app is client-only, but jsdom/test
- *  environments without a real layout still get a sane wide-tier default). */
-function useViewportWidth(): number {
-  const [width, setWidth] = useState<number>(() =>
-    typeof window === "undefined" ? 1280 : window.innerWidth,
-  );
-  useEffect(() => {
-    const onResize = () => setWidth(window.innerWidth);
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-  return width;
-}
 
 /** The 28px persistent status bar (REP-18 / Astrolabe V2). The ONLY chrome
  *  that is always on screen: everything HeaderBar / LensSwitcher / the
@@ -111,9 +99,19 @@ export function StatusBar() {
     () => (model ? resolveBreadcrumb(model, store.selected, nearestKey) : []),
     [model, store.selected, nearestKey],
   );
+  // The Inspector reserves no horizontal space (it sits below the bar), but
+  // it DOES change what the breadcrumb has to render: a selection appends the
+  // symbol as a synthetic leaf crumb (`selectionCrumbs`), so the chain is
+  // typically one segment longer with the drawer open than the camera-nearest
+  // fallback shown otherwise. Widths tuned for "the general case" therefore
+  // under-collapse right when the drawer opens — the fix round 2 regression
+  // ("crumbs over-truncate at 1280 with inspector open") — so the tier lookup
+  // treats an open Inspector as narrower by its own width + gutters.
+  const inspectorOpen =
+    model !== null && store.selected !== null && model.records.has(store.selected);
   const displayCrumbs = useMemo(
-    () => collapseCrumbsForDisplay(crumbs, breadcrumbMaxVisibleForWidth(width)),
-    [crumbs, width],
+    () => collapseCrumbsForDisplay(crumbs, breadcrumbMaxVisibleForWidth(width, inspectorOpen)),
+    [crumbs, width, inspectorOpen],
   );
 
   // Start the throttled camera-nearest poll once the model exists; stop it
@@ -278,17 +276,17 @@ function StatusBarCenter({ crumbs }: { crumbs: Crumb[] }) {
   return (
     <div className="flex min-w-0 flex-1 items-center justify-center overflow-hidden whitespace-nowrap px-2">
       {crumbs.map((crumb, i) => (
-        <span key={`${crumb.key}-${i}`} className="flex min-w-0 items-center">
+        <span key={`${crumb.key}-${i}`} className="flex min-w-[2ch] shrink items-center">
           {i > 0 && <span className="mx-1.5 shrink-0 opacity-35">·</span>}
           {crumb.clickable ? (
             <button
               type="button"
               onClick={() => onCrumbClick(crumb)}
               title={crumb.label}
-              className={`${MONO} min-w-0 truncate text-[13px] transition-opacity ${
+              className={`${MONO} min-w-0 truncate text-[13px] transition-opacity motion-reduce:transition-none ${
                 i === crumbs.length - 1
                   ? "text-[var(--color-brand-cream)] opacity-95"
-                  : "opacity-60 hover:opacity-90"
+                  : "opacity-70 hover:opacity-90"
               }`}
             >
               {crumb.label}

--- a/viz/src/panels/StatusBar.tsx
+++ b/viz/src/panels/StatusBar.tsx
@@ -277,7 +277,7 @@ function StatusBarCenter({ crumbs }: { crumbs: Crumb[] }) {
     <div className="flex min-w-0 flex-1 items-center justify-center overflow-hidden whitespace-nowrap px-2">
       {crumbs.map((crumb, i) => (
         <span key={`${crumb.key}-${i}`} className="flex min-w-[2ch] shrink items-center">
-          {i > 0 && <span className="mx-1.5 shrink-0 opacity-35">·</span>}
+          {i > 0 && <span aria-hidden="true" className="mx-1.5 shrink-0 opacity-35">·</span>}
           {crumb.clickable ? (
             <button
               type="button"

--- a/viz/src/panels/Toasts.tsx
+++ b/viz/src/panels/Toasts.tsx
@@ -1,4 +1,5 @@
 import { dismissToast, useToasts, type ToastTone } from "./toastState";
+import { useOpenLayer } from "./layerState";
 
 /** Toast host (Astrolabe V3 §5). Bottom-center, just above the status bar.
  *
@@ -6,7 +7,16 @@ import { dismissToast, useToasts, type ToastTone } from "./toastState";
  *  screen reader announces each new message once as it mounts; the region is
  *  always present in the DOM (an aria-live region added at the same time as its
  *  content is not reliably announced). Each toast carries a manual dismiss for
- *  pointer users — auto-dismiss is the norm, not the only exit. */
+ *  pointer users — auto-dismiss is the norm, not the only exit.
+ *
+ *  MOVES TO THE TOP while a summoned layer is open (fix round 2 / REP-22
+ *  polish): the bottom-center toast stack (z-150) used to sit ABOVE a
+ *  centered layer (z-120) in paint order without any positional awareness of
+ *  it, so a toast firing while the Help overlay was open could paint over its
+ *  bottom edge — and, since every layer becomes a full-width bottom sheet
+ *  below 640px (Astrolabe V5 §2), the same collision is now possible for the
+ *  right-docked layers too. Any open layer is reason enough to move: there is
+ *  no bottom-docked toast position guaranteed clear of all four. */
 
 const TONE: Record<ToastTone, string> = {
   info: "border-[rgba(148,163,207,0.28)] text-[var(--color-brand-cream)]",
@@ -17,12 +27,16 @@ const TONE: Record<ToastTone, string> = {
 
 export function Toasts() {
   const toasts = useToasts();
+  const layerOpen = useOpenLayer() !== null;
   return (
     <div
       aria-live="polite"
       aria-atomic="false"
       data-testid="toast-region"
-      className="pointer-events-none fixed bottom-10 left-1/2 z-[150] flex w-[min(360px,calc(100vw-2rem))] -translate-x-1/2 flex-col items-center gap-1.5"
+      data-position={layerOpen ? "top" : "bottom"}
+      className={`pointer-events-none fixed left-1/2 z-[150] flex w-[min(360px,calc(100vw-2rem))] -translate-x-1/2 flex-col items-center gap-1.5 ${
+        layerOpen ? "top-3" : "bottom-10"
+      }`}
     >
       {toasts.map((t) => (
         <div

--- a/viz/src/panels/Toasts.tsx
+++ b/viz/src/panels/Toasts.tsx
@@ -48,7 +48,7 @@ export function Toasts() {
           <span className="min-w-0 flex-1">
             <span className="block">{t.text}</span>
             {t.hint && (
-              <span className="mt-0.5 block text-[11px] text-[var(--color-brand-cream)] opacity-55">
+              <span className="mt-0.5 block text-[11px] text-[var(--color-brand-cream)] opacity-70">
                 {t.hint}
               </span>
             )}
@@ -57,7 +57,7 @@ export function Toasts() {
             type="button"
             onClick={() => dismissToast(t.id)}
             aria-label="Dismiss notification"
-            className="shrink-0 text-[var(--color-brand-cream)] opacity-50 hover:opacity-100"
+            className="shrink-0 text-[var(--color-brand-cream)] opacity-70 hover:opacity-100"
           >
             ✕
           </button>

--- a/viz/src/panels/chromeStates.test.tsx
+++ b/viz/src/panels/chromeStates.test.tsx
@@ -187,6 +187,18 @@ describe("ErrorScreen — actionable, with Retry", () => {
     expect(root.className).not.toMatch(/pointer-events-none/);
   });
 
+  /** Fix round 2 / REP-22 polish: this surface used to carry
+   *  `backdrop-blur-sm`, violating the "blur only on transient surfaces"
+   *  rule (V3 §6) — an error screen persists for as long as the underlying
+   *  failure does, which is the opposite of transient. It should now be a
+   *  flat, opaque navy instead. */
+  it("is opaque, not blurred — it can persist indefinitely, unlike a summoned layer", () => {
+    currentStore = makeStore().store;
+    render(<ErrorScreen message="boom" />);
+    const root = screen.getByTestId("error-screen");
+    expect(root.className).not.toMatch(/backdrop-blur/);
+  });
+
   it("Retry can be pressed more than once (a transient failure may recur)", () => {
     const { store, actions } = makeStore();
     currentStore = store;

--- a/viz/src/panels/coachMark.test.tsx
+++ b/viz/src/panels/coachMark.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+//
+// First-run coach mark (Astrolabe V5 §1). A single dismissible hint, shown
+// once per browser, persisted via localStorage — the smallest possible
+// onboarding surface, deliberately NOT a multi-step tour.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { CoachMark } from "./CoachMark";
+import {
+  dismissCoachMark,
+  isCoachMarkDismissed,
+  resetCoachMark,
+  subscribeCoachMark,
+} from "./coachMarkState";
+import { resetLayers, showLayer } from "./layerState";
+
+// This project's jsdom test environment doesn't expose `window.localStorage`
+// out of the box (Node's own experimental `localStorage` global shadows it
+// and warns without `--localstorage-file`) — a real browser always has it, so
+// a minimal in-memory polyfill here is what makes the PERSISTENCE assertions
+// below meaningful rather than vacuous. `coachMarkState.ts` itself degrades
+// gracefully with no polyfill at all (that's the point of its try/catch), so
+// production code needs none of this.
+function installLocalStorageStub(): void {
+  const backing = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => backing.get(k) ?? null,
+      setItem: (k: string, v: string) => backing.set(k, v),
+      removeItem: (k: string) => backing.delete(k),
+      clear: () => backing.clear(),
+    },
+  });
+}
+
+beforeEach(() => {
+  installLocalStorageStub();
+  resetCoachMark();
+});
+
+afterEach(() => {
+  cleanup();
+  resetCoachMark();
+  resetLayers();
+});
+
+describe("coachMarkState — persistence", () => {
+  it("is not dismissed on a fresh browser", () => {
+    expect(isCoachMarkDismissed()).toBe(false);
+  });
+
+  it("dismissing persists across a fresh read (survives a reload)", () => {
+    dismissCoachMark();
+    expect(isCoachMarkDismissed()).toBe(true);
+    expect(window.localStorage.getItem("reposkein.coachmark.dismissed.v1")).toBe("1");
+  });
+
+  it("dismissing twice is a no-op (idempotent, no duplicate writes/emits)", () => {
+    let calls = 0;
+    const unsub = subscribeCoachMark(() => calls++);
+    dismissCoachMark();
+    dismissCoachMark();
+    expect(calls).toBe(1);
+    unsub();
+  });
+
+  it("resetCoachMark clears both the in-memory flag and localStorage", () => {
+    dismissCoachMark();
+    resetCoachMark();
+    expect(isCoachMarkDismissed()).toBe(false);
+    expect(window.localStorage.getItem("reposkein.coachmark.dismissed.v1")).toBeNull();
+  });
+
+  it("notifies subscribers on dismiss", () => {
+    const seen: boolean[] = [];
+    const unsub = subscribeCoachMark(() => seen.push(isCoachMarkDismissed()));
+    dismissCoachMark();
+    expect(seen).toEqual([true]);
+    unsub();
+  });
+});
+
+describe("CoachMark — lifecycle (show / dismiss / persist)", () => {
+  it("shows once after load when never dismissed", () => {
+    render(<CoachMark />);
+    const mark = screen.getByTestId("coach-mark");
+    expect(mark.getAttribute("role")).toBe("status");
+    expect(mark.textContent).toContain("⌘K");
+    expect(mark.textContent).toContain("?");
+  });
+
+  it("does not render at all once already dismissed (a returning viewer)", () => {
+    dismissCoachMark();
+    render(<CoachMark />);
+    expect(screen.queryByTestId("coach-mark")).toBeNull();
+  });
+
+  it("clicking the dismiss button hides it immediately and persists the dismissal", () => {
+    render(<CoachMark />);
+    fireEvent.click(screen.getByLabelText("Dismiss hint"));
+    expect(screen.queryByTestId("coach-mark")).toBeNull();
+    expect(isCoachMarkDismissed()).toBe(true);
+  });
+
+  it("stays dismissed across a remount (persisted, not just local state)", () => {
+    const { unmount } = render(<CoachMark />);
+    fireEvent.click(screen.getByLabelText("Dismiss hint"));
+    unmount();
+    render(<CoachMark />);
+    expect(screen.queryByTestId("coach-mark")).toBeNull();
+  });
+
+  it("hides (without dismissing) while a summoned layer is open, reappears once it closes", () => {
+    render(<CoachMark />);
+    expect(screen.getByTestId("coach-mark")).toBeTruthy();
+
+    act(() => showLayer("help"));
+    expect(screen.queryByTestId("coach-mark")).toBeNull();
+    // Not dismissed — just hidden for the moment the layer occupies the same
+    // bottom-center real estate the hint would otherwise point at.
+    expect(isCoachMarkDismissed()).toBe(false);
+
+    act(() => resetLayers());
+    expect(screen.getByTestId("coach-mark")).toBeTruthy();
+  });
+
+  it("respects reduced motion (the entrance animation is dropped, not just eased)", () => {
+    render(<CoachMark />);
+    const mark = screen.getByTestId("coach-mark");
+    expect(mark.className).toContain("motion-safe:animate-");
+    expect(mark.className).toContain("motion-reduce:animate-none");
+  });
+});

--- a/viz/src/panels/coachMark.test.tsx
+++ b/viz/src/panels/coachMark.test.tsx
@@ -13,6 +13,7 @@ import {
   subscribeCoachMark,
 } from "./coachMarkState";
 import { resetLayers, showLayer } from "./layerState";
+import { pushToast, resetToasts } from "./toastState";
 
 // This project's jsdom test environment doesn't expose `window.localStorage`
 // out of the box (Node's own experimental `localStorage` global shadows it
@@ -43,6 +44,7 @@ afterEach(() => {
   cleanup();
   resetCoachMark();
   resetLayers();
+  resetToasts();
 });
 
 describe("coachMarkState — persistence", () => {
@@ -122,6 +124,22 @@ describe("CoachMark — lifecycle (show / dismiss / persist)", () => {
     expect(isCoachMarkDismissed()).toBe(false);
 
     act(() => resetLayers());
+    expect(screen.getByTestId("coach-mark")).toBeTruthy();
+  });
+
+  /** Fix round 1: CoachMark (bottom-9, z-101) and Toasts (bottom-10, z-150)
+   *  sit close enough vertically that a toast box genuinely overlaps the
+   *  hint's pill — the brief required no collision. Same pattern as the
+   *  layer-hide case above: hide (never dismiss) while a toast is visible. */
+  it("hides (without dismissing) while a toast is visible, reappears once it clears", () => {
+    render(<CoachMark />);
+    expect(screen.getByTestId("coach-mark")).toBeTruthy();
+
+    act(() => pushToast("Screenshot saved", { duration: 0 }));
+    expect(screen.queryByTestId("coach-mark")).toBeNull();
+    expect(isCoachMarkDismissed()).toBe(false);
+
+    act(() => resetToasts());
     expect(screen.getByTestId("coach-mark")).toBeTruthy();
   });
 

--- a/viz/src/panels/coachMarkState.ts
+++ b/viz/src/panels/coachMarkState.ts
@@ -1,0 +1,70 @@
+import { useSyncExternalStore } from "react";
+
+/** First-run coach mark persistence (Astrolabe V5 §1). A ~30-line singleton,
+ *  same shape as `toastState.ts`/`layerState.ts` for the same reason: this is
+ *  ephemeral chrome state, not reducer state, and it must be readable from a
+ *  plain function (the dismiss button) without forcing a subscriber on every
+ *  reducer consumer.
+ *
+ *  Persistence is `localStorage`, not the reducer/URL — the point of a
+ *  first-run hint is that it survives across sessions on the SAME browser
+ *  without needing a signed-in account or a URL param a viewer could strip.
+ *  Every read/write is wrapped: a privacy-mode browser or a disabled storage
+ *  API must never throw and must never block the hint from at least trying to
+ *  show (degrading to "show every time" is safe; throwing is not). */
+
+const STORAGE_KEY = "reposkein.coachmark.dismissed.v1";
+
+function readDismissed(): boolean {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+let dismissed = typeof window === "undefined" ? true : readDismissed();
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+/** Whether the hint has already been dismissed (this browser, ever). */
+export function isCoachMarkDismissed(): boolean {
+  return dismissed;
+}
+
+/** Dismisses the hint for good — persisted, so it never shows again on this
+ *  browser. Safe to call more than once. */
+export function dismissCoachMark(): void {
+  if (dismissed) return;
+  dismissed = true;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, "1");
+  } catch {
+    /* best-effort — an in-memory dismiss for this session is still correct */
+  }
+  emit();
+}
+
+export function subscribeCoachMark(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useCoachMarkDismissed(): boolean {
+  return useSyncExternalStore(subscribeCoachMark, isCoachMarkDismissed, isCoachMarkDismissed);
+}
+
+/** Test hook: forget the dismissal (in memory AND in storage), so a test can
+ *  exercise "first run" more than once in a process. */
+export function resetCoachMark(): void {
+  dismissed = false;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+  emit();
+}

--- a/viz/src/panels/colorIdentity.test.tsx
+++ b/viz/src/panels/colorIdentity.test.tsx
@@ -28,15 +28,18 @@ import { fromWorker, type ClientModel } from "../data/clientModel";
 import type { WorkerResult } from "../data/worker/graph.worker";
 import type { RawGraph } from "../data/types";
 import {
+  BRAND,
   EDGE_TYPE_META,
   LANGUAGE_HEX,
   NODE_KIND_META,
+  STATUS_META,
   SYMBOL_KIND_META,
 } from "../scene/encoding";
 import {
   edgeTypeVarName,
   languageVarName,
   nodeKindVarName,
+  statusVarName,
   varSlug,
 } from "../data/encodingVars";
 import { renderTokensCss, tokenGroups, tokenSlug } from "../styles/tokens";
@@ -173,6 +176,27 @@ describe("encodingVars ↔ styles/tokens: the same slug, always", () => {
     // Sanity: the generator itself declares nothing beyond the tables.
     const declared = tokenGroups().flatMap((g) => g.tokens.map((t) => t.name));
     expect(new Set(declared).size).toBe(declared.length);
+  });
+});
+
+/** Status-token identity (fix round 2 / REP-22 polish) — the same chain
+ *  proven above for node kinds / edge types / languages, now for the
+ *  ok/warn/danger status hues the Inspector's impact badges and any future
+ *  status pill draw from. Before this table, those badges carried literal
+ *  hexes (`#ff8a73`, `#74ff8e`) with no generated token behind them at all. */
+describe("status tokens (STATUS_META) — the same SSoT chain, one level simpler", () => {
+  it("every status has a declared token whose value is the encoding.ts hex", () => {
+    const tokens = generatedTokens();
+    for (const meta of STATUS_META) {
+      const varName = statusVarName(meta.status);
+      expect(tokens.has(varName)).toBe(true);
+      expect(tokens.get(varName)).toBe(meta.color);
+    }
+  });
+
+  it("'warn' is BRAND.amber itself, not a second hex that happens to match", () => {
+    const warn = STATUS_META.find((m) => m.status === "warn")!;
+    expect(warn.color).toBe(BRAND.amber);
   });
 });
 

--- a/viz/src/panels/layerStack.test.tsx
+++ b/viz/src/panels/layerStack.test.tsx
@@ -58,10 +58,19 @@ const { setCommandPaletteOpen, isCommandPaletteOpen, requestCommandPalette } = a
 const { CommandPalette } = await import("./CommandPalette");
 const { handleGlobalKey } = await import("./globalKeys");
 
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+/** Sets `window.innerWidth` and fires a resize event — `useViewportWidth`
+ *  (shared by `LayerShell`/`Inspector`/`StatusBar`) listens for exactly this. */
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: width });
+  fireEvent(window, new Event("resize"));
+}
+
 afterEach(() => {
   cleanup();
   resetLayers();
   setCommandPaletteOpen(false);
+  setViewportWidth(ORIGINAL_INNER_WIDTH);
 });
 
 function mockActions(): Actions {
@@ -136,6 +145,11 @@ function makeStore(overrides: Partial<Store> = {}): { store: Store; actions: Act
  *  suite, which has to distinguish "a node is selected" from "the drawer is
  *  really on screen". */
 const SYM = "rs1:r:sym:a.ts#run@0";
+
+/** The exact class `layerPlacement` emits when `reserveInspectorColumn` is
+ *  true — no `md:` (or any) media-query prefix any more (fix round 1, review
+ *  finding #1). Named here so a typo in one assertion doesn't silently pass. */
+const INSPECTOR_COLUMN_RIGHT = "right-[calc(360px+0.75rem)]";
 
 function symbolModel(): ClientModel {
   const g: RawGraph = {
@@ -404,23 +418,42 @@ describe("status bar pills drive the layer singleton", () => {
  *  LOWER z-index (110 vs 120) — so selecting a node and opening the legend
  *  painted the sheet over the drawer's pinned Impact / Focus action row and made
  *  it unreachable. The fix reserves the drawer's column; these assert the
- *  geometry, since jsdom computes no layout to measure. */
+ *  geometry, since jsdom computes no layout to measure.
+ *
+ *  REGRESSION 2 (REP-22 fix round 1, review finding #1): the column
+ *  reservation used to fire off a hardcoded Tailwind `md:` (768px) prefix
+ *  while Inspector.tsx independently switches drawer→sheet at
+ *  `BP_INSPECTOR_SHEET` (900px) — two breakpoints answering the same
+ *  question. Between 768–899px with a selection, the Inspector had already
+ *  become a bottom sheet (no column to avoid) while the `md:` class still
+ *  fired here, needlessly shifting/narrowing every layer. `layerPlacement`
+ *  now takes a plain `reserveInspectorColumn` boolean — no media query — so
+ *  the same `BP_INSPECTOR_SHEET` constant drives both modules. */
 describe("layer placement never collides with the Inspector", () => {
-  it("layerPlacement reserves the Inspector's column at md and up", () => {
+  it("layerPlacement reserves the Inspector's column when reserveInspectorColumn is true", () => {
     for (const dock of ["right", "center"] as const) {
       const closed = layerPlacement(dock, false);
       const open = layerPlacement(dock, true);
 
       // Closed: hugs the right gutter, clamped only by the viewport.
       expect(closed).toContain("right-3");
-      expect(closed).not.toMatch(/md:right-/);
+      expect(closed).not.toContain(INSPECTOR_COLUMN_RIGHT);
 
       // Open: shifted left by the drawer's full width + a gutter…
-      expect(open).toContain("md:right-[calc(360px+0.75rem)]");
+      expect(open).toContain(INSPECTOR_COLUMN_RIGHT);
       // …and clamped so a wide layer can't overflow back across it.
-      expect(open).toContain("md:max-w-[calc(100vw-360px-0.75rem*3)]");
-      // Below md the drawer is near-full-width; overlaying is correct there.
-      expect(open).toContain("right-3");
+      expect(open).toContain("max-w-[calc(100vw-360px-0.75rem*3)]");
+    }
+  });
+
+  // No `md:` (or any other) media-query prefix anywhere in the output — the
+  // whole point of the fix is that ONE JS-computed boolean, not a second CSS
+  // breakpoint, decides this.
+  it("never emits a media-query-prefixed class (the bug this replaces)", () => {
+    for (const dock of ["right", "center"] as const) {
+      for (const reserve of [false, true]) {
+        expect(layerPlacement(dock, reserve)).not.toMatch(/\bmd:/);
+      }
     }
   });
 
@@ -429,7 +462,7 @@ describe("layer placement never collides with the Inspector", () => {
     const open = layerPlacement("center", true);
     expect(open).toContain("left-3");
     expect(open).toContain("mx-auto");
-    expect(open).toContain("md:right-[calc(360px+0.75rem)]");
+    expect(open).toContain(INSPECTOR_COLUMN_RIGHT);
   });
 
   it("every layer offsets while a node is selected, and none does otherwise", () => {
@@ -442,9 +475,12 @@ describe("layer placement never collides with the Inspector", () => {
       summon(id);
       const unselected = screen.getByTestId(`layer-${id}`);
       expect(unselected.getAttribute("data-inspector-open")).toBe("false");
-      expect(unselected.className).not.toMatch(/md:right-/);
+      expect(unselected.getAttribute("data-reserve-inspector-column")).toBe("false");
+      expect(unselected.className).not.toContain(INSPECTOR_COLUMN_RIGHT);
 
-      // Selection on a node that really exists → column reserved.
+      // Selection on a node that really exists, at a width wide enough that
+      // the Inspector is actually a drawer (jsdom's default is 1024) →
+      // column reserved.
       cleanup();
       resetLayers();
       currentStore = makeStore({
@@ -456,8 +492,9 @@ describe("layer placement never collides with the Inspector", () => {
       summon(id);
       const selected = screen.getByTestId(`layer-${id}`);
       expect(selected.getAttribute("data-inspector-open")).toBe("true");
+      expect(selected.getAttribute("data-reserve-inspector-column")).toBe("true");
       expect(selected.className, `layer ${id} does not clear the inspector`).toContain(
-        "md:right-[calc(360px+0.75rem)]",
+        INSPECTOR_COLUMN_RIGHT,
       );
     }
   });
@@ -500,6 +537,92 @@ describe("layer placement never collides with the Inspector", () => {
   });
 });
 
+/** THE BAND THE MISMATCH LIVED IN (fix round 1, review finding #1): 768–899px
+ *  is exactly where the OLD `md:` (768px) breakpoint would have reserved the
+ *  drawer's column while Inspector.tsx (900px) had already switched it to a
+ *  bottom sheet. Both sides of the shared `BP_INSPECTOR_SHEET` (900) boundary
+ *  are asserted too, so a future change to either constant without the other
+ *  shows up here first. */
+describe("layer placement across the Inspector's drawer/sheet boundary (BP_INSPECTOR_SHEET=900)", () => {
+  it("does NOT reserve a column at 800px with a selection — the Inspector is a bottom sheet there, not a drawer", () => {
+    currentStore = makeStore({
+      model: symbolModel(),
+      selected: SYM,
+      status: { kind: "ready" },
+    }).store;
+    setViewportWidth(800);
+    render(<LayerHost />);
+    summon("legend");
+    const el = screen.getByTestId("layer-legend");
+    expect(el.getAttribute("data-inspector-open")).toBe("true"); // selected, and the Inspector IS mounted…
+    expect(el.getAttribute("data-reserve-inspector-column")).toBe("false"); // …just not as a drawer
+    expect(el.className).not.toContain(INSPECTOR_COLUMN_RIGHT);
+    expect(el.className).toContain("right-3"); // the plain, unshifted position
+  });
+
+  it("still does not reserve a column anywhere in the 768–899 band (the old md: breakpoint's range)", () => {
+    for (const width of [768, 820, 899]) {
+      cleanup();
+      resetLayers();
+      currentStore = makeStore({
+        model: symbolModel(),
+        selected: SYM,
+        status: { kind: "ready" },
+      }).store;
+      setViewportWidth(width);
+      render(<LayerHost />);
+      summon("legend");
+      expect(
+        screen.getByTestId("layer-legend").getAttribute("data-reserve-inspector-column"),
+        `width=${width}`,
+      ).toBe("false");
+    }
+  });
+
+  it("reserves the column starting exactly at 900px (the same boundary Inspector.tsx switches on)", () => {
+    currentStore = makeStore({
+      model: symbolModel(),
+      selected: SYM,
+      status: { kind: "ready" },
+    }).store;
+    setViewportWidth(900);
+    render(<LayerHost />);
+    summon("legend");
+    const el = screen.getByTestId("layer-legend");
+    expect(el.getAttribute("data-reserve-inspector-column")).toBe("true");
+    expect(el.className).toContain(INSPECTOR_COLUMN_RIGHT);
+  });
+
+  it("does not reserve a column one pixel below the boundary (899px)", () => {
+    currentStore = makeStore({
+      model: symbolModel(),
+      selected: SYM,
+      status: { kind: "ready" },
+    }).store;
+    setViewportWidth(899);
+    render(<LayerHost />);
+    summon("legend");
+    expect(screen.getByTestId("layer-legend").getAttribute("data-reserve-inspector-column")).toBe(
+      "false",
+    );
+  });
+
+  it("without a selection, no column is reserved anywhere across the boundary either", () => {
+    for (const width of [800, 900, 1024]) {
+      cleanup();
+      resetLayers();
+      currentStore = makeStore({ model: symbolModel(), selected: null }).store;
+      setViewportWidth(width);
+      render(<LayerHost />);
+      summon("legend");
+      expect(
+        screen.getByTestId("layer-legend").getAttribute("data-reserve-inspector-column"),
+        `width=${width}`,
+      ).toBe("false");
+    }
+  });
+});
+
 /** Astrolabe V5 §2 (responsive <640px): every summoned layer becomes a
  *  full-width bottom sheet below `BP_LAYER_FULL_WIDTH`, regardless of its
  *  normal dock/width — there is no room left over for a docked 184px–30rem
@@ -518,13 +641,6 @@ describe("layer placement — full-width bottom sheet under 640px (Astrolabe V5 
   it("is opt-in: the default (no third argument) is the normal docked placement", () => {
     expect(layerPlacement("right", false)).not.toContain("max-w-none");
   });
-
-  const ORIGINAL_INNER_WIDTH = window.innerWidth;
-  function setViewportWidth(width: number) {
-    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: width });
-    fireEvent(window, new Event("resize"));
-  }
-  afterEach(() => setViewportWidth(ORIGINAL_INNER_WIDTH));
 
   it("a mounted LayerShell drops the sheet below 640px, marking itself via data-full-width-sheet", () => {
     currentStore = makeStore({ model: tinyModel() }).store;

--- a/viz/src/panels/layerStack.test.tsx
+++ b/viz/src/panels/layerStack.test.tsx
@@ -47,6 +47,9 @@ const {
   resetLayers,
   showLayer,
   toggleLayer,
+  stashLayer,
+  restoreStashedLayer,
+  stashedLayer,
   LAYER_IDS,
 } = await import("./layerState");
 const { setCommandPaletteOpen, isCommandPaletteOpen, requestCommandPalette } = await import(
@@ -209,6 +212,44 @@ describe("layerState — exclusivity is structural", () => {
     expect(hideLayer()).toBe(false);
     summon("help");
     expect(hideLayer()).toBe(true);
+    expect(openLayer()).toBeNull();
+  });
+});
+
+/** Fix round 2 / REP-22 polish: "palette layer-toggle during active tour is
+ *  clobbered by stash restore on tour exit". `stashLayer`/`restoreStashedLayer`
+ *  are tested directly here (no need to mount TourController — it's a thin
+ *  wrapper that calls exactly these two functions on the tour's
+ *  active/inactive transitions; see `tourCinematic.test.tsx` for that wiring). */
+describe("layerState — stash/restore is merge-aware (fix round 2)", () => {
+  it("an explicit toggle taken DURING the tour wins over the pre-tour stash", () => {
+    resetLayers();
+    showLayer("help"); // open before the tour starts
+    stashLayer(); // tour entry: park it, close everything
+    expect(openLayer()).toBeNull();
+    expect(stashedLayer()).toBe("help");
+
+    showLayer("legend"); // an in-tour explicit toggle (e.g. via the palette)
+    restoreStashedLayer(); // tour exit
+
+    expect(openLayer()).toBe("legend"); // NOT "help" — the explicit choice wins
+    expect(stashedLayer()).toBeNull(); // the stash is still consumed, not left dangling
+  });
+
+  it("restores the pre-tour stash when nothing was explicitly opened during the tour", () => {
+    resetLayers();
+    showLayer("filters");
+    stashLayer();
+    expect(openLayer()).toBeNull();
+
+    restoreStashedLayer();
+
+    expect(openLayer()).toBe("filters");
+  });
+
+  it("is a no-op when nothing was stashed (no layer was open before the tour)", () => {
+    resetLayers();
+    restoreStashedLayer();
     expect(openLayer()).toBeNull();
   });
 });
@@ -456,6 +497,54 @@ describe("layer placement never collides with the Inspector", () => {
     // z-120 vs the Inspector's z-110: intentional, so a layer summoned over the
     // drawer's own edge is never clipped by it.
     expect(screen.getByTestId("layer-filters").className).toContain("z-[120]");
+  });
+});
+
+/** Astrolabe V5 §2 (responsive <640px): every summoned layer becomes a
+ *  full-width bottom sheet below `BP_LAYER_FULL_WIDTH`, regardless of its
+ *  normal dock/width — there is no room left over for a docked 184px–30rem
+ *  panel at this size, and the Inspector is itself a full-bleed sheet down
+ *  here too. */
+describe("layer placement — full-width bottom sheet under 640px (Astrolabe V5 §2)", () => {
+  it("layerPlacement ignores dock/inspector state and returns a full-width sheet", () => {
+    for (const dock of ["right", "center"] as const) {
+      for (const inspectorOpen of [false, true]) {
+        const placement = layerPlacement(dock, inspectorOpen, true);
+        expect(placement).toBe("bottom-9 inset-x-3 max-w-none");
+      }
+    }
+  });
+
+  it("is opt-in: the default (no third argument) is the normal docked placement", () => {
+    expect(layerPlacement("right", false)).not.toContain("max-w-none");
+  });
+
+  const ORIGINAL_INNER_WIDTH = window.innerWidth;
+  function setViewportWidth(width: number) {
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: width });
+    fireEvent(window, new Event("resize"));
+  }
+  afterEach(() => setViewportWidth(ORIGINAL_INNER_WIDTH));
+
+  it("a mounted LayerShell drops the sheet below 640px, marking itself via data-full-width-sheet", () => {
+    currentStore = makeStore({ model: tinyModel() }).store;
+    setViewportWidth(500);
+    render(<LayerHost />);
+    summon("legend");
+    const el = screen.getByTestId("layer-legend");
+    expect(el.getAttribute("data-full-width-sheet")).toBe("true");
+    expect(el.className).toContain("max-w-none");
+    expect(el.className).not.toContain("w-56"); // LegendSheet's normal desired width
+  });
+
+  it("stays docked at its normal width at 900px", () => {
+    currentStore = makeStore({ model: tinyModel() }).store;
+    setViewportWidth(900);
+    render(<LayerHost />);
+    summon("legend");
+    const el = screen.getByTestId("layer-legend");
+    expect(el.getAttribute("data-full-width-sheet")).toBe("false");
+    expect(el.className).toContain("w-56");
   });
 });
 

--- a/viz/src/panels/layerState.ts
+++ b/viz/src/panels/layerState.ts
@@ -35,13 +35,6 @@ export type LayerId = "legend" | "minimap" | "filters" | "help";
 /** Display order — also the order the help overlay lists the toggles in. */
 export const LAYER_IDS: readonly LayerId[] = ["minimap", "legend", "filters", "help"];
 
-export const LAYER_LABEL: Record<LayerId, string> = {
-  minimap: "Map",
-  legend: "Legend",
-  filters: "Filters",
-  help: "Help",
-};
-
 let openId: LayerId | null = null;
 const listeners = new Set<() => void>();
 
@@ -103,11 +96,19 @@ export function stashLayer(): void {
 
 /** Re-opens the layer `stashLayer` parked, if any, and forgets it. Called on
  *  tour exit, so the tour is a genuine round trip rather than a way to silently
- *  lose the panel you had open. */
+ *  lose the panel you had open.
+ *
+ *  MERGE-AWARE (fix round 2 / REP-22 polish): a layer summoned from the
+ *  palette WHILE the tour is running (nothing stops that — only Esc defers to
+ *  the tour, opening one doesn't) leaves `openId` non-null at exit time. Blindly
+ *  restoring the stash on top of that clobbered the viewer's own in-tour
+ *  choice with whatever was open before the tour even started. The fix: only
+ *  restore when nothing is currently open — an explicit toggle taken during
+ *  the tour wins over the pre-tour stash. */
 export function restoreStashedLayer(): void {
   const next = stashed;
   stashed = null;
-  if (next) showLayer(next);
+  if (next && openId === null) showLayer(next);
 }
 
 /** Test/introspection hook: what `restoreStashedLayer` would re-open. */

--- a/viz/src/panels/toasts.test.tsx
+++ b/viz/src/panels/toasts.test.tsx
@@ -16,6 +16,7 @@ import {
   subscribeToasts,
 } from "./toastState";
 import { Toasts } from "./Toasts";
+import { resetLayers, showLayer } from "./layerState";
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -25,6 +26,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   resetToasts();
+  resetLayers();
   vi.useRealTimers();
 });
 
@@ -156,5 +158,37 @@ describe("Toasts — rendering and a11y", () => {
       "first✕",
       "second✕",
     ]);
+  });
+});
+
+/** Fix round 2 / REP-22 polish: "toasts (bottom-10, z-150) can paint over the
+ *  centered Help overlay's bottom edge". The toast stack now moves to the top
+ *  of the screen whenever ANY summoned layer is open — including the Help
+ *  overlay, and (since every layer becomes a full-width bottom sheet below
+ *  640px) the right-docked ones too — rather than staying pinned to a bottom
+ *  position no single spot could stay clear of. */
+describe("Toasts — repositions above an open summoned layer", () => {
+  it("sits at the bottom by default (nothing summoned)", () => {
+    render(<Toasts />);
+    const region = screen.getByTestId("toast-region");
+    expect(region.getAttribute("data-position")).toBe("bottom");
+    expect(region.className).toContain("bottom-10");
+  });
+
+  it("moves to the top while the Help overlay (or any layer) is open", () => {
+    render(<Toasts />);
+    act(() => showLayer("help"));
+    const region = screen.getByTestId("toast-region");
+    expect(region.getAttribute("data-position")).toBe("top");
+    expect(region.className).toContain("top-3");
+    expect(region.className).not.toContain("bottom-10");
+  });
+
+  it("returns to the bottom once the layer closes", () => {
+    render(<Toasts />);
+    act(() => showLayer("legend"));
+    act(() => resetLayers());
+    const region = screen.getByTestId("toast-region");
+    expect(region.getAttribute("data-position")).toBe("bottom");
   });
 });

--- a/viz/src/panels/viewport.ts
+++ b/viz/src/panels/viewport.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+/** Shared responsive-breakpoint plumbing (Astrolabe V5 polish). Previously
+ *  `StatusBar.tsx` carried its own private `useViewportWidth` for its
+ *  progressive-degradation tiers; the Inspector's <900px bottom-sheet mode and
+ *  the summoned layers' <640px full-width sheets need the exact same "current
+ *  viewport width, updated on resize" primitive, so it moved here rather than
+ *  being copied a third and fourth time. */
+export function useViewportWidth(): number {
+  const [width, setWidth] = useState<number>(() =>
+    typeof window === "undefined" ? 1280 : window.innerWidth,
+  );
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return width;
+}
+
+/** Below this width the Inspector drawer becomes a fixed-height bottom sheet
+ *  (brief: "Responsive <900px"). */
+export const BP_INSPECTOR_SHEET = 900;
+
+/** Below this width every summoned layer (map/legend/filters/help) becomes a
+ *  full-width bottom sheet instead of docking right/center at its normal
+ *  width — there is no room left over for a docked panel at this size, and
+ *  the Inspector is ALSO a full-bleed sheet down here, so there is no column
+ *  to reserve either. */
+export const BP_LAYER_FULL_WIDTH = 640;

--- a/viz/src/routes/Root.tsx
+++ b/viz/src/routes/Root.tsx
@@ -26,6 +26,7 @@ import { Toasts } from "../panels/Toasts";
 import { ModeToasts } from "../panels/ModeToasts";
 import { LoadingScreen } from "../panels/LoadingScreen";
 import { ErrorScreen } from "../panels/ErrorScreen";
+import { CoachMark } from "../panels/CoachMark";
 import { toggleLayer } from "../panels/layerState";
 import { isCommandPaletteOpen, requestCommandPalette } from "../panels/paletteOpenState";
 import { handleGlobalKey } from "../panels/globalKeys";
@@ -243,6 +244,7 @@ function View() {
         <StatusBar />
         {store.status.kind === "ready" && <Inspector />}
         <LayerHost />
+        {store.status.kind === "ready" && <CoachMark />}
         {nodeNotice && (
           <NodeMovedNotice nodeId={nodeNotice} onDismiss={() => setNodeNotice(null)} />
         )}

--- a/viz/src/scene/encoding.ts
+++ b/viz/src/scene/encoding.ts
@@ -211,3 +211,18 @@ export const SYMBOL_KIND_META: { kind: string; filterKey: string; color: string;
     filterKey: m.kind.toLowerCase(),
   }));
 
+/** Status semantics for HUD chrome (REP-22 polish). Before this table, the
+ *  Inspector's impact/covering-test badges carried their own literal hexes
+ *  (`#ff8a73`, `#74ff8e`) with no relationship to anything else on screen —
+ *  exactly the drift `scene/encoding.ts` exists to prevent for node/edge/
+ *  language hues. `warn` reuses `BRAND.amber` (not a new hex) because it's
+ *  already the app's one "something needs attention" hue (toasts, the
+ *  edge-cap indicator, confidence badges); `ok`/`danger` are new but now
+ *  live here, generated into `--color-status-*` tokens by `styles/tokens.ts`
+ *  exactly like every other table above. */
+export const STATUS_META: { status: "ok" | "warn" | "danger"; color: string; label: string }[] = [
+  { status: "danger", color: "#ff8a73", label: "Danger / impacted" },
+  { status: "ok", color: "#74ff8e", label: "OK / covering" },
+  { status: "warn", color: BRAND.amber, label: "Warning" },
+];
+

--- a/viz/src/styles/tokens.test.ts
+++ b/viz/src/styles/tokens.test.ts
@@ -6,6 +6,7 @@ import {
   LANGUAGE_DEFAULT_HEX,
   LANGUAGE_HEX,
   NODE_KIND_META,
+  STATUS_META,
 } from "../scene/encoding";
 
 /** The generated `@theme` block is a build artifact (git-ignored, regenerated at
@@ -46,6 +47,9 @@ describe("renderTokensCss", () => {
       expect(css).toContain(`--color-lang-${tokenSlug(lang)}: ${hexValue};`);
     }
     expect(css).toContain(`--color-lang-default: ${LANGUAGE_DEFAULT_HEX};`);
+    for (const meta of STATUS_META) {
+      expect(css).toContain(`--color-status-${tokenSlug(meta.status)}: ${meta.color};`);
+    }
   });
 
   it("declares each token exactly once, with CSS-safe names, sorted per group", () => {
@@ -67,7 +71,8 @@ describe("renderTokensCss", () => {
         NODE_KIND_META.length +
         EDGE_TYPE_META.length +
         Object.keys(LANGUAGE_HEX).length +
-        1,
+        1 +
+        STATUS_META.length,
     );
   });
 

--- a/viz/src/styles/tokens.ts
+++ b/viz/src/styles/tokens.ts
@@ -18,6 +18,7 @@ import {
   LANGUAGE_DEFAULT_HEX,
   LANGUAGE_HEX,
   NODE_KIND_META,
+  STATUS_META,
 } from "../scene/encoding";
 
 /** CSS-identifier-safe slug for a token name segment: lower-case, non
@@ -60,11 +61,17 @@ export function tokenGroups(): { title: string; tokens: Token[] }[] {
     { name: "--color-lang-default", value: LANGUAGE_DEFAULT_HEX },
   ].sort(byName);
 
+  const status: Token[] = STATUS_META.map((m) => ({
+    name: `--color-status-${tokenSlug(m.status)}`,
+    value: m.color,
+  })).sort(byName);
+
   return [
     { title: "brand accents (BRAND)", tokens: brand },
     { title: "node kinds (NODE_KIND_META)", tokens: nodeKinds },
     { title: "edge types (EDGE_TYPE_META)", tokens: edgeTypes },
     { title: "languages (LANGUAGE_HEX + LANGUAGE_DEFAULT_HEX)", tokens: languages },
+    { title: "status (STATUS_META)", tokens: status },
   ];
 }
 


### PR DESCRIPTION
Astrolabe V5 — the final polish pass. Closes the redesign and clears every deferred minor accumulated across V1–V4.

## What changed
- **First-run coach mark**: one dismissible hint ("⌘K to navigate · ? for keys"), localStorage-persisted, hidden while a layer or toast is up, reduced-motion aware. No multi-step onboarding.
- **Responsive**: Inspector becomes a bottom sheet below 900px; layers become full-width bottom sheets below 640px. Layer placement now derives its Inspector-column reservation from the **same JS breakpoint constant** the Inspector uses — killing a 768–899px band where layers dodged a drawer that wasn't there (tested at 768/800/899/900).
- **A11y**: contrast floor enforced across every chrome surface (one app-wide dim token, so hierarchy got *more* consistent, not flatter); `:focus-visible` rings everywhere interactive; decorative glyphs correctly `aria-hidden` (the breadcrumb `·` was announcing itself to screen readers); reduced-motion fallbacks. Honest note: axe / eslint-a11y aren't configured in this repo, so that box is unchecked rather than quietly assumed.
- **Status colors tokenized**: the last hardcoded hexes in the Inspector now flow from the same generated token source as everything else, with an identity test.
- **Deferred-minors ledger cleared**: breadcrumb adjacent-duplicate dedupe + truncation tiers, tour-stash restore is now merge-aware (an in-tour layer toggle wins over the stash), `aria-expanded` reflects real results, ErrorScreen is opaque (blur is for transient overlays only), toast/Help stacking resolved, and baked static exports finally report real node/edge counts in the manifest.
- **Dead code** removed; design detector (`detect.mjs`) returns **zero findings**.

## Bundle audit
Recorded in the task report: total gzip +32.7% (JS +14.5%) versus the pre-redesign v0.3.0 baseline, traced almost entirely to the React 19 / R3F v9 / drei v10 / `@react-three/postprocessing` v3 major bumps from V0 — this task added no dependencies. Documented rather than trimmed (no risky refactors in a polish pass).

## Tests
viz **640 passed / 50 files** · mcp **701 passed** (untouched) · typecheck, lint, build clean · detector `[]`.

Linear: REP-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
