### PR TITLE
feat(mcp): optional shared remote MCP — serve --http, bearer auth, per-token attribution (REP-17)

### DIFF
--- a/.reposkein/decisions/2026-08-21-optional-shared-remote-mcp-server-hosted-multi-user-access-b.json
+++ b/.reposkein/decisions/2026-08-21-optional-shared-remote-mcp-server-hosted-multi-user-access-b.json
@@ -1,0 +1,61 @@
+{
+  "id": "adr:2026-08-21-optional-shared-remote-mcp-server-hosted-multi-user-access-b",
+  "alternatives": "Keep the non-goal and tell teams to run the stdio server behind their own socket bridge (mcp-proxy, ssh): no auth story, no per-caller identity, and the process-global select_repo makes two callers actively unsafe. Ship SSE transport instead of Streamable HTTP: deprecated in the MCP spec and it would need the same auth work. Add OAuth/OIDC via the SDK's auth router: correct for a real SaaS, disproportionate for an operator running one process against one checkout, and it drags in an identity provider — a zero-infra violation in spirit. Read-write by default with an opt-out: inverts the safe default for a networked service. Re-index on a filesystem watcher instead of a HEAD poll: fires on every editor save, and the indexer's idempotence guarantee is defined against committed state, not scratch edits. Serve `/api/*` from a second process next to the MCP server: two graphs, two staleness stories, and the viewer and the agent drift apart — the exact failure sharing view.ts's handler factory prevents.",
+  "anchors": [
+    {
+      "hash": "42bd60b11ac0e0e42d309f8d2d33ecd44096a7f32bb70dfb11d9a8aaf79e8a8e",
+      "kind": "File",
+      "name": "index.ts",
+      "node_id": "rs1:e1e153794891:file:mcp/src/index.ts",
+      "path": "mcp/src/index.ts"
+    },
+    {
+      "hash": "591883190ce68e5b7b0dece441dbe589320cfe0a58abea6f385c7a01d4031f1d",
+      "kind": "File",
+      "name": "view.ts",
+      "node_id": "rs1:e1e153794891:file:mcp/src/cli/view.ts",
+      "path": "mcp/src/cli/view.ts"
+    },
+    {
+      "hash": "f2197f68327fa84e53e018805f5374143bb4b5094a76791998052b3201cef3a4",
+      "kind": "File",
+      "name": "repoSession.ts",
+      "node_id": "rs1:e1e153794891:file:mcp/src/store/repoSession.ts",
+      "path": "mcp/src/store/repoSession.ts"
+    },
+    {
+      "hash": "b5c29ff8f37ca2d986ad8c83e68e5e4e90e11574603e88a2580f0081c1906375",
+      "kind": "File",
+      "name": "writeSemanticSummary.ts",
+      "node_id": "rs1:e1e153794891:file:mcp/src/tools/writeSemanticSummary.ts",
+      "path": "mcp/src/tools/writeSemanticSummary.ts"
+    },
+    {
+      "hash": "d7243b9f1e85ff5249b58ee958d8644c3df5cb53449334c5b3032df6b0a7f920",
+      "kind": "File",
+      "name": "recordDecision.ts",
+      "node_id": "rs1:e1e153794891:file:mcp/src/tools/recordDecision.ts",
+      "path": "mcp/src/tools/recordDecision.ts"
+    }
+  ],
+  "body_hash": "41b84e5b88fd19407cef6e0836112b849a6f54ed4c90b5dee85662b2292dd72a",
+  "consequences": "RepoSkein gains a second deployment shape, and with it a threat model it did not have: a mode where an attacker who reaches the port and holds a token can read every file the served repo contains (`/api/source` serves arbitrary in-repo slices) and, with a write token, mutate the sidecar and the decision log. That risk is bounded by the mode being opt-in, auth-mandatory, read-only by default, and single-checkout, but it now has to be documented and maintained. Extracting the tool registration into a per-connection factory is the structural cost: `main()` no longer owns the McpServer, and any new tool must declare whether it mutates so the capability gate stays honest — a checklist item that did not exist before. Attribution improves everywhere, including stdio, because identity became an explicit parameter instead of an ambient env read. The watch loop makes the server's graph a moving target: a caller can see nodes appear between two tool calls, which the stdio path (indexed once at startup) never did.",
+  "context": "The PRD lists a hosted, multi-user deployment as a non-goal, and the code was built to match: the server is launched over stdio by one agent on one machine, its RepoSession/select_repo state and store cache are process-global singletons, the `view` HTTP server binds 127.0.0.1 with no auth because a loopback-only server already trusts its caller, and every write is attributed to REPOSKEIN_AGENT or, when nobody sets it, the literal string \"agent\". Two pressures argue against keeping that non-goal absolute. First, teams that adopted committed summaries and ADRs as shared memory have no way to hand the graph to an agent that is not sitting on a clone of the checkout — a CI job, a hosted coding agent, a reviewer without the repo — short of installing the indexer and cloning everywhere. Second, the anonymity of writes is a real defect for a knowledge base with more than one author: `summary_by` and `decided_by` are almost always \"agent\", so the ADR log cannot say who decided anything. A remote mode with named bearer tokens fixes attribution as a side effect of solving access. The user approved this phase explicitly in the session that produced this record.",
+  "decided_at": "2026-08-21",
+  "decided_by": "marcus (approved in session, recorded by claude)",
+  "decision": "Hosted, multi-user access is now IN scope, but only as a strictly optional operator-run mode: `reposkein-mcp serve --http [--port N] [--host H]`. The following boundaries are part of the decision, not implementation detail. (1) stdio remains the default and the only supported path for a single developer: `reposkein-mcp` with no subcommand behaves exactly as before, and no socket is bound unless `serve` is invoked. (2) The mode is auth-mandatory. `serve` refuses to start with no tokens configured; tokens come from `[serve] tokens` in `.reposkein/config.toml` or `REPOSKEIN_SERVE_TOKENS` as `name:token[:write]` entries; every MCP and `/api/*` request must carry `Authorization: Bearer <token>`; comparison is timing-safe; token values are never logged. (3) The toolset is read-only by default. write_semantic_summary, record_decision, set_decision_status, reaffirm_decision, reindex_file, and init_cpg_skeleton require a token carrying the `write` capability; a read-only token calling one gets a structured refusal naming the tool and the missing capability, never a partial write. (4) Session state is per connection. Each MCP session owns its RepoSession, tool logger, and repo-context cache, so one caller's select_repo cannot move another caller's active repo. (5) The token's NAME is the writer identity for its connection: it lands in `summary_by`/`decided_by` and selects the per-agent sidecar file, overriding REPOSKEIN_AGENT. (6) The checkout stays the source of truth. The server polls `git rev-parse HEAD` (default 30s, `--watch-interval`, 0 disables) and re-indexes only when HEAD differs from the `.reposkein/local/indexed-at` marker, so the deterministic indexer keeps its idempotence and `doctor`'s staleness view stays coherent. (7) One process serves exactly one checkout, and the same process serves the viewer: `/api/*` comes from view.ts's own handler factory (shared, not duplicated) so the hosted viewer and the remote MCP can never disagree about the graph. (8) TLS termination, network exposure, and token distribution are the operator's job; RepoSkein speaks plain HTTP and docs/REMOTE.md says so plainly. (9) Explicitly NOT lifted by this record and still out of scope: user accounts, OAuth/OIDC, per-path or per-repo authorization, rate limiting, audit trails beyond the existing session log, multi-tenancy, and any RepoSkein-operated hosted service. Zero-infra is untouched — no database, no Docker, no new runtime dependency beyond what the MCP SDK already ships. This record is written directly as `accepted` rather than record_decision's default `proposed` because the user ratified the direction explicitly in session; that approval is the same signal set_decision_status exists to capture, so recording it as proposed would understate what happened.",
+  "paths": [
+    "mcp/src/serve/",
+    "mcp/src/server/",
+    "mcp/src/index.ts",
+    "mcp/src/cli/view.ts",
+    "mcp/src/store/repoSession.ts",
+    "docs/REMOTE.md"
+  ],
+  "status": "accepted",
+  "supersedes": [],
+  "title": "Optional shared remote MCP server: hosted multi-user access behind per-token capabilities",
+  "trigger": {
+    "kind": "manual"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ cliff.toml    # git-cliff config (Conventional Commits → CHANGELOG.md)
 | Task | Location |
 |---|---|
 | Add language extractor | `indexer/crates/lang-<x>/` (template: `lang-go`); register in `indexer/crates/cli/src/main.rs` |
-| New MCP tool | `mcp/src/tools/` + register in `mcp/src/index.ts` |
+| New MCP tool | `mcp/src/tools/` + register in `mcp/src/server/createMcpServer.ts` (one server per connection; a MUTATING tool must also be listed in `WRITE_TOOLS` and registered with `withWrite`, or `serve --http`'s read-only tokens could write) |
 | Graph storage backend | `mcp/src/store/` (GraphStore + JSONL + Neo4j + Federation) |
 | Cross-file resolution semantics | `indexer/crates/core/src/resolve.rs` (2291 LOC) |
 | Frozen `@arity` qualified-name rule | `indexer/crates/core/src/id.rs` (changing it orphans all summaries) |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For complex setups — multi-repo workspaces, Neo4j backend, the local embedding
 Python, TypeScript, JavaScript, Rust, Go, Java, C# — with an honest per-language matrix of what resolves `exact` vs by-name vs `ambiguous`. Full table + the resolution rules: **[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#supported-languages)**. [Adding a language](CONTRIBUTING.md#adding-a-new-language) is a well-trodden path — contributions welcome.
 
 <a id="how-it-works"></a><a id="cross-repo-federation"></a><a id="visualize-the-graph--the-constellation-viewer"></a><a id="optional-semantic-embeddings"></a><a id="optional-neo4j-backend"></a><a id="build-from-source"></a><a id="repository-layout"></a>
-**Going deeper:** [how the graph is built + cross-repo federation](docs/ARCHITECTURE.md) · [the constellation viewer](docs/VIEWER.md) · [semantic embeddings](docs/EMBEDDINGS.md) · [Neo4j backend](docs/NEO4J.md) · [building from source + repo layout](CONTRIBUTING.md).
+**Going deeper:** [how the graph is built + cross-repo federation](docs/ARCHITECTURE.md) · [the constellation viewer](docs/VIEWER.md) · [semantic embeddings](docs/EMBEDDINGS.md) · [Neo4j backend](docs/NEO4J.md) · [shared remote server](docs/REMOTE.md) · [building from source + repo layout](CONTRIBUTING.md).
 
 ## Documentation
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -511,3 +511,23 @@ Actions workflow that publishes it to GitHub Pages on every push.
 **Read [`docs/HOSTING.md`](./HOSTING.md) before enabling this** — it covers
 GitHub Pages' public-by-default visibility and internal-host alternatives.
 
+
+---
+
+## 12. Share one live server instead (advanced, optional)
+
+Everything above installs the **stdio** server: your agent launches
+`reposkein-mcp` as a subprocess on the machine holding the checkout. That is
+the default and the supported path — if you have the repo locally, stop here.
+
+If you need agents that have **no clone** (a CI job, a hosted coding agent, a
+reviewer without the repo) to reach one always-current graph, there is an
+opt-in remote mode: `reposkein-mcp serve --http` speaks MCP over Streamable
+HTTP and serves the viewer + `/api/*` from the same process, behind
+bearer-token auth, read-only by default, re-indexing when the served checkout's
+HEAD moves.
+
+**Read [`docs/REMOTE.md`](./REMOTE.md) before enabling this** — it covers token
+capabilities, per-connection isolation, and the security division of labour
+(TLS termination and network exposure are the operator's job). It is not
+required for normal use and nothing opens a socket unless you run it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ the [root README's Documentation table](../README.md#documentation).
 - **Visualizing the graph?** → [`VIEWER.md`](VIEWER.md) — the 3D constellation viewer (`reposkein-mcp view`), its lenses/overlays, and static export.
 - **Wiring up semantic search?** → [`EMBEDDINGS.md`](EMBEDDINGS.md) — the optional hybrid embeddings tier: cloud (Voyage), local (Ollama), or self-hosted (`voyage-4-nano`).
 - **Scaling past the default store?** → [`NEO4J.md`](NEO4J.md) — the optional Neo4j backend, for very large graphs or raw Cypher.
+- **Need one shared, always-current server for agents that have no clone?** → [`REMOTE.md`](REMOTE.md) — the **advanced, optional** `serve --http` mode: MCP over Streamable HTTP + the viewer in one process, bearer tokens, read-only by default. Not needed for normal use (stdio is the default).
 
 ## Understanding the system
 

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -1,0 +1,248 @@
+# Remote MCP (advanced, optional)
+
+> **This is an opt-in deployment mode, not part of normal use.** RepoSkein's
+> default and supported transport is **stdio**: your agent launches
+> `reposkein-mcp` as a subprocess on the machine that holds the checkout.
+> Nothing in this document is required to use RepoSkein, and nothing binds a
+> network socket unless you explicitly run `serve --http`.
+>
+> The decision to support this at all — and the scope boundaries it comes
+> with — is recorded as an ADR in
+> `.reposkein/decisions/2026-08-21-optional-shared-remote-mcp-server-hosted-multi-user-access-b.json`
+> (`reposkein-mcp adr export .` to read it as prose).
+
+## What it is
+
+One process, one git checkout, two surfaces:
+
+| Route | What it serves |
+|---|---|
+| `POST/GET/DELETE /mcp` | The MCP **Streamable HTTP** transport — tools, per connection |
+| `GET /api/graph` | The graph manifest (repo id, node/edge counts, commit metadata) |
+| `GET /api/jsonl/nodes.jsonl`, `GET /api/jsonl/edges.jsonl` | The committed graph |
+| `GET /api/source?path=&start=&end=` | A read-only, size-capped source slice |
+| `GET /api/temporal` | The git-derived co-change overlay |
+| `GET /` and everything else | The prebuilt constellation viewer (SPA) |
+
+The `/api/*` routes are **not a reimplementation** — `serve` calls the same
+handler factory `reposkein-mcp view` uses, so the hosted viewer and the remote
+agent read the same graph by construction. A dedicated test asserts the
+responses are identical.
+
+Who it is for: a team that wants one always-current graph reachable by agents
+that are *not* sitting on a clone — a CI job, a hosted coding agent, a reviewer
+without the repo. If you have the repo locally, use stdio; it is faster, needs
+no tokens, and has no attack surface.
+
+## Quickstart
+
+```bash
+# 1. On the machine that holds the checkout, index it once.
+cd /srv/checkouts/myrepo
+npx @reposkein/mcp init .
+
+# 2. Mint tokens. Names are identities, not secrets; the secret is the 2nd field.
+#    Append `:write` to grant write tools. Read-only is the default.
+export REPOSKEIN_SERVE_TOKENS="review-bot:$(openssl rand -hex 24),ci:$(openssl rand -hex 24):write"
+
+# 3. Serve. --http is required and explicit.
+npx @reposkein/mcp serve --http . --port 4318 --host 127.0.0.1
+```
+
+Point an agent at it (Claude Code example — any MCP client with Streamable
+HTTP support works the same way):
+
+```json
+{
+  "mcpServers": {
+    "reposkein-remote": {
+      "type": "http",
+      "url": "https://reposkein.internal.example.com/mcp",
+      "headers": { "Authorization": "Bearer <the token>" }
+    }
+  }
+}
+```
+
+Open the hosted viewer in a browser by visiting
+`https://reposkein.internal.example.com/?token=<the token>` **once**: the
+server trades the query parameter for an `HttpOnly` cookie and redirects to the
+clean URL, so the secret appears in one request line instead of every one.
+
+## Flags
+
+```
+reposkein-mcp serve --http [path] [--port N] [--host H] [--watch-interval SECONDS]
+```
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--http` | — | **Required.** The only transport this subcommand serves. Without it, `serve` prints usage and exits 1. |
+| `[path]` | `$REPOSKEIN_REPO_PATH` or `.` | The one checkout this process serves. |
+| `--port` | `4318` | |
+| `--host` | `127.0.0.1` | Deliberately loopback even here — exposing the port is an explicit decision. |
+| `--watch-interval` | `30` (seconds) | `0` disables the HEAD poll entirely. |
+
+## Tokens and capabilities
+
+A token is `name:secret[:write]`. Entries are separated by commas or
+whitespace, so the same string pastes into a shell `export`, a systemd
+`Environment=`, or a TOML value.
+
+```
+REPOSKEIN_SERVE_TOKENS="review-bot:8f3c…,ci:1a90…:write"
+```
+
+or, **for a private deployment only** (`.reposkein/config.toml` is committed —
+putting a real secret there shares it with everyone who can read the repo):
+
+```toml
+[serve]
+tokens = "review-bot:8f3c…, ci:1a90…:write"
+```
+
+`REPOSKEIN_SERVE_TOKENS` wins outright when set; the two sources are never
+merged, so "why does this old token still work?" always has one answer.
+
+- Secrets shorter than 16 characters are **dropped**, with a reason on stderr
+  that never contains the secret itself.
+- `serve` **refuses to start** with no usable tokens. An unauthenticated remote
+  MCP server would hand the network read access to your source and, with a
+  write-capable toolset, your decision log.
+- A token's **name** is the writer identity for its connection. It lands in
+  `summary_by` and `decided_by`, and selects that writer's
+  `.reposkein/local/summaries-<name>.jsonl` sidecar — overriding
+  `REPOSKEIN_AGENT`. This is why remote writes are attributable at all: over
+  stdio, everything unlabelled is just `agent`.
+
+### Read-only by default
+
+These tools require a `write`-capable token:
+
+`write_semantic_summary` · `record_decision` · `set_decision_status` ·
+`reaffirm_decision` · `reindex_file` · `init_cpg_skeleton`
+
+They stay listed in `tools/list` for a read-only connection (with a note in the
+description) so the failure is legible rather than a mysterious "unknown
+tool" — but calling one changes nothing and returns a structured error:
+
+```json
+{
+  "error": "write_capability_required",
+  "tool": "record_decision",
+  "required_capability": "write",
+  "identity": "review-bot",
+  "detail": "This connection is read-only, so record_decision was refused before it could change anything. …"
+}
+```
+
+Everything else — `get_context_profile`, `semantic_find`, `impact`,
+`get_temporal_context`, `list_decisions`, `get_decision`, `read_cypher`,
+`list_repos`, `select_repo` — works with any valid token. `select_repo` is not
+gated: it moves only *this connection's* active repo (see below).
+
+## Per-connection isolation
+
+Each MCP session gets its own server instance: its own active-repo selection,
+its own store cache, its own tool-call log file. One caller's `select_repo` is
+invisible to every other caller.
+
+Sessions are also **bound to the token that opened them** — presenting someone
+else's `Mcp-Session-Id` returns `403 session_token_mismatch`, so a read-only
+credential can never inherit a write-capable session. Unknown session ids get
+`404` (re-`initialize` to open a new one), and the process holds at most 64
+concurrent sessions.
+
+## Staying current with the checkout
+
+The server polls `git rev-parse HEAD` on `--watch-interval` and re-indexes
+**only** when HEAD differs from `.reposkein/local/indexed-at` — the same marker
+`reposkein-mcp doctor` reads, so the watcher and the staleness check can never
+disagree. Consequences of that design:
+
+- An unchanged checkout costs one `git rev-parse` per tick and logs nothing.
+- `git pull` in the served checkout produces exactly **one** re-index, one
+  log line, and a refreshed `/api/*` handler (so the viewer's counts move with
+  the tools').
+- A restart doesn't re-index a checkout that is already current, because the
+  marker is on disk.
+- Re-index failures keep serving the previous graph and retry on the next tick.
+- It is a **poll, not a filesystem watcher**: the indexer's determinism
+  guarantee is defined against committed state, and an fs watcher would fire on
+  every editor save.
+
+Keep the checkout updated however you like — `git fetch && git reset --hard` in
+a cron job, a deploy hook, whatever. `serve` only reacts to HEAD.
+
+Note that indexing writes to the working tree (the committed summary shards
+absorb any `local/summaries-*.jsonl` sidecars). Serve a checkout you are happy
+to have `git status` churn in — a dedicated deploy clone, not someone's laptop
+working copy.
+
+## Security
+
+RepoSkein is not a hardened multi-tenant service, and this mode does not
+pretend to be one. What you get, and what is yours to provide:
+
+**Ours**
+
+- Bearer-token auth on **every** route, including `/api/*` and the viewer.
+- Timing-safe token comparison over fixed-length digests; the whole token list
+  is scanned with no early exit, so response time reveals neither which token
+  matched nor how many exist.
+- Tokens are never logged, printed, or echoed into a tool result or error. The
+  startup banner and the session log show **names** only.
+- Read-only default toolset; write access is per-token and explicit.
+- `127.0.0.1` default bind; `--host` is your decision.
+- Path traversal on `/api/source` is rejected (lexical **and** realpath
+  checks), and slices are line-capped.
+- `?token=` is accepted only on viewer routes, never on `/mcp`, and is
+  immediately traded for an `HttpOnly; SameSite=Strict` cookie.
+
+**Yours**
+
+- **TLS termination.** `serve` speaks plain HTTP. Put nginx/Caddy/a load
+  balancer in front of it, or bind loopback and reach it over an SSH tunnel or
+  a private network. Sending a bearer token over cleartext HTTP across an
+  untrusted network hands it to anyone on the path.
+- **Token distribution and rotation.** There is no token database and no
+  revocation endpoint: rotating means changing `REPOSKEIN_SERVE_TOKENS` and
+  restarting. Treat each token as a long-lived shared secret and scope it by
+  giving each caller its own.
+- **Network exposure.** `--host 0.0.0.0` on a public interface publishes your
+  source to anyone who obtains a token.
+- **Access logging.** If your proxy logs full URLs, the one-time `?token=`
+  handshake lands in those logs. Prefer the `Authorization` header for
+  anything automated.
+
+**What a valid token can reach.** Any token can read the whole graph, every
+committed summary and decision, and arbitrary line ranges of any file in the
+served checkout (`/api/source`). There is no per-path or per-repo
+authorization. A write-capable token can additionally add summaries, record and
+re-status decisions, and trigger a re-index. Hand out read-only tokens by
+default, and do not serve a checkout containing secrets you would not give the
+token holder directly.
+
+**Explicitly out of scope** (see the ADR): user accounts, OAuth/OIDC, per-path
+authorization, rate limiting, audit trails beyond the existing session log,
+multi-tenancy (one process, one checkout), and any RepoSkein-operated hosting.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `refusing to start with no tokens` | `REPOSKEIN_SERVE_TOKENS` unset/empty and no `[serve] tokens`. Also check stderr for dropped entries (short secret, bad name, unknown capability field). |
+| `401 unauthorized` on every route | Missing or wrong `Authorization: Bearer`. The server logs `401 <METHOD> <path>` plus `no bearer token` or `token rejected` — never a secret. |
+| `404 session_not_found` | The server restarted, or the session was closed. Re-`initialize`. |
+| `403 session_token_mismatch` | Two callers sharing one `Mcp-Session-Id`. Give each its own connection. |
+| `write_capability_required` | The token lacks `:write`. |
+| The viewer 404s but `/api/*` works | The packaged viewer bundle is missing (`mcp/dist/viz`). Reinstall the package, or `npm run build` in `mcp/`. |
+| The graph never updates | `--watch-interval 0`, or the served path is not a git checkout (`no-head`), or re-indexing is failing — check stderr. |
+
+## See also
+
+- [`INSTALL.md`](INSTALL.md) — the normal (stdio) setup.
+- [`HOSTING.md`](HOSTING.md) — publishing a **static** constellation to GitHub
+  Pages. No server, no tokens; the right answer when you only want the viewer.
+- [`VIEWER.md`](VIEWER.md) — `reposkein-mcp view`, the local read-only viewer.
+- [`TOOLS.md`](TOOLS.md) — the MCP tool reference.

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -17,7 +17,9 @@ One process, one git checkout, two surfaces:
 
 | Route | What it serves |
 |---|---|
-| `POST/GET/DELETE /mcp` | The MCP **Streamable HTTP** transport — tools, per connection |
+| `POST /mcp` | The MCP **Streamable HTTP** transport — tools, per connection |
+| `DELETE /mcp` | Ends one MCP session |
+| `GET /mcp` | `405` — there is no standalone notification stream; this server only ever answers what you asked for |
 | `GET /api/graph` | The graph manifest (repo id, node/edge counts, commit metadata) |
 | `GET /api/jsonl/nodes.jsonl`, `GET /api/jsonl/edges.jsonl` | The committed graph |
 | `GET /api/source?path=&start=&end=` | A read-only, size-capped source slice |
@@ -93,6 +95,13 @@ whitespace, so the same string pastes into a shell `export`, a systemd
 REPOSKEIN_SERVE_TOKENS="review-bot:8f3c…,ci:1a90…:write"
 ```
 
+Because the format is delimited by `:` and entries by commas/whitespace, a
+**secret may not contain `:`, `,`, or any whitespace** — an entry that does
+splits wrong and is dropped with a reason on stderr rather than silently
+becoming a partial credential. Hex and URL-safe base64 are both fine, which is
+why the quickstart uses `openssl rand -hex 24`. Minimum length is 16
+characters.
+
 or, **for a private deployment only** (`.reposkein/config.toml` is committed —
 putting a real secret there shares it with everyone who can read the repo):
 
@@ -114,6 +123,12 @@ merged, so "why does this old token still work?" always has one answer.
   `.reposkein/local/summaries-<name>.jsonl` sidecar — overriding
   `REPOSKEIN_AGENT`. This is why remote writes are attributable at all: over
   stdio, everything unlabelled is just `agent`.
+- Attribution has one gap worth knowing: `set_decision_status` records only the
+  decision's new status, not who changed it. The record's `decided_by` still
+  names whoever *recorded* the decision, so a remote token ratifying someone
+  else's ADR leaves no per-actor trace in the record itself — only a
+  `set_decision_status` entry in that token's session log. Treat "who accepted
+  this" as a session-log question, not a record question.
 
 ### Read-only by default
 
@@ -141,6 +156,24 @@ Everything else — `get_context_profile`, `semantic_find`, `impact`,
 `list_repos`, `select_repo` — works with any valid token. `select_repo` is not
 gated: it moves only *this connection's* active repo (see below).
 
+A read-only token also never causes an **index build**. Touching a repo whose
+derived graph isn't built normally makes the server run the indexer on first
+use, which writes `.reposkein/nodes.jsonl`, `edges.jsonl`, and the committed
+summary shards — the one mutation a read-only caller could otherwise trigger
+just by naming an unbuilt repo. Read-only connections skip that step entirely
+and get an explanation instead:
+
+```
+/srv/checkouts/other has no built graph (.reposkein/nodes.jsonl is derived from the
+working tree and git-ignored, so a fresh clone has none), and this connection is
+read-only — the server will not build one for it. Ask the operator to run
+`reposkein-mcp index /srv/checkouts/other`, or use a write-capable token. Nothing
+was changed.
+```
+
+This matters mainly in a workspace: the served checkout is indexed at startup,
+but `select_repo` can reach a sibling repo that isn't.
+
 ## Per-connection isolation
 
 Each MCP session gets its own server instance: its own active-repo selection,
@@ -152,6 +185,15 @@ else's `Mcp-Session-Id` returns `403 session_token_mismatch`, so a read-only
 credential can never inherit a write-capable session. Unknown session ids get
 `404` (re-`initialize` to open a new one), and the process holds at most 64
 concurrent sessions.
+
+A session with **no request for 5 minutes is reaped** and its id starts
+returning `404`. Clients that crash or lose the network never send the DELETE
+that closes their session, so without this a long-lived server slowly fills up
+with corpses and eventually refuses new connections at the cap. A session with
+a request still executing is never reaped, however long that request takes, and
+every new-connection attempt sweeps idle sessions first — so a server wedged at
+the cap by dead clients frees itself on the next connect, with no operator
+action.
 
 ## Staying current with the checkout
 
@@ -170,14 +212,29 @@ disagree. Consequences of that design:
 - It is a **poll, not a filesystem watcher**: the indexer's determinism
   guarantee is defined against committed state, and an fs watcher would fire on
   every editor save.
+- Indexer runs are **serialized process-wide**. A write-capable tool call that
+  triggers an index (`reindex_file`, `init_cpg_skeleton`, `record_decision`'s
+  pre-stamp refresh) and the HEAD watcher can now arrive from different
+  connections at once; two indexers on one checkout would interleave their
+  writes to the same files. The watcher **skips** a tick while another run holds
+  the lock rather than queueing behind it, so a busy server doesn't accumulate
+  redundant full indexes.
 
 Keep the checkout updated however you like — `git fetch && git reset --hard` in
 a cron job, a deploy hook, whatever. `serve` only reacts to HEAD.
 
-Note that indexing writes to the working tree (the committed summary shards
-absorb any `local/summaries-*.jsonl` sidecars). Serve a checkout you are happy
-to have `git status` churn in — a dedicated deploy clone, not someone's laptop
-working copy.
+### Serve a deploy clone, not a working copy
+
+Indexing writes to the working tree: the committed summary shards absorb any
+`local/summaries-*.jsonl` sidecars, so a served checkout accumulates diffs over
+time. A re-index also picks up whatever is in the tree at that moment,
+including someone's half-finished edits.
+
+`serve` therefore runs `git status --porcelain` at startup and prints a
+prominent warning naming those two consequences when the tree is dirty. It is a
+**warning, never a refusal** — serving a dirty checkout is sometimes exactly
+what you want. But the recommended shape is a dedicated clone that only ever
+fast-forwards, used by nothing else.
 
 ## Security
 
@@ -233,9 +290,13 @@ multi-tenancy (one process, one checkout), and any RepoSkein-operated hosting.
 |---|---|
 | `refusing to start with no tokens` | `REPOSKEIN_SERVE_TOKENS` unset/empty and no `[serve] tokens`. Also check stderr for dropped entries (short secret, bad name, unknown capability field). |
 | `401 unauthorized` on every route | Missing or wrong `Authorization: Bearer`. The server logs `401 <METHOD> <path>` plus `no bearer token` or `token rejected` — never a secret. |
-| `404 session_not_found` | The server restarted, or the session was closed. Re-`initialize`. |
+| `404 session_not_found` | The session was idle for 5 minutes, was closed, or the server restarted. Re-`initialize`. |
 | `403 session_token_mismatch` | Two callers sharing one `Mcp-Session-Id`. Give each its own connection. |
+| `405 sse_stream_not_supported` | Something opened `GET /mcp`. This server has no notification stream; POST-only is expected and clients continue fine. |
+| `503 too_many_sessions` | 64 live sessions. Usually clients that never sent DELETE — idle ones are reaped after 5 minutes and the next connect sweeps them, so this normally clears itself. If it persists, something is opening a session per request instead of reusing one. |
 | `write_capability_required` | The token lacks `:write`. |
+| `read-only — the server will not build one for it` | A read-only token reached a repo whose graph isn't built. Run `reposkein-mcp index <path>` on the server, or use a write-capable token. |
+| `WARNING — the served checkout has N uncommitted change(s)` | Advisory only. See "Serve a deploy clone" above. |
 | The viewer 404s but `/api/*` works | The packaged viewer bundle is missing (`mcp/dist/viz`). Reinstall the package, or `npm run build` in `mcp/`. |
 | The graph never updates | `--watch-interval 0`, or the served path is not a git checkout (`no-head`), or re-indexing is failing — check stderr. |
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -75,6 +75,7 @@ RepoSkein ships two cross-agent [Agent Skills](https://skills.sh) — `npx skill
 | `reposkein-mcp view [path]` | open the [constellation viewer](VIEWER.md) (`--export <dir>` for a static site). |
 | `reposkein-mcp stats [path]` | session usage report — calls by tool, top queried nodes/files, ADRs/summaries written, session duration, and an estimated context-tokens-saved-vs-grep number. |
 | `reposkein-mcp adr export/import [path] [dir]` | see [Architecture decisions](#architecture-decisions-adrs) below. |
+| `reposkein-mcp serve --http [path]` | **advanced, optional** — one shared server: MCP over Streamable HTTP + the viewer and `/api/*` in one process, bearer-token auth, read-only by default, re-indexing when the served checkout's HEAD moves. Not needed for normal use; stdio is the default transport. See [`REMOTE.md`](REMOTE.md). |
 
 ## Architecture decisions (ADRs)
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -75,6 +75,7 @@ Then ask your agent *"what calls this function?"* or *"what breaks if I change X
 - `reposkein-mcp index` — rebuild the committed graph after big changes.
 - `reposkein-mcp stats [--last | --session <id> | --all] [--json]` — session usage report: calls by tool, top queried nodes/files, ADRs/summaries written, session duration, and an *estimated* context-tokens-saved-vs-grep number. See [Session usage stats](#session-usage-stats) below.
 - `reposkein-mcp view [path]` — open the **constellation viewer**: a local, read-only, zero-infra web app (bound to `127.0.0.1`) that renders the committed `.reposkein` graph as an interactive 3D astronomy-style map. `--export <dir>` instead writes a self-contained static site (works from `file://` or any static host). See the [viewer section in the main README](https://github.com/reposkein/reposkein#visualize-the-graph--the-constellation-viewer), or **[try the live demo](https://reposkein.github.io/reposkein/)** (RepoSkein viewing its own graph).
+- `reposkein-mcp serve --http [path]` — **advanced, optional**: one shared server for agents that have no clone. Speaks MCP over Streamable HTTP and serves the viewer + `/api/*` from the same process, behind bearer-token auth, read-only by default, re-indexing when the served checkout's HEAD moves. Nothing binds a socket unless you run it; stdio remains the default transport. See [`docs/REMOTE.md`](https://github.com/reposkein/reposkein/blob/main/docs/REMOTE.md).
 
 ## How your agent uses it
 
@@ -170,6 +171,8 @@ a resolved repo. See `mcp/src/store/resolveRepoPath.ts` and
 | `REPOSKEIN_REPO_PATH` | pins the repository the server operates on — optional, see repo resolution above |
 | `REPOSKEIN_SESSION_ID` | override the session id used for `reposkein-mcp stats` logging (default: start-timestamp + pid) |
 | `REPOSKEIN_STORE` | `auto` (default) · `jsonl` (zero-infra) · `neo4j` |
+| `REPOSKEIN_AGENT` | names the writer in `summary_by` / `decided_by` and picks its `local/summaries-<agent>.jsonl` sidecar (default `agent`) |
+| `REPOSKEIN_SERVE_TOKENS` | `serve --http` only — `name:secret[:write]` entries, comma- or whitespace-separated. Required for that mode; see [`docs/REMOTE.md`](https://github.com/reposkein/reposkein/blob/main/docs/REMOTE.md) |
 | `REPOSKEIN_INDEXER_BIN` | override the `reposkein-indexer` binary path (unsupported platforms) |
 | `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD` | optional Neo4j backend (large graphs / Cypher at scale) |
 | `REPOSKEIN_EMBED_PROVIDER` | `none` (default) · `voyage` · `http` — see below |

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -6,67 +6,29 @@ import { runDoctor, resolveDoctorRepoPath } from "./cli/doctor.js";
 import { runAdr } from "./cli/adr.js";
 import { runView, runExport, parseViewArgs } from "./cli/view.js";
 import { runStats } from "./cli/stats.js";
-import { existsSync, realpathSync } from "node:fs";
-import { join } from "node:path";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { runServe, parseServeArgs } from "./serve/serve.js";
+import { realpathSync } from "node:fs";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
-import { Neo4jGraphStore } from "./store/Neo4jGraphStore.js";
-import { UnconfiguredStore } from "./store/UnconfiguredStore.js";
-import type { GraphStore } from "./store/GraphStore.js";
-import { JsonlGraphStore } from "./store/JsonlGraphStore.js";
-import { makeReadCypher } from "./tools/readCypher.js";
-import type { ToolResult } from "./tools/readCypher.js";
-import { makeGetContextProfile } from "./tools/getContextProfile.js";
-import { makeWriteSemanticSummary } from "./tools/writeSemanticSummary.js";
-import { makeInitCpgSkeleton, makeReindexFile } from "./tools/indexerTools.js";
-import { makeSemanticFind } from "./tools/semanticFind.js";
-import { makeTemporalContext } from "./tools/temporalContext.js";
-import { makeImpact } from "./tools/impact.js";
-import { makeRecordDecision } from "./tools/recordDecision.js";
-import { makeSetDecisionStatus } from "./tools/setDecisionStatus.js";
-import { makeReaffirmDecision } from "./tools/reaffirmDecision.js";
-import { makeListDecisions } from "./tools/listDecisions.js";
-import { makeGetDecision } from "./tools/getDecision.js";
 import { resolveRepoId } from "./store/repoId.js";
-import type { RepoResolution } from "./store/resolveRepoPath.js";
-import { RepoSession } from "./store/repoSession.js";
-import { makeCache } from "./store/repoContextCache.js";
-import { ensureGraph } from "./indexer/ensureGraph.js";
-import { ensureIndexerBinary, packageVersion } from "./indexer/fetchBinary.js";
-import { spawnIndexer } from "./indexer/runIndexer.js";
-import { SessionLogger, resolveSessionId } from "./store/sessionLog.js";
-import { createToolLogger } from "./store/instrumentTool.js";
+import { createMcpServer } from "./server/createMcpServer.js";
+import { packageVersion } from "./indexer/fetchBinary.js";
 
-/** Selects the store backend.
- *  REPOSKEIN_STORE = "jsonl" | "neo4j" | "auto" (default "auto").
- *  - auto: JSONL if <repoPath>/.reposkein/nodes.jsonl exists, else Neo4j if
- *    NEO4J_PASSWORD is set, else Unconfigured.
- *  - jsonl: JSONL if available, else Unconfigured.
- *  - neo4j: Neo4j if configured, else Unconfigured. */
-function buildStore(repoPath: string | undefined, repoId: string | undefined): GraphStore {
-  const mode = (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase();
-  const jsonlReady =
-    !!repoPath && !!repoId && existsSync(join(repoPath, ".reposkein", "nodes.jsonl"));
-
-  const neo4j = (): GraphStore => {
-    try {
-      return Neo4jGraphStore.fromEnv();
-    } catch {
-      return new UnconfiguredStore();
-    }
-  };
-
-  if (mode === "jsonl") {
-    return jsonlReady ? new JsonlGraphStore(repoPath!, repoId!) : new UnconfiguredStore();
-  }
-  if (mode === "neo4j") {
-    return neo4j();
-  }
-  // auto
-  if (jsonlReady) return new JsonlGraphStore(repoPath!, repoId!);
-  return neo4j();
-}
+/** Re-exported from `server/createMcpServer.ts`, where the tool registration
+ *  now lives (REP-17 extracted it so `serve --http` can build one server PER
+ *  CONNECTION). Kept here because these are this module's public surface. */
+export {
+  repoRequiredMessage,
+  repoUnindexedMessage,
+  getContextProfileInputSchema,
+  recordDecisionInputSchema,
+  setDecisionStatusInputSchema,
+  reaffirmDecisionInputSchema,
+  listDecisionsInputSchema,
+  getDecisionInputSchema,
+  createMcpServer,
+  buildStore,
+  WRITE_TOOLS,
+} from "./server/createMcpServer.js";
 
 const HELP_TEXT = `reposkein-mcp — deterministic code-graph MCP server
 
@@ -78,6 +40,7 @@ Usage:
   reposkein-mcp adr <sub> ...   decision-log utilities
   reposkein-mcp stats [path]    session usage report (calls, tokens saved vs grep)
   reposkein-mcp view [path]     open the constellation viewer (--export <dir> for a static site)
+  reposkein-mcp serve --http    ADVANCED, OPTIONAL: shared remote server — MCP over Streamable HTTP + the viewer/API in one process, bearer-token auth, read-only by default (see docs/REMOTE.md)
   reposkein-mcp --help          show this help
   reposkein-mcp --version       print the package version
 
@@ -92,464 +55,22 @@ Repo resolution (used by the server and by [path]-less CLI commands):
 
 Docs: https://github.com/reposkein/reposkein/tree/main/mcp#readme`;
 
-/** Structured, actionable message for repo-scoped tool calls when no repo
- *  resolved (see `resolveRepoPath`). Names the discovered candidates when
- *  resolution failed due to workspace-mode ambiguity, and points at
- *  `list_repos` / `select_repo` so the agent can pick one instead of
- *  abandoning the tools. */
-// Exported for the regression test below (repoRequiredMessage.test.ts) — it
-// must keep pointing agents at list_repos/select_repo, not just the env var.
-export function repoRequiredMessage(resolution: RepoResolution): string {
-  if (resolution.candidates && resolution.candidates.length > 0) {
-    return (
-      `Multiple RepoSkein repos were found under ${process.cwd()} and none is selected: ` +
-      resolution.candidates.join(", ") +
-      ". Call list_repos to see them, then select_repo with one of its `path` or `name` " +
-      "values (or set REPOSKEIN_REPO_PATH) to use this tool."
-    );
-  }
-  return (
-    "No RepoSkein repo found (checked the current directory, its ancestors, and its " +
-    "immediate subdirectories for .reposkein/). Run `reposkein-mcp init` in the repository " +
-    "you want to work with, call list_repos to check what was discovered, or set " +
-    "REPOSKEIN_REPO_PATH to its root."
-  );
-}
-
-// Exported for the regression test below (repoRequiredMessage.test.ts) — it
-// must name the found path and the fix (`reposkein-mcp index`), not repeat
-// the generic "no repo found" message: a repo WAS found here, it's just not
-// indexed yet (or, if `.reposkein/` isn't actually there, misconfigured).
-export function repoUnindexedMessage(repoPath: string): string {
-  if (existsSync(join(repoPath, ".reposkein"))) {
-    return (
-      `Found .reposkein/ at ${repoPath}, but it has no meta.json (not indexed yet). ` +
-      `Run \`reposkein-mcp index ${repoPath}\` (or the init_cpg_skeleton tool) to build it, ` +
-      "then retry this call."
-    );
-  }
-  return (
-    `${repoPath} has no .reposkein/ directory. Run \`reposkein-mcp init ${repoPath}\` there, ` +
-    "or point REPOSKEIN_REPO_PATH / select_repo at a repo that already has one."
-  );
-}
-
-// Exported for the regression test. `hops` MUST stay a bounded integer: a literal union
-// (z.union([z.literal(1), z.literal(2)])) serialises to JSON-Schema `anyOf:[{const:1},{const:2}]`,
-// which Gemini's tool-schema validator 400-rejects — and one bad tool declaration fails the
-// whole request, breaking every Gemini model whenever a reposkein tool is in the payload.
-export const getContextProfileInputSchema = {
-  node_id: z.string().optional(),
-  file_path: z.string().optional(),
-  name: z.string().optional(),
-  hops: z.number().int().min(1).max(2).optional(),
-  federated: z.boolean().optional(),
-};
-
-// Exported for the schema regression test (no anyOf/oneOf — see the hops note
-// above; z.enum serialises to a plain `enum`, which every provider accepts).
-export const recordDecisionInputSchema = {
-  title: z.string(),
-  context: z.string(),
-  decision: z.string(),
-  consequences: z.string().optional(),
-  alternatives: z.string().optional(),
-  status: z.enum(["proposed", "accepted"]).optional(),
-  anchor_node_ids: z.array(z.string()).max(20).optional(),
-  anchor_paths: z.array(z.string()).max(20).optional(),
-  supersedes: z.array(z.string()).max(5).optional(),
-};
-
-export const setDecisionStatusInputSchema = {
-  decision_id: z.string(),
-  status: z.enum(["accepted", "rejected", "deprecated"]),
-};
-
-export const reaffirmDecisionInputSchema = {
-  decision_id: z.string(),
-};
-
-export const listDecisionsInputSchema = {
-  status: z.enum(["proposed", "accepted", "rejected", "deprecated", "superseded"]).optional(),
-  anchor: z.string().optional(),
-  q: z.string().optional(),
-  limit: z.number().int().min(1).max(50).optional(),
-};
-
-export const getDecisionInputSchema = {
-  decision_id: z.string(),
-};
-
+/** Starts the MCP server on the stdio transport — the default and only
+ *  transport for a single developer. One `createMcpServer` per process, with
+ *  full write capability and the historical REPOSKEIN_AGENT identity
+ *  fallback: unchanged by REP-17. */
 export async function main(): Promise<void> {
-  // Zero-config repo resolution: explicit arg (n/a here) > REPOSKEIN_REPO_PATH >
-  // walk-up (nearest ancestor with .reposkein/) > walk-down (workspace mode).
-  // See store/resolveRepoPath.ts for the full precedence + ambiguity rules.
-  // Session-scoped resolution: `select_repo` (below) can override this for
-  // the rest of the connection. Precedence: select_repo > REPOSKEIN_REPO_PATH
-  // > walk-up > walk-down. See store/repoSession.ts.
-  const session = new RepoSession({
+  const server = createMcpServer({
     cwd: process.cwd(),
     envRepoPath: process.env.REPOSKEIN_REPO_PATH,
   });
-
-  // REP-20 session usage stats: one instrumentation point for every tool
-  // call, wrapping the handler passed to `server.registerTool` below (each
-  // call site does `withLog("tool_name", async (args) => {...})` — logging
-  // logic itself lives only in instrumentTool.ts/sessionLog.ts, never in a
-  // handler body). Session id = this process's lifetime (start-timestamp +
-  // pid), overridable via REPOSKEIN_SESSION_ID for reproducible tests/tooling.
-  // `cachedResolve` (used by `resolveActiveRepo` below, and by the two
-  // handlers that gate on repoPath alone) memoizes `session.resolve()` per
-  // call, so the handler's own resolution and the logger's are the same
-  // filesystem walk, not two — see instrumentTool.ts for why and how.
-  const sessionLogger = new SessionLogger(resolveSessionId(process.env));
-  const { withLog, cachedResolve } = createToolLogger(session, sessionLogger);
-
-  // Per-repoPath {repoId, store} cache. Constructing a JsonlGraphStore is
-  // cheap (it lazily loads/re-parses its graph per call, keyed by file
-  // mtime) but re-running resolveRepoId/ensureGraph/buildStore on every tool
-  // call would still be wasted work for the common single-repo case, and
-  // rebuilding the store object would also throw away that per-instance
-  // mtime cache — so one context is built per repoPath and reused, letting
-  // `select_repo` switch back and forth cheaply too.
-  //
-  // Only a SUCCESSFUL resolution (repoId defined) is cached — see
-  // store/repoContextCache.ts. A repo whose `.reposkein/` exists but isn't
-  // indexed yet (no meta.json) is a transient, fixable state: an agent might
-  // run `reposkein-mcp index` (or init_cpg_skeleton) out-of-band and expect
-  // the very next call in this same session to pick it up. Caching that
-  // failure would freeze the session on a stale "not found" forever,
-  // undercutting select_repo's whole no-restart-needed point.
-  const getRepoContext = makeCache(
-    async (path: string): Promise<{ repoId: string | undefined; store: GraphStore }> => {
-      const id = resolveRepoId(path, process.env.REPOSKEIN_REPO_ID);
-      // Build the graph if the repo has none yet. Derived JSONL is
-      // git-ignored, so a fresh clone arrives without it; without this the
-      // first query on a newly selected repo would fail on one that indexes
-      // fine in seconds.
-      await ensureGraph(path, id, {
-        mode: (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase(),
-        neo4jConfigured: !!process.env.NEO4J_PASSWORD,
-      });
-      return { repoId: id, store: buildStore(path, id) };
-    },
-    (ctx) => !!ctx.repoId
-  );
-
-  type ActiveRepo =
-    | { ok: true; repoPath: string; repoId: string; store: GraphStore }
-    | { ok: false; message: string };
-  /** Resolves the session's current repo for a repo-scoped tool call.
-   *  Re-evaluated on every call (not once at startup) so `select_repo`
-   *  actually takes effect for calls made after it. Uses `cachedResolve`
-   *  (not `session.resolve()` directly) so this and the REP-20 logging
-   *  wrapper share one filesystem walk per call. */
-  async function resolveActiveRepo(): Promise<ActiveRepo> {
-    const resolution = cachedResolve();
-    if (!resolution.repoPath) return { ok: false, message: repoRequiredMessage(resolution) };
-    const ctx = await getRepoContext(resolution.repoPath);
-    // Distinct from repoRequiredMessage: a repo path WAS resolved here — the
-    // problem is it isn't indexed (or doesn't actually have .reposkein/),
-    // not that none could be found at all. See repoUnindexedMessage.
-    if (!ctx.repoId) return { ok: false, message: repoUnindexedMessage(resolution.repoPath) };
-    return { ok: true, repoPath: resolution.repoPath, repoId: ctx.repoId, store: ctx.store };
-  }
-  const errResult = (message: string): ToolResult => ({ content: [{ type: "text", text: message }], isError: true });
-
-  const server = new McpServer({ name: "@reposkein/mcp", version: "0.0.0" });
-
-  server.registerTool(
-    "list_repos",
-    {
-      title: "List discovered repos",
-      description:
-        "Enumerate the RepoSkein repos discovered from the server's working directory (walk-up: the nearest ancestor with .reposkein/; walk-down/workspace mode: subdirectories, when no ancestor has one). Single-repo setups return exactly one entry. In workspace mode (multiple sibling repos, no default selected), use this to see the candidates, then `select_repo` one before calling other repo-scoped tools.",
-      inputSchema: {},
-    },
-    withLog("list_repos", async () => {
-      const repos = session.list();
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              mode: repos.length > 1 ? "workspace" : "single",
-              repos,
-            }),
-          },
-        ],
-      };
-    })
-  );
-
-  server.registerTool(
-    "select_repo",
-    {
-      title: "Select the active repo",
-      description:
-        "Set the session-active repo for all subsequent repo-scoped tool calls (get_context_profile, semantic_find, impact, decisions, etc.) — the fix for workspace-mode ambiguity (list_repos returned more than one candidate). Pass a `repo` value from list_repos: its `path` or its `name`. Overrides REPOSKEIN_REPO_PATH and any earlier select_repo call for the rest of this connection; stays in effect until called again.",
-      inputSchema: { repo: z.string() },
-    },
-    withLog("select_repo", async (args) => {
-      const result = session.select(args.repo);
-      if (!result.ok) return errResult(result.error);
-      return { content: [{ type: "text", text: JSON.stringify({ ok: true, selected: result.repo }) }] };
-    })
-  );
-
-  server.registerTool(
-    "read_cypher",
-    {
-      title: "Read-only Cypher query",
-      description:
-        "Run a read-only Cypher query against the RepoSkein graph. Writes are rejected. Filter by `n.repo_id = $repo_id` (or `n.repo_id IN $repo_ids`); pass `federated: true` to span this repo and its nested repos via `$repo_ids`. Results are capped (200 rows / 64KB).",
-      inputSchema: {
-        query: z.string(),
-        params: z.record(z.string(), z.unknown()).optional(),
-        federated: z.boolean().optional(),
-      },
-    },
-    withLog("read_cypher", async (args) => {
-      // read_cypher tolerates an unresolved repo (falls back to whatever
-      // buildStore(undefined, undefined) picks — Neo4j if configured, else
-      // UnconfiguredStore — matching its pre-existing, non-gated behavior).
-      const resolution = cachedResolve();
-      const ctx = resolution.repoPath
-        ? await getRepoContext(resolution.repoPath)
-        : { repoId: undefined, store: buildStore(undefined, undefined) };
-      return makeReadCypher(ctx.store, ctx.repoId)(args);
-    })
-  );
-
-  server.registerTool(
-    "get_context_profile",
-    {
-      title: "Get context profile",
-      description:
-        "Resolve a function/class (by node_id, file_path+name, or name) and return its caller/callee neighborhood (hops 1-2) with inlined prose and an enrichment_needed list. Never guesses — returns candidates if a name is ambiguous. Pass federated:true to resolve and traverse across nested repos.",
-      inputSchema: getContextProfileInputSchema,
-    },
-    withLog("get_context_profile", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      return makeGetContextProfile(active.store, active.repoId, active.repoPath)(args);
-    })
-  );
-
-  server.registerTool(
-    "write_semantic_summary",
-    {
-      title: "Write semantic summary",
-      description:
-        "Attach a 1-3 sentence plain-text business-logic summary to a node, stamped with its current content hash for staleness tracking. Plain text only (no markdown links or code fences), max 1000 chars.",
-      inputSchema: {
-        node_id: z.string(),
-        summary: z.string(),
-        model: z.string().optional(),
-      },
-    },
-    withLog("write_semantic_summary", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      return makeWriteSemanticSummary(active.store, active.repoId)(args);
-    })
-  );
-
-  server.registerTool(
-    "init_cpg_skeleton",
-    {
-      title: "Build the code graph",
-      description:
-        "Index the repository with the native indexer and load it into the graph database. Run once on a fresh repo (or to rebuild). Returns node/edge counts.",
-      inputSchema: {
-        path: z.string().optional(),
-        full: z.boolean().optional(),
-      },
-    },
-    withLog("init_cpg_skeleton", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      // repoPath is threaded through explicitly (see indexerTools.ts) so this
-      // always targets the resolved active repo, not a cwd/env-based guess —
-      // an explicit args.path still wins inside makeInitCpgSkeleton itself.
-      return makeInitCpgSkeleton(active.repoId, active.repoPath)(args);
-    })
-  );
-
-  server.registerTool(
-    "reindex_file",
-    {
-      title: "Reindex after editing",
-      description:
-        "Refresh the graph after editing a source file (pass its path). v1 performs a full reindex.",
-      inputSchema: { path: z.string() },
-    },
-    withLog("reindex_file", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      // repoPath threaded explicitly — reindex_file has no path override of
-      // its own, so without this it would silently reindex whatever
-      // REPOSKEIN_REPO_PATH/cwd points at instead of the selected repo.
-      return makeReindexFile(active.repoId, active.repoPath)(args);
-    })
-  );
-
-  server.registerTool(
-    "semantic_find",
-    {
-      title: "Find code by meaning",
-      description:
-        "Rank functions/classes by a lexical match over their qualified names, signatures, and agent-written summaries — the entry point to seed get_context_profile when you don't know where to start. Returns ranked node_ids. Architecture decisions are part of the corpus: \"why\" questions (why don't we X, what did we decide about Y) surface Decision rows — follow up with get_decision. federated:true spans nested repos.",
-      inputSchema: {
-        query: z.string(),
-        limit: z.number().int().min(1).max(25).optional(),
-        kind: z.enum(["Function", "Class", "Interface", "Enum", "Decision"]).optional(),
-        federated: z.boolean().optional(),
-      },
-    },
-    withLog("semantic_find", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      return makeSemanticFind(active.store, active.repoId, active.repoPath, undefined, { decisions: true })(args);
-    })
-  );
-
-  server.registerTool(
-    "get_temporal_context",
-    {
-      title: "Git temporal context",
-      description:
-        "Git-derived signals for a file: how often/recently it changes, who owns it, and which files most often change together with it (co-change) — answers \"what else should I touch?\". Advisory (derived from git history, not the committed graph). Before a cross-cutting change, use this to find files that historically change together.",
-      inputSchema: { path: z.string() },
-    },
-    withLog("get_temporal_context", async (args) => {
-      // Gated on repoPath only (not repoId/store) — it reads from .git directly.
-      const resolution = cachedResolve();
-      if (!resolution.repoPath) return errResult(repoRequiredMessage(resolution));
-      return makeTemporalContext(resolution.repoPath)(args);
-    })
-  );
-
-  server.registerTool(
-    "impact",
-    {
-      title: "Change impact + covering tests",
-      description:
-        "Given a function/class, return its transitive callers (what could break if you change it) split into impacted code vs the tests that cover it (what to run). Resolves by node_id, file_path+name, or name. federated:true spans nested repos.",
-      inputSchema: {
-        node_id: z.string().optional(),
-        file_path: z.string().optional(),
-        name: z.string().optional(),
-        depth: z.number().int().min(1).max(5).optional(),
-        federated: z.boolean().optional(),
-      },
-    },
-    withLog("impact", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      return makeImpact(active.store, active.repoId, active.repoPath)(args);
-    })
-  );
-
-  // Decision tools are gated on repoPath + repoId: records live as committed
-  // files under <repoPath>/.reposkein/decisions/, the graph is used only for
-  // anchor resolution and hash stamping (Phase 1 — no GraphStore changes).
-  // `resolveActiveRepo` already requires both, so it doubles as the gate.
-  server.registerTool(
-    "record_decision",
-    {
-      title: "Record an architecture decision",
-      description:
-        "Record an Architecture Decision Record (ADR): why a significant design choice was made, anchored to the graph nodes and paths it governs. Use for decisions that affect structure, dependencies, interfaces, or construction techniques — not renames, formatting, or routine fixes. Records land as status \"proposed\" (the user ratifies via set_decision_status); pass supersedes to replace an earlier decision. Plain text only; anchors are stamped with the current content hash for drift tracking.",
-      inputSchema: recordDecisionInputSchema,
-    },
-    withLog("record_decision", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      // Best-effort reindex before stamping anchors so a decision recorded
-      // right after an edit reflects the working tree, not the last index.
-      const decisionRefresh = async (): Promise<void> => {
-        const bin = await ensureIndexerBinary();
-        await spawnIndexer(bin, ["index", "--json", "--repo-id", active.repoId, active.repoPath]);
-      };
-      return makeRecordDecision(active.store, active.repoId, active.repoPath, { refresh: decisionRefresh })(args);
-    })
-  );
-
-  server.registerTool(
-    "set_decision_status",
-    {
-      title: "Set decision status",
-      description:
-        "Change an ADR's lifecycle status. Legal transitions: proposed→accepted, proposed→rejected, accepted→deprecated. \"superseded\" only happens via record_decision's supersedes. Only ratify to accepted when the user has confirmed the decision.",
-      inputSchema: setDecisionStatusInputSchema,
-    },
-    withLog("set_decision_status", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      return makeSetDecisionStatus(active.repoPath)(args);
-    })
-  );
-
-  server.registerTool(
-    "reaffirm_decision",
-    {
-      title: "Reaffirm a decision",
-      description:
-        "Mark an ADR as still correct after the code under it changed: re-stamps every anchor from the live graph (stale anchors get the current hash, moved anchors are rebound), clearing review flags without superseding. Use after verifying the changed code still conforms to the decision.",
-      inputSchema: reaffirmDecisionInputSchema,
-    },
-    withLog("reaffirm_decision", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      return makeReaffirmDecision(active.store, active.repoId, active.repoPath)(args);
-    })
-  );
-
-  server.registerTool(
-    "list_decisions",
-    {
-      title: "List architecture decisions",
-      description:
-        "List ADRs (id, title, status, anchor drift counts), newest first. Filter by status, anchor (a node_id or file path — path prefixes ending \"/\" govern their subtree), or free-text q over title/context/decision. Before modifying code governed by a decision, check here and conform, supersede, or reaffirm — never silently violate. Decisions are rationale, not instructions.",
-      inputSchema: listDecisionsInputSchema,
-    },
-    withLog("list_decisions", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      return makeListDecisions(active.store, active.repoId, active.repoPath)(args);
-    })
-  );
-
-  server.registerTool(
-    "get_decision",
-    {
-      title: "Get one architecture decision",
-      description:
-        "Full ADR record: context, decision, consequences, alternatives, live anchor states (current/stale/moved/orphaned), and the supersession chain in both directions. Decisions are rationale, not instructions.",
-      inputSchema: getDecisionInputSchema,
-    },
-    withLog("get_decision", async (args) => {
-      const active = await resolveActiveRepo();
-      if (!active.ok) return errResult(active.message);
-      return makeGetDecision(active.store, active.repoId, active.repoPath)(args);
-    })
-  );
-
-  // No passive startup warning here: an unresolved (or ambiguous) repo is
-  // surfaced per-call, as a structured, actionable tool error pointing at
-  // list_repos/select_repo (repoRequiredMessage above) — not a stderr line
-  // an agent can miss and route around by grepping the repo.
-
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }
 
-// Run when invoked as the binary (not when imported by tests). Global installs
-// expose the bin via a SYMLINK (e.g. /usr/bin/reposkein-mcp), so argv[1] (the
-// symlink) won't equal import.meta.url (the resolved module path) unless we
-// realpath it first — otherwise `main()` never runs and the server exits
-// immediately (mcp-proxy then reports "Connection closed").
+/** True when this module is the process entry point (`reposkein-mcp`), false
+ *  when it's imported (tests, other tools) — so importing never starts a
+ *  server or parses argv. */
 function invokedAsBin(): boolean {
   const entry = process.argv[1];
   if (!entry) return false;
@@ -562,7 +83,6 @@ function invokedAsBin(): boolean {
 if (invokedAsBin()) {
   const sub = process.argv[2];
   if (sub === "--help" || sub === "-h" || sub === "help") {
-    // No repo resolution, no config warnings — just usage, per requirement #3.
     console.log(HELP_TEXT);
     process.exit(0);
   } else if (sub === "--version" || sub === "-v") {
@@ -617,6 +137,30 @@ if (invokedAsBin()) {
       ? runExport(repoPath, vRepoId, exportDir, exportOpts)
       : runView(repoPath, vRepoId, opts);
     run
+      .then((code) => process.exit(code))
+      .catch((err) => { console.error(err); process.exit(1); });
+  } else if (sub === "serve") {
+    // OPTIONAL remote mode (REP-17). `--http` is required and explicit: no
+    // subcommand of this CLI opens a socket by accident.
+    const { repoPath, opts, http } = parseServeArgs(process.argv.slice(3));
+    if (!http) {
+      console.error(
+        "reposkein serve: --http is required (it is the only transport this subcommand serves).\n" +
+          "  Usage: reposkein-mcp serve --http [path] [--port N] [--host H] [--watch-interval SECONDS]\n" +
+          "  This is an advanced, optional deployment — see docs/REMOTE.md. For normal use, run\n" +
+          "  `reposkein-mcp` with no subcommand (stdio)."
+      );
+      process.exit(1);
+    }
+    const serveRepoId = resolveRepoId(repoPath, process.env.REPOSKEIN_REPO_ID);
+    if (!serveRepoId) {
+      console.error(
+        `reposkein serve: could not resolve a repo id for ${repoPath} (no .reposkein/meta.json, no REPOSKEIN_REPO_ID).\n` +
+          "  Run `reposkein-mcp init` there first."
+      );
+      process.exit(1);
+    }
+    runServe(repoPath, serveRepoId, opts)
       .then((code) => process.exit(code))
       .catch((err) => { console.error(err); process.exit(1); });
   } else {

--- a/mcp/src/indexer/indexLock.ts
+++ b/mcp/src/indexer/indexLock.ts
@@ -1,0 +1,70 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** Process-wide mutual exclusion for indexer invocations.
+ *
+ *  Every `reposkein-indexer` run writes into the served checkout's
+ *  `.reposkein/` — `nodes.jsonl`, `edges.jsonl`, the committed summary shards,
+ *  the pending-drift delta. Two runs at once on one checkout interleave those
+ *  writes, and the loser's output is whatever the filesystem happened to
+ *  order last. That was survivable while the server was one stdio process
+ *  serving one agent: index runs were driven by one caller, one at a time.
+ *
+ *  `serve --http` (REP-17) removes that accident. A write-capable tool call
+ *  (`reindex_file`, `init_cpg_skeleton`, `record_decision`'s pre-stamp
+ *  refresh) can now land while the HEAD watcher is mid-reindex, from a
+ *  different connection, with no shared call stack to serialize them. So the
+ *  serialization has to be explicit and it has to be somewhere no future
+ *  caller can forget it — which is inside `spawnIndexer` itself, the single
+ *  choke point every invocation passes through.
+ *
+ *  Reentrancy-safe: a lock holder that (now or later) reaches `spawnIndexer`
+ *  again runs straight through instead of deadlocking the process against
+ *  itself. FIFO: waiters run in arrival order, so a queued tool call can't be
+ *  starved by a fast-polling watcher. */
+
+const reentrant = new AsyncLocalStorage<true>();
+
+/** Tail of the FIFO queue: resolves when every already-queued holder is done. */
+let tail: Promise<void> = Promise.resolve();
+/** Holders plus waiters. Drives `isIndexLockHeld` (see its doc comment). */
+let outstanding = 0;
+
+/** True when an indexer run is in progress OR queued.
+ *
+ *  Deliberately counts waiters, not just the active holder: the HEAD watcher
+ *  uses this to SKIP a tick rather than queue behind a tool call, and a tick
+ *  that queued would fire a redundant index the moment the tool's run
+ *  finished — for a HEAD the tool's own run has by then already indexed. */
+export function isIndexLockHeld(): boolean {
+  return outstanding > 0;
+}
+
+/** Runs `fn` with exclusive access to the indexer. */
+export async function withIndexLock<T>(fn: () => Promise<T>): Promise<T> {
+  // Already ours (a nested spawn inside a lock-holding operation): proceed.
+  if (reentrant.getStore()) return fn();
+
+  outstanding++;
+  let release!: () => void;
+  const mine = new Promise<void>((r) => {
+    release = r;
+  });
+  const prior = tail;
+  // A rejection can't come from `mine` (release never throws), but chain
+  // defensively: a broken tail would wedge every future acquisition.
+  tail = prior.then(() => mine).catch(() => undefined);
+  try {
+    await prior;
+    return await reentrant.run(true, fn);
+  } finally {
+    outstanding--;
+    release();
+  }
+}
+
+/** Test-only: drains the queue so one suite's leftovers can't wedge the next.
+ *  Never call this from production code — it does not cancel a running
+ *  holder, it only waits for the queue to empty. */
+export async function drainIndexLock(): Promise<void> {
+  await tail;
+}

--- a/mcp/src/indexer/runIndexer.ts
+++ b/mcp/src/indexer/runIndexer.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { withIndexLock } from "./indexLock.js";
 
 const ALLOWED_KEYS = new Set(["PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "NEO4J_URI", "NEO4J_USER", "NEO4J_PASSWORD"]);
 
@@ -32,7 +33,19 @@ export interface SpawnResult {
 // env/cwd-based resolver here — see mcp/src/store/resolveRepoPath.ts for the
 // one central resolution algorithm.
 
+/** Runs the indexer binary, capped and timed out.
+ *
+ *  Serialized process-wide by `withIndexLock`: every invocation writes into
+ *  the target checkout's `.reposkein/`, and since REP-17 two callers (a
+ *  write-capable tool call on one connection, the HEAD watcher on another) can
+ *  arrive concurrently with no shared call stack to order them. The lock lives
+ *  HERE rather than at each call site so a new call site cannot forget it —
+ *  see `indexLock.ts`. */
 export function spawnIndexer(bin: string, args: string[]): Promise<SpawnResult> {
+  return withIndexLock(() => spawnIndexerUnlocked(bin, args));
+}
+
+function spawnIndexerUnlocked(bin: string, args: string[]): Promise<SpawnResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(bin, args, { env: buildChildEnv() });
     let stdout = "";

--- a/mcp/src/serve/serve.ts
+++ b/mcp/src/serve/serve.ts
@@ -409,6 +409,14 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
     }
     // Reserved synchronously, in the same tick as the check above.
     reservedSlots++;
+    // Set by `onsessioninitialized` the moment the session is registered with
+    // `inFlight: 1` (this request). Held out here, not read back off the
+    // transport, so the `finally` can release the count on EVERY exit path.
+    // If anything after registration throws — the SDK `await`s our callback
+    // and does not guard it, and the response write can fail — an inline
+    // decrement is skipped, and a session stuck at `inFlight: 1` is one the
+    // reaper will never touch: a slot leaked until restart.
+    let registeredId: string | undefined;
 
     try {
       // A NEW connection: its own McpServer, its own RepoSession. Nothing in
@@ -432,6 +440,7 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
         // instant) on a long-running shared process.
         enableJsonResponse: true,
         onsessioninitialized: (id: string) => {
+          registeredId = id;
           sessions.set(id, {
             transport,
             server,
@@ -455,12 +464,22 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
       };
       await server.connect(transport);
       await transport.handleRequest(req, res, body.value);
-      const id = transport.sessionId;
-      if (id) {
-        const created = sessions.get(id);
+    } finally {
+      // Mirrors the existing-session branch: this request's own `inFlight`
+      // claim is released HERE, not inline after `handleRequest`, so no exit
+      // path can skip it.
+      //
+      // Defense in depth as of SDK 1.30: the Node wrapper runs the transport
+      // inside `@hono/node-server`'s request listener, which catches handler
+      // errors and answers 500 itself — so a throw after registration does not
+      // currently reject `handleRequest`. That is a library implementation
+      // detail we don't control, and it is the only thing that was keeping an
+      // inline decrement correct. Structurally, nothing may sit between the
+      // request completing and the claim being released.
+      if (registeredId !== undefined) {
+        const created = sessions.get(registeredId);
         if (created) created.inFlight--;
       }
-    } finally {
       reservedSlots--;
     }
   }

--- a/mcp/src/serve/serve.ts
+++ b/mcp/src/serve/serve.ts
@@ -1,14 +1,15 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { makeViewHandler, vizDistDir } from "../cli/view.js";
-import { createMcpServer } from "../server/createMcpServer.js";
+import { createMcpServer, type CreateMcpServerOptions } from "../server/createMcpServer.js";
 import { agentSlug } from "../store/sidecar.js";
-import { defaultSessionId } from "../store/sessionLog.js";
+import { resolveSessionId } from "../store/sessionLog.js";
 import {
   bearerFromAuthHeader,
   loadServeTokens,
@@ -33,6 +34,16 @@ const MAX_BODY_BYTES = 4 * 1024 * 1024;
  *  the process allocate servers without bound; an operator hitting this has a
  *  problem worth an error, not silent growth. */
 const MAX_SESSIONS = 64;
+
+/** How long a session may sit untouched before it is reaped.
+ *
+ *  A crashed or network-partitioned client never sends the DELETE that closes
+ *  its session, so without this every such client permanently consumes one of
+ *  MAX_SESSIONS — and a long-lived server eventually wedges at the cap with
+ *  nothing but corpses. Five minutes is far longer than any tool call and far
+ *  shorter than a working day, so a live-but-idle agent that comes back gets a
+ *  clean `404 session_not_found` and re-initializes. */
+const SESSION_IDLE_MS = 5 * 60 * 1000;
 
 export interface ServeOptions {
   port: number;
@@ -87,6 +98,15 @@ interface McpSession {
    *  different token presenting a stolen session id gets 403, so a read-only
    *  credential can never inherit a write-capable session. */
   tokenName: string;
+  /** `now()` at the START of the most recent request on this session.
+   *  Stamped at start, not completion, so a request that outlives the idle
+   *  window is protected by `inFlight` rather than by a moving timestamp —
+   *  the two guards stay independent and each one is testable alone. */
+  lastSeen: number;
+  /** Requests currently executing on this session. A session is NEVER reaped
+   *  while this is above zero: killing a session mid-tool-call would drop the
+   *  response on the floor and leave the caller waiting forever. */
+  inFlight: number;
 }
 
 export interface CreateServeAppOptions {
@@ -97,6 +117,15 @@ export interface CreateServeAppOptions {
   /** Test seam: replaces `makeViewHandler` (which reads the repo's JSONL and
    *  shells out to git at construction time). */
   viewHandlerFactory?: (repoPath: string, repoId: string) => NodeHandler;
+  /** Test seam: passed through to every per-connection `createMcpServer`. */
+  ensureGraph?: CreateMcpServerOptions["ensureGraph"];
+  /** Concurrent-session cap. Defaults to `MAX_SESSIONS` (64); lowered in
+   *  tests so the cap and the reaper-then-retry path are cheap to exercise. */
+  maxSessions?: number;
+  /** Idle-session reap threshold. Defaults to `SESSION_IDLE_MS` (5 min). */
+  idleMs?: number;
+  /** Clock. Injectable so the reaper can be tested without waiting minutes. */
+  now?: () => number;
 }
 
 export interface ServeApp {
@@ -107,6 +136,11 @@ export interface ServeApp {
    *  watcher's `onReindexed` hook, and it is why the MCP tools and the viewer
    *  cannot drift apart: they are refreshed by the same event. */
   refresh: () => void;
+  /** Closes every session idle past `idleMs` with no request in flight, and
+   *  returns how many it closed. Called automatically before each new-session
+   *  attempt (so a server wedged at the cap by dead clients frees itself on
+   *  the next connect); exposed for tests. */
+  sweepIdleSessions: () => number;
   close: () => Promise<void>;
   sessionCount: () => number;
 }
@@ -121,23 +155,46 @@ function sendJson(res: ServerResponse, status: number, body: unknown, headers: R
   res.end(text);
 }
 
+interface BodyOk {
+  ok: true;
+  /** `undefined` for an empty body — the caller decides whether that's legal. */
+  value: unknown;
+}
+interface BodyErr {
+  ok: false;
+  error: string;
+  /** True when the cap tripped: the caller must answer BEFORE destroying the
+   *  request, or the client gets a socket reset instead of the 400. */
+  oversize?: boolean;
+}
+
 /** Reads a request body as JSON, capped. Resolves `{ ok: false }` on a bad
- *  parse or an oversized body — never throws, never buffers past the cap. */
-function readJsonBody(req: IncomingMessage): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
-  return new Promise((resolve) => {
+ *  parse or an oversized body — never throws, never buffers past the cap.
+ *
+ *  Deliberately does NOT destroy the request itself: on oversize it stops
+ *  accumulating and resolves, leaving the caller to write its 400 first and
+ *  destroy afterwards. Destroying here raced the response and turned a clean
+ *  "body too large" into an unexplained connection reset. */
+function readJsonBody(req: IncomingMessage): Promise<BodyOk | BodyErr> {
+  return new Promise((resolvePromise) => {
     const chunks: Buffer[] = [];
     let size = 0;
     let settled = false;
-    const finish = (r: { ok: true; value: unknown } | { ok: false; error: string }): void => {
+    const finish = (r: BodyOk | BodyErr): void => {
       if (settled) return;
       settled = true;
-      resolve(r);
+      resolvePromise(r);
     };
     req.on("data", (chunk: Buffer) => {
+      if (settled) return; // over cap already; drain without buffering
       size += chunk.length;
       if (size > MAX_BODY_BYTES) {
-        finish({ ok: false, error: `request body exceeds ${MAX_BODY_BYTES} bytes` });
-        req.destroy();
+        chunks.length = 0;
+        finish({
+          ok: false,
+          error: `request body exceeds ${MAX_BODY_BYTES} bytes`,
+          oversize: true,
+        });
         return;
       }
       chunks.push(chunk);
@@ -188,8 +245,38 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
   const log = opts.log ?? ((m: string) => void process.stderr.write(`${m}\n`));
   const factory = opts.viewHandlerFactory ?? makeViewHandler;
   const repoPath = resolve(opts.repoPath);
+  const maxSessions = opts.maxSessions ?? MAX_SESSIONS;
+  const idleMs = opts.idleMs ?? SESSION_IDLE_MS;
+  const now = opts.now ?? Date.now;
+  // One session-log id per PROCESS (honoring REPOSKEIN_SESSION_ID), suffixed
+  // per token below. Computed once here rather than per connection: a
+  // reconnecting agent should append to the same file it was writing before,
+  // and `reposkein-mcp stats` groups by that id.
+  const logIdBase = resolveSessionId(process.env);
   let viewHandler = factory(repoPath, opts.repoId);
   const sessions = new Map<string, McpSession>();
+  // Slots claimed by an in-progress `initialize` that has not yet registered
+  // its session. The cap check and this increment are one synchronous pair,
+  // which is what closes the check-then-set race: without it, N concurrent
+  // initializes all saw `sessions.size` from before any of them had connected
+  // and every one of them was admitted.
+  let reservedSlots = 0;
+
+  /** Closes idle, quiescent sessions. See `ServeApp.sweepIdleSessions`. */
+  function sweepIdleSessions(): number {
+    const cutoff = now() - idleMs;
+    let closed = 0;
+    for (const [id, s] of [...sessions]) {
+      if (s.inFlight > 0) continue; // never kill a live request
+      if (s.lastSeen > cutoff) continue;
+      sessions.delete(id);
+      closed++;
+      log(`reposkein serve: reaped idle mcp session for "${s.tokenName}"`);
+      void s.transport.close().catch(() => undefined);
+      void s.server.close().catch(() => undefined);
+    }
+    return closed;
+  }
 
   const unauthorized = (res: ServerResponse, detail: string): void =>
     sendJson(
@@ -216,6 +303,28 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
   }
 
   async function handleMcp(req: IncomingMessage, res: ServerResponse, token: ServeToken): Promise<void> {
+    // No standalone notification stream. This server never sends anything the
+    // client didn't ask for (every tool is request/response, `enableJsonResponse`
+    // is on), so a GET would open a socket that stays open for the connection's
+    // whole life and produces nothing. Worse, it never completes — which meant
+    // it pinned `inFlight` above zero and made the idle reaper a no-op for any
+    // client that opened one. The spec allows 405 here; clients treat the
+    // stream as optional and carry on.
+    if (req.method === "GET") {
+      sendJson(
+        res,
+        405,
+        {
+          error: "sse_stream_not_supported",
+          detail:
+            "This server answers MCP over POST only (JSON responses, no server-initiated " +
+            "notifications). Use POST for requests and DELETE to end a session.",
+        },
+        { Allow: "POST, DELETE" }
+      );
+      return;
+    }
+
     const rawSessionId = req.headers["mcp-session-id"];
     const sessionId = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
 
@@ -225,8 +334,8 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
         sendJson(res, 404, {
           error: "session_not_found",
           detail:
-            "This Mcp-Session-Id is unknown (expired, or the server restarted). " +
-            "Re-run initialize to open a new session.",
+            "This Mcp-Session-Id is unknown (expired after 5 minutes idle, closed, or the " +
+            "server restarted). Re-run initialize to open a new session.",
         });
         return;
       }
@@ -239,20 +348,37 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
         });
         return;
       }
-      const body =
-        req.method === "POST" ? await readJsonBody(req) : { ok: true as const, value: undefined };
-      if (!body.ok) {
-        sendJson(res, 400, { error: "bad_request", detail: body.error });
-        return;
+      // Claim the session for the duration of this request: `lastSeen` keeps
+      // the reaper away from an active client, `inFlight` keeps it away from
+      // an active REQUEST even if that request outlives the idle window.
+      existing.lastSeen = now();
+      existing.inFlight++;
+      try {
+        const body =
+          req.method === "POST" ? await readJsonBody(req) : { ok: true as const, value: undefined };
+        if (!body.ok) {
+          sendJson(res, 400, { error: "bad_request", detail: body.error });
+          if (body.oversize) req.destroy();
+          return;
+        }
+        if (req.method === "POST" && body.value === undefined) {
+          sendJson(res, 400, {
+            error: "bad_request",
+            detail: "Empty POST body. Send a JSON-RPC request, notification, or batch.",
+          });
+          return;
+        }
+        await existing.transport.handleRequest(req, res, body.value);
+      } finally {
+        existing.inFlight--;
       }
-      await existing.transport.handleRequest(req, res, body.value);
       return;
     }
 
     if (req.method !== "POST") {
       sendJson(res, 400, {
         error: "bad_request",
-        detail: "Mcp-Session-Id is required for GET and DELETE on /mcp.",
+        detail: "Mcp-Session-Id is required for DELETE on /mcp.",
       });
       return;
     }
@@ -260,6 +386,7 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
     const body = await readJsonBody(req);
     if (!body.ok) {
       sendJson(res, 400, { error: "bad_request", detail: body.error });
+      if (body.oversize) req.destroy();
       return;
     }
     if (!isInitializeRequest(body.value)) {
@@ -271,50 +398,71 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
       });
       return;
     }
-    if (sessions.size >= MAX_SESSIONS) {
+    // Free anything the network already abandoned before deciding we're full.
+    sweepIdleSessions();
+    if (sessions.size + reservedSlots >= maxSessions) {
       sendJson(res, 503, {
         error: "too_many_sessions",
-        detail: `This server holds the maximum of ${MAX_SESSIONS} MCP sessions. Retry later.`,
+        detail: `This server holds the maximum of ${maxSessions} MCP sessions. Retry later.`,
       });
       return;
     }
+    // Reserved synchronously, in the same tick as the check above.
+    reservedSlots++;
 
-    // A NEW connection: its own McpServer, its own RepoSession. Nothing in
-    // here is shared with any other session, which is what makes one
-    // caller's `select_repo` invisible to everybody else.
-    const server = createMcpServer({
-      cwd: repoPath,
-      envRepoPath: repoPath,
-      // One log file per token per process start, so an operator can see who
-      // did what without every connection sharing one file.
-      sessionId: `${defaultSessionId()}-${agentSlug(token.name)}`,
-      identity: token.name,
-      capabilities: { write: token.write },
-    });
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-      // Plain JSON responses rather than an SSE stream per request: this
-      // server has no server-initiated notifications to push, and a
-      // request/response shape keeps sockets short-lived (and shutdown
-      // instant) on a long-running shared process.
-      enableJsonResponse: true,
-      onsessioninitialized: (id: string) => {
-        sessions.set(id, { transport, server, tokenName: token.name });
-        log(`reposkein serve: mcp session opened for "${token.name}" (write=${token.write})`);
-      },
-      onsessionclosed: (id: string) => {
-        sessions.delete(id);
-      },
-    });
-    transport.onclose = () => {
-      const id = transport.sessionId;
-      if (id) sessions.delete(id);
-      void server.close().catch(() => {
-        /* shutting down */
+    try {
+      // A NEW connection: its own McpServer, its own RepoSession. Nothing in
+      // here is shared with any other session, which is what makes one
+      // caller's `select_repo` invisible to everybody else.
+      const server = createMcpServer({
+        cwd: repoPath,
+        envRepoPath: repoPath,
+        // One log file per token per process, so an operator can see who did
+        // what without every connection sharing one file.
+        sessionId: `${logIdBase}-${agentSlug(token.name)}`,
+        identity: token.name,
+        capabilities: { write: token.write },
+        ...(opts.ensureGraph ? { ensureGraph: opts.ensureGraph } : {}),
       });
-    };
-    await server.connect(transport);
-    await transport.handleRequest(req, res, body.value);
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        // Plain JSON responses rather than an SSE stream per request: this
+        // server has no server-initiated notifications to push, and a
+        // request/response shape keeps sockets short-lived (and shutdown
+        // instant) on a long-running shared process.
+        enableJsonResponse: true,
+        onsessioninitialized: (id: string) => {
+          sessions.set(id, {
+            transport,
+            server,
+            tokenName: token.name,
+            lastSeen: now(),
+            // The initialize request itself is in flight right now.
+            inFlight: 1,
+          });
+          log(`reposkein serve: mcp session opened for "${token.name}" (write=${token.write})`);
+        },
+        onsessionclosed: (id: string) => {
+          sessions.delete(id);
+        },
+      });
+      transport.onclose = () => {
+        const id = transport.sessionId;
+        if (id) sessions.delete(id);
+        void server.close().catch(() => {
+          /* shutting down */
+        });
+      };
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body.value);
+      const id = transport.sessionId;
+      if (id) {
+        const created = sessions.get(id);
+        if (created) created.inFlight--;
+      }
+    } finally {
+      reservedSlots--;
+    }
   }
 
   const handler: NodeHandler = (req, res) => {
@@ -356,9 +504,20 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
     if (fromQuery) {
       url.searchParams.delete("token");
       const q = url.searchParams.toString();
+      // `Secure` whenever the request reached us over TLS. We terminate plain
+      // HTTP ourselves, so the only evidence is the proxy's forwarded scheme —
+      // set it when that says https so the cookie can't leak back over a
+      // downgraded connection, and omit it otherwise (a `Secure` cookie on a
+      // genuinely plain-HTTP deployment is simply discarded by the browser,
+      // which would break the handshake this exists to provide).
+      const forwardedProto = req.headers["x-forwarded-proto"];
+      const rawProto = Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto;
+      const proto = (rawProto ?? "").split(",")[0]!.trim().toLowerCase();
+      const secure = proto === "https" ? "; Secure" : "";
       res.writeHead(302, {
         Location: url.pathname + (q ? `?${q}` : ""),
-        "Set-Cookie": `${TOKEN_COOKIE}=${encodeURIComponent(token.token)}; Path=/; HttpOnly; SameSite=Strict`,
+        "Set-Cookie":
+          `${TOKEN_COOKIE}=${encodeURIComponent(token.token)}; Path=/; HttpOnly; SameSite=Strict${secure}`,
         "Cache-Control": "no-store",
       });
       res.end();
@@ -373,6 +532,7 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
     refresh: () => {
       viewHandler = factory(repoPath, opts.repoId);
     },
+    sweepIdleSessions,
     close: async () => {
       const open = [...sessions.values()];
       sessions.clear();
@@ -391,6 +551,50 @@ export function createServeApp(opts: CreateServeAppOptions): ServeApp {
     },
     sessionCount: () => sessions.size,
   };
+}
+
+/** `git status --porcelain` for the served checkout, or null when git is
+ *  unavailable / the path isn't a repo. Never throws. */
+export function gitPorcelainStatus(repoPath: string): string[] | null {
+  try {
+    const out = execFileSync("git", ["-C", repoPath, "status", "--porcelain"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return out.split("\n").filter((l) => l.trim() !== "");
+  } catch {
+    return null;
+  }
+}
+
+/** The startup warning for serving a checkout with local modifications, or
+ *  null when the tree is clean (or git can't tell us).
+ *
+ *  Serving a dirty checkout is legal and sometimes exactly what an operator
+ *  wants, so this WARNS and never refuses. But it is worth saying loudly:
+ *  `serve`'s own re-index writes into `.reposkein/` (the committed summary
+ *  shards absorb every `local/summaries-*.jsonl` sidecar), so a checkout that
+ *  someone also works in will accumulate diffs that look like the server's
+ *  fault — and a re-index landing on top of half-finished local edits indexes
+ *  those edits. A dedicated deploy clone has neither problem. */
+export function dirtyCheckoutWarning(
+  repoPath: string,
+  statusFn: (p: string) => string[] | null = gitPorcelainStatus
+): string | null {
+  const lines = statusFn(repoPath);
+  if (!lines || lines.length === 0) return null;
+  const sample = lines.slice(0, 5).map((l) => `    ${l}`);
+  const more = lines.length > sample.length ? `\n    … and ${lines.length - sample.length} more` : "";
+  return (
+    `reposkein serve: WARNING — the served checkout has ${lines.length} uncommitted ` +
+    `change(s):\n${sample.join("\n")}${more}\n` +
+    "  Serving it anyway. Two things to know:\n" +
+    "    - re-indexing writes into .reposkein/ (committed summary shards absorb the local\n" +
+    "      sidecars), so this working tree will keep accumulating diffs.\n" +
+    "    - a re-index picks up whatever is in the tree, including half-finished edits.\n" +
+    "  Recommended: serve a DEDICATED DEPLOY CLONE that only ever fast-forwards, not a\n" +
+    "  working copy someone edits. See docs/REMOTE.md."
+  );
 }
 
 /** `reposkein-mcp serve --http [path] [--port N] [--host H] [--watch-interval S]`.
@@ -428,6 +632,10 @@ export async function runServe(repoPath: string, repoId: string, opts: ServeOpti
         "but the SPA will 404. Rebuild the package (`npm run build` in mcp/) to serve it."
     );
   }
+
+  // Warn, never refuse: see `dirtyCheckoutWarning`.
+  const dirty = dirtyCheckoutWarning(repoPath);
+  if (dirty) console.error(dirty);
 
   const app = createServeApp({ repoPath, repoId, tokens: loaded.tokens });
   const watcher: HeadWatcher = startHeadWatcher(repoPath, repoId, {

--- a/mcp/src/serve/serve.ts
+++ b/mcp/src/serve/serve.ts
@@ -1,0 +1,481 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { makeViewHandler, vizDistDir } from "../cli/view.js";
+import { createMcpServer } from "../server/createMcpServer.js";
+import { agentSlug } from "../store/sidecar.js";
+import { defaultSessionId } from "../store/sessionLog.js";
+import {
+  bearerFromAuthHeader,
+  loadServeTokens,
+  matchServeToken,
+  type ServeToken,
+} from "./tokens.js";
+import { startHeadWatcher, type HeadWatcher } from "./watch.js";
+
+/** The one path the MCP Streamable HTTP transport answers on. Everything else
+ *  is the viewer + `/api/*`, served by view.ts's own handler. */
+export const MCP_PATH = "/mcp";
+
+/** Cookie the viewer gets after a successful `?token=` handshake, so a browser
+ *  can keep loading `/api/*` without the secret in every URL. */
+const TOKEN_COOKIE = "reposkein_token";
+
+/** Cap on a single JSON-RPC POST body. Tool arguments are prose and node ids;
+ *  4 MB is orders of magnitude past anything legitimate. */
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+/** Cap on concurrent MCP sessions. A leaked token shouldn't be able to make
+ *  the process allocate servers without bound; an operator hitting this has a
+ *  problem worth an error, not silent growth. */
+const MAX_SESSIONS = 64;
+
+export interface ServeOptions {
+  port: number;
+  host: string;
+  /** `git rev-parse HEAD` poll interval. 0 disables the watcher. */
+  watchIntervalMs: number;
+}
+
+/** Default bind host. NOT 0.0.0.0: even in the mode that exists to be
+ *  reachable, exposure is an explicit `--host` decision by the operator. */
+export const DEFAULT_SERVE_HOST = "127.0.0.1";
+export const DEFAULT_SERVE_PORT = 4318;
+export const DEFAULT_WATCH_INTERVAL_MS = 30_000;
+
+export function parseServeArgs(argv: string[]): {
+  repoPath: string;
+  opts: ServeOptions;
+  http: boolean;
+} {
+  let port = DEFAULT_SERVE_PORT;
+  let host = DEFAULT_SERVE_HOST;
+  let watchIntervalMs = DEFAULT_WATCH_INTERVAL_MS;
+  let http = false;
+  const positional: string[] = [];
+  const intArg = (raw: string | undefined, fallback: number): number => {
+    const n = parseInt(raw ?? "", 10);
+    return Number.isFinite(n) && n >= 0 ? n : fallback;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--http") http = true;
+    else if (a === "--port") port = intArg(argv[++i], DEFAULT_SERVE_PORT);
+    else if (a.startsWith("--port=")) port = intArg(a.slice(7), DEFAULT_SERVE_PORT);
+    else if (a === "--host") host = argv[++i] ?? DEFAULT_SERVE_HOST;
+    else if (a.startsWith("--host=")) host = a.slice(7);
+    // Seconds on the CLI (an operator thinks in seconds), ms internally.
+    else if (a === "--watch-interval") watchIntervalMs = intArg(argv[++i], 30) * 1000;
+    else if (a.startsWith("--watch-interval="))
+      watchIntervalMs = intArg(a.slice(17), 30) * 1000;
+    else if (!a.startsWith("-")) positional.push(a);
+  }
+  const repoPath = positional[0] ?? process.env.REPOSKEIN_REPO_PATH ?? ".";
+  return { repoPath, opts: { port, host, watchIntervalMs }, http };
+}
+
+type NodeHandler = (req: IncomingMessage, res: ServerResponse) => void;
+
+interface McpSession {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+  /** The token NAME that created this session. A session is bound to it: a
+   *  different token presenting a stolen session id gets 403, so a read-only
+   *  credential can never inherit a write-capable session. */
+  tokenName: string;
+}
+
+export interface CreateServeAppOptions {
+  repoPath: string;
+  repoId: string;
+  tokens: readonly ServeToken[];
+  log?: (message: string) => void;
+  /** Test seam: replaces `makeViewHandler` (which reads the repo's JSONL and
+   *  shells out to git at construction time). */
+  viewHandlerFactory?: (repoPath: string, repoId: string) => NodeHandler;
+}
+
+export interface ServeApp {
+  handler: NodeHandler;
+  /** Rebuilds the `/api/*` handler. The view handler snapshots node/edge
+   *  counts and git metadata once per construction, so after a re-index the
+   *  hosted viewer would otherwise keep reporting the old graph — this is the
+   *  watcher's `onReindexed` hook, and it is why the MCP tools and the viewer
+   *  cannot drift apart: they are refreshed by the same event. */
+  refresh: () => void;
+  close: () => Promise<void>;
+  sessionCount: () => number;
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown, headers: Record<string, string> = {}): void {
+  const text = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+    ...headers,
+  });
+  res.end(text);
+}
+
+/** Reads a request body as JSON, capped. Resolves `{ ok: false }` on a bad
+ *  parse or an oversized body — never throws, never buffers past the cap. */
+function readJsonBody(req: IncomingMessage): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let settled = false;
+    const finish = (r: { ok: true; value: unknown } | { ok: false; error: string }): void => {
+      if (settled) return;
+      settled = true;
+      resolve(r);
+    };
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        finish({ ok: false, error: `request body exceeds ${MAX_BODY_BYTES} bytes` });
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (chunks.length === 0) return finish({ ok: true, value: undefined });
+      try {
+        finish({ ok: true, value: JSON.parse(Buffer.concat(chunks).toString("utf8")) });
+      } catch {
+        finish({ ok: false, error: "request body is not valid JSON" });
+      }
+    });
+    req.on("error", () => finish({ ok: false, error: "request stream error" }));
+  });
+}
+
+function cookieValue(header: string | undefined, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() !== name) continue;
+    try {
+      return decodeURIComponent(part.slice(eq + 1).trim()) || null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/** Builds the one request handler that answers both the MCP endpoint and the
+ *  viewer/`/api/*` surface (REP-17 requirement: one process, one graph).
+ *
+ *  URL layout:
+ *    POST/GET/DELETE `/mcp`  — MCP Streamable HTTP transport
+ *    GET `/api/graph`, `/api/jsonl/*`, `/api/source`, `/api/temporal`
+ *                            — byte-identical to `reposkein-mcp view`, because
+ *                              it IS view.ts's handler, not a copy
+ *    GET everything else     — the prebuilt viewer SPA
+ *
+ *  Auth applies to every route. `/mcp` accepts ONLY
+ *  `Authorization: Bearer <token>`; the viewer routes additionally accept
+ *  `?token=` (which is immediately traded for an HttpOnly cookie and
+ *  redirected away, so it appears once) because a static SPA in a browser
+ *  cannot attach an Authorization header to its own page load. */
+export function createServeApp(opts: CreateServeAppOptions): ServeApp {
+  const log = opts.log ?? ((m: string) => void process.stderr.write(`${m}\n`));
+  const factory = opts.viewHandlerFactory ?? makeViewHandler;
+  const repoPath = resolve(opts.repoPath);
+  let viewHandler = factory(repoPath, opts.repoId);
+  const sessions = new Map<string, McpSession>();
+
+  const unauthorized = (res: ServerResponse, detail: string): void =>
+    sendJson(
+      res,
+      401,
+      { error: "unauthorized", detail },
+      { "WWW-Authenticate": `Bearer realm="reposkein"` }
+    );
+
+  /** Authenticates one request. `allowCookieAndQuery` is false for `/mcp`. */
+  function authenticate(
+    req: IncomingMessage,
+    url: URL,
+    allowCookieAndQuery: boolean
+  ): { token: ServeToken | null; fromQuery: boolean } {
+    const header = bearerFromAuthHeader(req.headers.authorization);
+    const hit = matchServeToken(opts.tokens, header);
+    if (hit || !allowCookieAndQuery) return { token: hit, fromQuery: false };
+    const fromQuery = url.searchParams.get("token");
+    const q = matchServeToken(opts.tokens, fromQuery);
+    if (q) return { token: q, fromQuery: true };
+    const cookie = cookieValue(req.headers.cookie, TOKEN_COOKIE);
+    return { token: matchServeToken(opts.tokens, cookie), fromQuery: false };
+  }
+
+  async function handleMcp(req: IncomingMessage, res: ServerResponse, token: ServeToken): Promise<void> {
+    const rawSessionId = req.headers["mcp-session-id"];
+    const sessionId = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
+
+    if (sessionId) {
+      const existing = sessions.get(sessionId);
+      if (!existing) {
+        sendJson(res, 404, {
+          error: "session_not_found",
+          detail:
+            "This Mcp-Session-Id is unknown (expired, or the server restarted). " +
+            "Re-run initialize to open a new session.",
+        });
+        return;
+      }
+      if (existing.tokenName !== token.name) {
+        sendJson(res, 403, {
+          error: "session_token_mismatch",
+          detail:
+            "This MCP session belongs to a different token. Start a new session " +
+            "(omit Mcp-Session-Id) instead of reusing another caller's.",
+        });
+        return;
+      }
+      const body =
+        req.method === "POST" ? await readJsonBody(req) : { ok: true as const, value: undefined };
+      if (!body.ok) {
+        sendJson(res, 400, { error: "bad_request", detail: body.error });
+        return;
+      }
+      await existing.transport.handleRequest(req, res, body.value);
+      return;
+    }
+
+    if (req.method !== "POST") {
+      sendJson(res, 400, {
+        error: "bad_request",
+        detail: "Mcp-Session-Id is required for GET and DELETE on /mcp.",
+      });
+      return;
+    }
+
+    const body = await readJsonBody(req);
+    if (!body.ok) {
+      sendJson(res, 400, { error: "bad_request", detail: body.error });
+      return;
+    }
+    if (!isInitializeRequest(body.value)) {
+      sendJson(res, 400, {
+        error: "bad_request",
+        detail:
+          "No valid Mcp-Session-Id and this is not an initialize request. " +
+          "Open a session with initialize first.",
+      });
+      return;
+    }
+    if (sessions.size >= MAX_SESSIONS) {
+      sendJson(res, 503, {
+        error: "too_many_sessions",
+        detail: `This server holds the maximum of ${MAX_SESSIONS} MCP sessions. Retry later.`,
+      });
+      return;
+    }
+
+    // A NEW connection: its own McpServer, its own RepoSession. Nothing in
+    // here is shared with any other session, which is what makes one
+    // caller's `select_repo` invisible to everybody else.
+    const server = createMcpServer({
+      cwd: repoPath,
+      envRepoPath: repoPath,
+      // One log file per token per process start, so an operator can see who
+      // did what without every connection sharing one file.
+      sessionId: `${defaultSessionId()}-${agentSlug(token.name)}`,
+      identity: token.name,
+      capabilities: { write: token.write },
+    });
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      // Plain JSON responses rather than an SSE stream per request: this
+      // server has no server-initiated notifications to push, and a
+      // request/response shape keeps sockets short-lived (and shutdown
+      // instant) on a long-running shared process.
+      enableJsonResponse: true,
+      onsessioninitialized: (id: string) => {
+        sessions.set(id, { transport, server, tokenName: token.name });
+        log(`reposkein serve: mcp session opened for "${token.name}" (write=${token.write})`);
+      },
+      onsessionclosed: (id: string) => {
+        sessions.delete(id);
+      },
+    });
+    transport.onclose = () => {
+      const id = transport.sessionId;
+      if (id) sessions.delete(id);
+      void server.close().catch(() => {
+        /* shutting down */
+      });
+    };
+    await server.connect(transport);
+    await transport.handleRequest(req, res, body.value);
+  }
+
+  const handler: NodeHandler = (req, res) => {
+    const rawUrl = req.url ?? "/";
+    // The base is a placeholder — only pathname/searchParams are used.
+    const url = new URL(rawUrl, "http://localhost");
+    const isMcp = url.pathname === MCP_PATH;
+
+    const { token, fromQuery } = authenticate(req, url, !isMcp);
+    if (!token) {
+      log(
+        `reposkein serve: 401 ${req.method ?? "?"} ${url.pathname} ` +
+          `(${req.headers.authorization ? "token rejected" : "no bearer token"})`
+      );
+      unauthorized(
+        res,
+        isMcp
+          ? "Send `Authorization: Bearer <token>`. Ask the operator for a token; see docs/REMOTE.md."
+          : "Send `Authorization: Bearer <token>`, or open this page as `?token=<token>` once."
+      );
+      return;
+    }
+
+    if (isMcp) {
+      handleMcp(req, res, token).catch((err: unknown) => {
+        log(`reposkein serve: mcp request failed: ${err instanceof Error ? err.message : String(err)}`);
+        if (!res.headersSent) {
+          sendJson(res, 500, { error: "internal_error", detail: "See the server log." });
+        } else {
+          res.end();
+        }
+      });
+      return;
+    }
+
+    // A browser authenticated by `?token=`: trade it for an HttpOnly cookie
+    // and redirect to the clean URL, so the secret shows up in exactly one
+    // request line instead of every one.
+    if (fromQuery) {
+      url.searchParams.delete("token");
+      const q = url.searchParams.toString();
+      res.writeHead(302, {
+        Location: url.pathname + (q ? `?${q}` : ""),
+        "Set-Cookie": `${TOKEN_COOKIE}=${encodeURIComponent(token.token)}; Path=/; HttpOnly; SameSite=Strict`,
+        "Cache-Control": "no-store",
+      });
+      res.end();
+      return;
+    }
+
+    viewHandler(req, res);
+  };
+
+  return {
+    handler,
+    refresh: () => {
+      viewHandler = factory(repoPath, opts.repoId);
+    },
+    close: async () => {
+      const open = [...sessions.values()];
+      sessions.clear();
+      for (const s of open) {
+        try {
+          await s.transport.close();
+        } catch {
+          /* best-effort */
+        }
+        try {
+          await s.server.close();
+        } catch {
+          /* best-effort */
+        }
+      }
+    },
+    sessionCount: () => sessions.size,
+  };
+}
+
+/** `reposkein-mcp serve --http [path] [--port N] [--host H] [--watch-interval S]`.
+ *
+ *  Strictly optional (REP-17 / adr:2026-08-21-optional-shared-remote-mcp-server-…):
+ *  stdio is still the default transport and nothing binds a socket unless this
+ *  runs. Refuses to start without at least one configured token — an
+ *  unauthenticated remote MCP server would hand write access to the network. */
+export async function runServe(repoPath: string, repoId: string, opts: ServeOptions): Promise<number> {
+  const nodesPath = join(repoPath, ".reposkein", "nodes.jsonl");
+  if (!existsSync(nodesPath)) {
+    console.error(
+      `reposkein: no .reposkein/nodes.jsonl at ${repoPath}.\n` +
+        "  Build the graph first: `reposkein-mcp index` (or `reposkein-mcp init`)."
+    );
+    return 1;
+  }
+
+  const loaded = loadServeTokens(repoPath, process.env);
+  for (const e of loaded.errors) console.error(`reposkein serve: ${e}`);
+  if (loaded.tokens.length === 0) {
+    console.error(
+      "reposkein serve: refusing to start with no tokens.\n" +
+        "  Set REPOSKEIN_SERVE_TOKENS='name:secret[:write]' (comma-separated), or add\n" +
+        "  [serve] tokens = \"name:secret\" to .reposkein/config.toml (private deployments only —\n" +
+        "  config.toml is committed). See docs/REMOTE.md."
+    );
+    return 1;
+  }
+
+  const vizMissing = !existsSync(join(vizDistDir(), "index.html"));
+  if (vizMissing) {
+    console.error(
+      `reposkein serve: the viewer bundle is missing (${vizDistDir()}); /api/* still works, ` +
+        "but the SPA will 404. Rebuild the package (`npm run build` in mcp/) to serve it."
+    );
+  }
+
+  const app = createServeApp({ repoPath, repoId, tokens: loaded.tokens });
+  const watcher: HeadWatcher = startHeadWatcher(repoPath, repoId, {
+    intervalMs: opts.watchIntervalMs,
+    onReindexed: () => app.refresh(),
+  });
+  // Catch up once at startup: the checkout may have moved while nothing was
+  // watching it. Same idempotent check as every tick, so an up-to-date repo
+  // does no work.
+  await watcher.tick();
+
+  const server = createServer(app.handler);
+
+  return await new Promise<number>((resolvePromise) => {
+    let settled = false;
+    const settle = (code: number): void => {
+      if (settled) return;
+      settled = true;
+      resolvePromise(code);
+    };
+    server.on("error", (err) => {
+      console.error(`reposkein serve: server error: ${err.message}`);
+      watcher.stop();
+      settle(1);
+    });
+    server.listen(opts.port, opts.host, () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : opts.port;
+      const names = loaded.tokens
+        .map((t) => `${t.name}${t.write ? " (write)" : ""}`)
+        .join(", ");
+      console.error(
+        `reposkein serve: ${repoId} on http://${opts.host}:${port}\n` +
+          `  MCP endpoint:   http://${opts.host}:${port}${MCP_PATH}\n` +
+          `  viewer + /api/: http://${opts.host}:${port}/\n` +
+          `  tokens (${loaded.source}): ${names}\n` +
+          `  watch: ${opts.watchIntervalMs > 0 ? `${opts.watchIntervalMs / 1000}s HEAD poll` : "disabled"}\n` +
+          "  plain HTTP — terminate TLS in front of this. Ctrl-C to stop."
+      );
+    });
+
+    const shutdown = (): void => {
+      watcher.stop();
+      void app.close().finally(() => {
+        server.close(() => settle(0));
+      });
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/mcp/src/serve/tokens.ts
+++ b/mcp/src/serve/tokens.ts
@@ -1,0 +1,138 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { readConfigString } from "../store/teamConfig.js";
+
+/** One bearer credential a `serve --http` operator handed out (REP-17).
+ *
+ *  `name` is NOT a secret: it is the connection's writer identity, landing in
+ *  `summary_by` / `decided_by` and selecting the per-agent sidecar file. It is
+ *  the thing that gets logged. `token` is the secret and is never logged,
+ *  printed, or echoed into a tool result. */
+export interface ServeToken {
+  name: string;
+  token: string;
+  /** True only for entries declared `name:token:write`. */
+  write: boolean;
+}
+
+export interface ParsedTokens {
+  tokens: ServeToken[];
+  /** Human-readable reasons entries were dropped. NEVER contains a token
+   *  value — an operator pastes these into a bug report. */
+  errors: string[];
+}
+
+/** Minimum secret length we will accept. Short enough not to be annoying,
+ *  long enough that a token typed by hand isn't guessable in an afternoon. */
+const MIN_TOKEN_LENGTH = 16;
+
+/** Parses a token list: `name:token[:write]` entries separated by commas,
+ *  whitespace, or newlines.
+ *
+ *  Chosen over JSON because it has to survive being pasted into a shell
+ *  export, a systemd `Environment=` line, and a TOML string without escaping.
+ *  Anything unparseable is DROPPED with a reason rather than silently
+ *  becoming a valid credential — a malformed entry must never widen access.
+ *  Capability is opt-in: only the literal third field `write` grants it. */
+export function parseServeTokens(spec: string): ParsedTokens {
+  const tokens: ServeToken[] = [];
+  const errors: string[] = [];
+  const seenNames = new Set<string>();
+  const seenSecrets = new Set<string>();
+
+  for (const rawEntry of spec.split(/[,\s]+/)) {
+    const entry = rawEntry.trim();
+    if (entry === "") continue;
+    const parts = entry.split(":");
+    if (parts.length < 2 || parts.length > 3) {
+      errors.push(`ignored a token entry: expected "name:token" or "name:token:write"`);
+      continue;
+    }
+    const [name, token, cap] = parts as [string, string, string | undefined];
+    if (!/^[A-Za-z0-9._-]{1,40}$/.test(name)) {
+      errors.push(
+        `ignored a token entry: name must be 1-40 chars of [A-Za-z0-9._-] (got ${JSON.stringify(name)})`
+      );
+      continue;
+    }
+    if (token.length < MIN_TOKEN_LENGTH) {
+      errors.push(`ignored token "${name}": secret shorter than ${MIN_TOKEN_LENGTH} characters`);
+      continue;
+    }
+    if (cap !== undefined && cap !== "write") {
+      errors.push(`ignored token "${name}": third field must be "write" (got ${JSON.stringify(cap)})`);
+      continue;
+    }
+    if (seenNames.has(name)) {
+      errors.push(`ignored a duplicate token name: "${name}"`);
+      continue;
+    }
+    if (seenSecrets.has(token)) {
+      errors.push(`ignored token "${name}": its secret is already used by another name`);
+      continue;
+    }
+    seenNames.add(name);
+    seenSecrets.add(token);
+    tokens.push({ name, token, write: cap === "write" });
+  }
+  return { tokens, errors };
+}
+
+export interface LoadedTokens extends ParsedTokens {
+  /** Where the accepted entries came from, for the startup banner. */
+  source: "env" | "config" | "none";
+}
+
+/** Resolves the token list for `serve`: `REPOSKEIN_SERVE_TOKENS` wins over
+ *  `[serve] tokens` in `.reposkein/config.toml`.
+ *
+ *  Env-over-config because the config file is COMMITTED — an operator who
+ *  puts real secrets there has leaked them to everyone with repo access, so
+ *  the documented path is the env var and config is the convenience for a
+ *  private deployment. Only one source is consulted (no union): merging them
+ *  would make "why does this old token still work?" unanswerable. */
+export function loadServeTokens(
+  repoPath: string,
+  env: NodeJS.ProcessEnv = process.env
+): LoadedTokens {
+  const fromEnv = env.REPOSKEIN_SERVE_TOKENS?.trim();
+  if (fromEnv) return { ...parseServeTokens(fromEnv), source: "env" };
+  const fromConfig = readConfigString(repoPath, "serve", "tokens");
+  if (fromConfig && fromConfig.trim()) {
+    return { ...parseServeTokens(fromConfig), source: "config" };
+  }
+  return { tokens: [], errors: [], source: "none" };
+}
+
+/** Extracts the credential from an `Authorization: Bearer <token>` header.
+ *  Returns null for a missing, non-Bearer, or empty-value header. */
+export function bearerFromAuthHeader(header: string | string[] | undefined): string | null {
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) return null;
+  const m = /^Bearer[ \t]+(.+)$/i.exec(value.trim());
+  if (!m) return null;
+  const token = m[1]!.trim();
+  return token === "" ? null : token;
+}
+
+/** Length-independent constant-time comparison: both sides are hashed to a
+ *  fixed 32 bytes first, so `timingSafeEqual` never sees mismatched lengths
+ *  (it throws on those, and the throw itself would leak the length). */
+function secretEquals(a: string, b: string): boolean {
+  const ha = createHash("sha256").update(a, "utf8").digest();
+  const hb = createHash("sha256").update(b, "utf8").digest();
+  return timingSafeEqual(ha, hb);
+}
+
+/** Finds the token a presented credential matches, or null.
+ *
+ *  Scans the WHOLE list with no early exit so the response time doesn't
+ *  reveal which position matched (or how many tokens the operator
+ *  configured). */
+export function matchServeToken(tokens: readonly ServeToken[], presented: string | null): ServeToken | null {
+  if (presented === null) return null;
+  let hit: ServeToken | null = null;
+  for (const t of tokens) {
+    if (secretEquals(t.token, presented)) hit = t;
+  }
+  return hit;
+}

--- a/mcp/src/serve/watch.ts
+++ b/mcp/src/serve/watch.ts
@@ -1,0 +1,171 @@
+import { execFileSync } from "node:child_process";
+import { readIndexedAtSha, writeIndexedAtMarker } from "../store/indexedAt.js";
+import { ensureIndexerBinary } from "../indexer/fetchBinary.js";
+import { spawnIndexer, parseJsonStats } from "../indexer/runIndexer.js";
+
+/** What one watch tick did. `unchanged` is the overwhelmingly common case and
+ *  costs exactly one `git rev-parse` — the whole point of comparing against
+ *  the indexed-at marker rather than re-indexing on a timer. */
+export type WatchOutcome = "unchanged" | "reindexed" | "failed" | "no-head";
+
+export interface ReindexResult {
+  ok: boolean;
+  nodes?: number;
+  edges?: number;
+  error?: string;
+}
+
+export interface WatchDeps {
+  /** Current git HEAD of the served checkout, or null (not a repo / no HEAD). */
+  headSha: () => string | null;
+  /** The SHA the graph was last built from (`.reposkein/local/indexed-at`). */
+  indexedSha: () => string | null;
+  /** Rebuild the graph. MUST also refresh the indexed-at marker on success. */
+  reindex: () => Promise<ReindexResult>;
+  /** Where the one-line-per-reindex summary goes. MUST NOT be stdout in stdio
+   *  mode; `serve` has no stdio transport, but stderr stays the convention. */
+  log: (message: string) => void;
+}
+
+/** Reads HEAD of `repoPath`, or null. Never throws. */
+export function gitHeadSha(repoPath: string): string | null {
+  try {
+    const sha = execFileSync("git", ["-C", repoPath, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+/** One watch tick.
+ *
+ *  Idempotence is structural, not statistical: the decision to do work is
+ *  `HEAD !== indexed-at`, and the marker is written from HEAD by the index
+ *  step itself. So a tick against an unchanged checkout does nothing at all
+ *  (no indexer spawn, no log line), and a tick after `git pull` does exactly
+ *  one re-index — including across a server restart, because the marker is on
+ *  disk. If HEAD moves again DURING an index, the marker records the SHA that
+ *  was current when the index finished and the next tick converges.
+ *
+ *  Reusing REP-16's marker (rather than an in-memory "last seen" SHA) is what
+ *  keeps `doctor --ci`'s `graph_stale` check agreeing with the watcher: both
+ *  read the same file. */
+export async function watchTick(deps: WatchDeps): Promise<WatchOutcome> {
+  const head = deps.headSha();
+  if (!head) return "no-head";
+  if (head === deps.indexedSha()) return "unchanged";
+  const started = Date.now();
+  const r = await deps.reindex();
+  const secs = ((Date.now() - started) / 1000).toFixed(1);
+  const short = head.slice(0, 12);
+  if (!r.ok) {
+    deps.log(
+      `reposkein serve: reindex for HEAD ${short} FAILED after ${secs}s: ${r.error ?? "unknown error"} ` +
+        "(serving the previous graph; will retry on the next tick)"
+    );
+    return "failed";
+  }
+  deps.log(
+    `reposkein serve: reindexed at HEAD ${short} in ${secs}s ` +
+      `(${r.nodes ?? "?"} nodes, ${r.edges ?? "?"} edges)`
+  );
+  return "reindexed";
+}
+
+/** The default `reindex`: the same indexer invocation `reposkein-mcp index`
+ *  uses, followed by the indexed-at marker write. */
+export function makeDefaultReindex(repoPath: string, repoId: string): () => Promise<ReindexResult> {
+  return async (): Promise<ReindexResult> => {
+    try {
+      const bin = await ensureIndexerBinary();
+      const r = await spawnIndexer(bin, ["index", "--json", "--repo-id", repoId, repoPath]);
+      if (r.code !== 0) {
+        return { ok: false, error: r.stderr.trim() || r.stdout.trim() || `exit ${r.code}` };
+      }
+      const stats = parseJsonStats(r.stdout);
+      writeIndexedAtMarker(repoPath);
+      return stats ? { ok: true, nodes: stats.nodes, edges: stats.edges } : { ok: true };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  };
+}
+
+export interface HeadWatcherOptions {
+  intervalMs: number;
+  log?: (message: string) => void;
+  /** Called after a successful re-index — `serve` uses it to rebuild the
+   *  `/api/*` handler, whose node/edge counts and git metadata are computed
+   *  once per handler. */
+  onReindexed?: () => void;
+  /** Test seam: replaces the git + indexer plumbing wholesale. */
+  deps?: Partial<WatchDeps>;
+}
+
+export interface HeadWatcher {
+  /** Runs one tick now (awaitable — used by the startup catch-up and tests). */
+  tick: () => Promise<WatchOutcome>;
+  stop: () => void;
+}
+
+/** Polls `git rev-parse HEAD` on an interval and re-indexes when it moves.
+ *
+ *  A poll, not a filesystem watcher: the indexer's determinism guarantee is
+ *  defined against committed state, and an fs watcher would fire on every
+ *  editor save — re-indexing mid-edit, repeatedly, for a graph nobody asked
+ *  for yet. A poll also covers the case that actually matters for a shared
+ *  server (someone ran `git fetch && git reset --hard` in the checkout, or a
+ *  deploy hook did) without requiring a hook to be installed at all.
+ *
+ *  `intervalMs <= 0` disables polling entirely; `tick()` still works, so an
+ *  operator can drive re-indexing from their own post-receive hook by
+ *  restarting or by running `reposkein-mcp index`. */
+export function startHeadWatcher(
+  repoPath: string,
+  repoId: string,
+  opts: HeadWatcherOptions
+): HeadWatcher {
+  const log = opts.log ?? ((m: string) => void process.stderr.write(`${m}\n`));
+  const deps: WatchDeps = {
+    headSha: opts.deps?.headSha ?? (() => gitHeadSha(repoPath)),
+    indexedSha: opts.deps?.indexedSha ?? (() => readIndexedAtSha(repoPath)),
+    reindex: opts.deps?.reindex ?? makeDefaultReindex(repoPath, repoId),
+    log: opts.deps?.log ?? log,
+  };
+
+  // Ticks never overlap: a slow index on a big repo must not stack up behind
+  // a fast interval, and two concurrent indexer runs on one checkout would
+  // race on the same output files.
+  let busy = false;
+  let stopped = false;
+
+  const tick = async (): Promise<WatchOutcome> => {
+    if (busy || stopped) return "unchanged";
+    busy = true;
+    try {
+      const outcome = await watchTick(deps);
+      if (outcome === "reindexed") opts.onReindexed?.();
+      return outcome;
+    } finally {
+      busy = false;
+    }
+  };
+
+  const timer =
+    opts.intervalMs > 0
+      ? setInterval(() => {
+          void tick();
+        }, opts.intervalMs)
+      : null;
+
+  return {
+    tick,
+    stop: () => {
+      stopped = true;
+      if (timer) clearInterval(timer);
+    },
+  };
+}

--- a/mcp/src/serve/watch.ts
+++ b/mcp/src/serve/watch.ts
@@ -2,11 +2,14 @@ import { execFileSync } from "node:child_process";
 import { readIndexedAtSha, writeIndexedAtMarker } from "../store/indexedAt.js";
 import { ensureIndexerBinary } from "../indexer/fetchBinary.js";
 import { spawnIndexer, parseJsonStats } from "../indexer/runIndexer.js";
+import { isIndexLockHeld } from "../indexer/indexLock.js";
 
 /** What one watch tick did. `unchanged` is the overwhelmingly common case and
  *  costs exactly one `git rev-parse` — the whole point of comparing against
- *  the indexed-at marker rather than re-indexing on a timer. */
-export type WatchOutcome = "unchanged" | "reindexed" | "failed" | "no-head";
+ *  the indexed-at marker rather than re-indexing on a timer. `locked` means
+ *  another indexer run (a write-capable tool call, or the previous tick) owns
+ *  the index lock; the tick is skipped, not queued. */
+export type WatchOutcome = "unchanged" | "reindexed" | "failed" | "no-head" | "locked";
 
 export interface ReindexResult {
   ok: boolean;
@@ -25,6 +28,9 @@ export interface WatchDeps {
   /** Where the one-line-per-reindex summary goes. MUST NOT be stdout in stdio
    *  mode; `serve` has no stdio transport, but stderr stays the convention. */
   log: (message: string) => void;
+  /** Whether an indexer run is already in progress or queued. Injectable so
+   *  the skip path is testable without spawning anything. */
+  indexBusy: () => boolean;
 }
 
 /** Reads HEAD of `repoPath`, or null. Never throws. */
@@ -57,6 +63,12 @@ export async function watchTick(deps: WatchDeps): Promise<WatchOutcome> {
   const head = deps.headSha();
   if (!head) return "no-head";
   if (head === deps.indexedSha()) return "unchanged";
+  // Someone else is indexing (a write tool call, or a still-running earlier
+  // tick). SKIP rather than queue: whatever they are building is being built
+  // from the same working tree, so by the time the lock frees, this tick's
+  // work is either done or the next tick will see it needs doing. Queueing
+  // here would fire a redundant full index behind every write tool call.
+  if (deps.indexBusy()) return "locked";
   const started = Date.now();
   const r = await deps.reindex();
   const secs = ((Date.now() - started) / 1000).toFixed(1);
@@ -134,6 +146,7 @@ export function startHeadWatcher(
     indexedSha: opts.deps?.indexedSha ?? (() => readIndexedAtSha(repoPath)),
     reindex: opts.deps?.reindex ?? makeDefaultReindex(repoPath, repoId),
     log: opts.deps?.log ?? log,
+    indexBusy: opts.deps?.indexBusy ?? isIndexLockHeld,
   };
 
   // Ticks never overlap: a slow index on a big repo must not stack up behind
@@ -143,7 +156,10 @@ export function startHeadWatcher(
   let stopped = false;
 
   const tick = async (): Promise<WatchOutcome> => {
-    if (busy || stopped) return "unchanged";
+    if (stopped) return "unchanged";
+    // A previous tick is still running (slow index on a big repo, fast
+    // interval). Same reasoning as the index-lock skip in `watchTick`.
+    if (busy) return "locked";
     busy = true;
     try {
       const outcome = await watchTick(deps);

--- a/mcp/src/server/createMcpServer.ts
+++ b/mcp/src/server/createMcpServer.ts
@@ -103,6 +103,35 @@ export function repoUnindexedMessage(repoPath: string): string {
   );
 }
 
+/** Whether a graph is available to READ at `repoPath` without building one.
+ *
+ *  Mirrors `buildStore`'s backend choice exactly (same env, same order), so
+ *  "we can serve reads" and "we picked a real store" can never disagree:
+ *  explicit neo4j mode trusts the DB, otherwise the committed-derived JSONL
+ *  decides, and `auto` falls back to Neo4j when a password is configured. */
+export function graphAvailable(repoPath: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  const mode = (env.REPOSKEIN_STORE ?? "auto").toLowerCase();
+  if (mode === "neo4j") return true;
+  if (existsSync(join(repoPath, ".reposkein", "nodes.jsonl"))) return true;
+  return mode === "auto" && !!env.NEO4J_PASSWORD;
+}
+
+/** A read-only connection resolved a repo whose derived graph isn't built.
+ *
+ *  Building it means spawning the indexer and writing `.reposkein/*.jsonl` —
+ *  a write, and the LAST write a read-only token could still trigger, since
+ *  `ensureGraph` used to run unconditionally on first touch of any repo. So a
+ *  read-only caller gets this instead: an explanation and the exact command
+ *  for whoever does hold write access, with nothing changed on disk. */
+export function readOnlyUnindexedMessage(repoPath: string): string {
+  return (
+    `${repoPath} has no built graph (.reposkein/nodes.jsonl is derived from the working tree ` +
+    "and git-ignored, so a fresh clone has none), and this connection is read-only — the " +
+    "server will not build one for it. Ask the operator to run " +
+    `\`reposkein-mcp index ${repoPath}\`, or use a write-capable token. Nothing was changed.`
+  );
+}
+
 /** Exported for schema tests. */
 export const getContextProfileInputSchema = {
   node_id: z.string().optional(),
@@ -182,6 +211,10 @@ export interface CreateMcpServerOptions {
   identity?: string;
   /** Defaults to `{ write: true }` — the stdio behaviour. */
   capabilities?: ToolCapabilities;
+  /** Test seam for the first-touch graph build. Defaults to the real
+   *  `ensureGraph`. Injected in tests so the read-only build gate can be
+   *  asserted (called / not called) without spawning an indexer. */
+  ensureGraph?: typeof ensureGraph;
 }
 
 /** Builds ONE MCP server with its own session state.
@@ -195,21 +228,36 @@ export interface CreateMcpServerOptions {
 export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
   const caps: ToolCapabilities = opts.capabilities ?? { write: true };
   const identity = opts.identity;
+  const ensureGraphFn = opts.ensureGraph ?? ensureGraph;
 
   const session = new RepoSession({ cwd: opts.cwd, envRepoPath: opts.envRepoPath });
   const sessionLogger = new SessionLogger(opts.sessionId ?? resolveSessionId(process.env));
   const { withLog, cachedResolve } = createToolLogger(session, sessionLogger);
 
   const getRepoContext = makeCache(
-    async (path: string): Promise<{ repoId: string | undefined; store: GraphStore }> => {
+    async (
+      path: string
+    ): Promise<{ repoId: string | undefined; store: GraphStore; graphReady: boolean }> => {
       const id = resolveRepoId(path, process.env.REPOSKEIN_REPO_ID);
-      await ensureGraph(path, id, {
-        mode: (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase(),
-        neo4jConfigured: !!process.env.NEO4J_PASSWORD,
-      });
-      return { repoId: id, store: buildStore(path, id, identity) };
+      // REP-17: `ensureGraph` SPAWNS THE INDEXER and writes `.reposkein/*.jsonl`.
+      // That is a write, so a read-only connection must not reach it — it was
+      // the one mutation a read-only token could still cause, just by naming
+      // an unbuilt repo. Read-only callers get `readOnlyUnindexedMessage`
+      // below instead, and the repo is left exactly as it was found.
+      if (caps.write) {
+        await ensureGraphFn(path, id, {
+          mode: (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase(),
+          neo4jConfigured: !!process.env.NEO4J_PASSWORD,
+        });
+      }
+      return { repoId: id, store: buildStore(path, id, identity), graphReady: graphAvailable(path) };
     },
-    (ctx) => !!ctx.repoId
+    // Write connections: cache exactly as before (repoId resolved). Read-only
+    // connections additionally refuse to cache a graph-less resolution, so a
+    // graph built out of band (by the operator, or by the HEAD watcher) is
+    // picked up on the next call instead of sticking for the connection's life
+    // — they have no way to fix it themselves.
+    (ctx) => !!ctx.repoId && (caps.write || ctx.graphReady)
   );
 
   type ActiveRepo =
@@ -225,6 +273,12 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
     if (!resolution.repoPath) return { ok: false, message: repoRequiredMessage(resolution) };
     const ctx = await getRepoContext(resolution.repoPath);
     if (!ctx.repoId) return { ok: false, message: repoUnindexedMessage(resolution.repoPath) };
+    if (!ctx.graphReady) {
+      // Only reachable on a read-only connection: a write one already tried to
+      // build above, and if THAT failed ensureGraph explained why on stderr and
+      // the store degrades to Unconfigured (whose own error names the fix).
+      if (!caps.write) return { ok: false, message: readOnlyUnindexedMessage(resolution.repoPath) };
+    }
     return { ok: true, repoPath: resolution.repoPath, repoId: ctx.repoId, store: ctx.store };
   }
   const errResult = (message: string): ToolResult => ({

--- a/mcp/src/server/createMcpServer.ts
+++ b/mcp/src/server/createMcpServer.ts
@@ -1,0 +1,570 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { Neo4jGraphStore } from "../store/Neo4jGraphStore.js";
+import { UnconfiguredStore } from "../store/UnconfiguredStore.js";
+import type { GraphStore } from "../store/GraphStore.js";
+import { JsonlGraphStore } from "../store/JsonlGraphStore.js";
+import { makeReadCypher } from "../tools/readCypher.js";
+import type { ToolResult } from "../tools/readCypher.js";
+import { makeGetContextProfile } from "../tools/getContextProfile.js";
+import { makeWriteSemanticSummary } from "../tools/writeSemanticSummary.js";
+import { makeInitCpgSkeleton, makeReindexFile } from "../tools/indexerTools.js";
+import { makeSemanticFind } from "../tools/semanticFind.js";
+import { makeTemporalContext } from "../tools/temporalContext.js";
+import { makeImpact } from "../tools/impact.js";
+import { makeRecordDecision } from "../tools/recordDecision.js";
+import { makeSetDecisionStatus } from "../tools/setDecisionStatus.js";
+import { makeReaffirmDecision } from "../tools/reaffirmDecision.js";
+import { makeListDecisions } from "../tools/listDecisions.js";
+import { makeGetDecision } from "../tools/getDecision.js";
+import { resolveRepoId } from "../store/repoId.js";
+import type { RepoResolution } from "../store/resolveRepoPath.js";
+import { RepoSession } from "../store/repoSession.js";
+import { makeCache } from "../store/repoContextCache.js";
+import { ensureGraph } from "../indexer/ensureGraph.js";
+import { ensureIndexerBinary } from "../indexer/fetchBinary.js";
+import { spawnIndexer } from "../indexer/runIndexer.js";
+import { SessionLogger, resolveSessionId } from "../store/sessionLog.js";
+import { createToolLogger } from "../store/instrumentTool.js";
+
+/** Selects the store backend.
+ *  REPOSKEIN_STORE = "jsonl" | "neo4j" | "auto" (default "auto").
+ *  - auto: JSONL if <repoPath>/.reposkein/nodes.jsonl exists, else Neo4j if
+ *    NEO4J_PASSWORD is set, else Unconfigured.
+ *  - jsonl: JSONL if available, else Unconfigured.
+ *  - neo4j: Neo4j if configured, else Unconfigured.
+ *
+ *  `agent` names the writer for sidecar selection (one summaries file per
+ *  agent, see store/sidecar.ts); undefined keeps the REPOSKEIN_AGENT default. */
+export function buildStore(
+  repoPath: string | undefined,
+  repoId: string | undefined,
+  agent?: string
+): GraphStore {
+  const mode = (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase();
+  const jsonlReady =
+    !!repoPath && !!repoId && existsSync(join(repoPath, ".reposkein", "nodes.jsonl"));
+
+  const neo4j = (): GraphStore => {
+    try {
+      return Neo4jGraphStore.fromEnv();
+    } catch {
+      return new UnconfiguredStore();
+    }
+  };
+
+  if (mode === "jsonl") {
+    return jsonlReady ? new JsonlGraphStore(repoPath!, repoId!, agent) : new UnconfiguredStore();
+  }
+  if (mode === "neo4j") {
+    return neo4j();
+  }
+  // auto
+  if (jsonlReady) return new JsonlGraphStore(repoPath!, repoId!, agent);
+  return neo4j();
+}
+
+/** Structured, actionable message for repo-scoped tool calls when no repo
+ *  resolved (see `resolveRepoPath`). Names the discovered candidates when
+ *  resolution failed due to workspace-mode ambiguity, and points at
+ *  `list_repos` / `select_repo` so the agent can pick one instead of
+ *  abandoning the tools. */
+export function repoRequiredMessage(resolution: RepoResolution): string {
+  if (resolution.candidates && resolution.candidates.length > 0) {
+    return (
+      `Multiple RepoSkein repos were found under ${process.cwd()} and none is selected: ` +
+      resolution.candidates.join(", ") +
+      ". Call list_repos to see them, then select_repo with one of its `path` or `name` " +
+      "values (or set REPOSKEIN_REPO_PATH) to use this tool."
+    );
+  }
+  return (
+    "No RepoSkein repo found (checked the current directory, its ancestors, and its " +
+    "immediate subdirectories for .reposkein/). Run `reposkein-mcp init` in the repository " +
+    "you want to work with, call list_repos to check what was discovered, or set " +
+    "REPOSKEIN_REPO_PATH to its root."
+  );
+}
+
+/** A repo resolved but has no committed `meta.json` (never indexed). */
+export function repoUnindexedMessage(repoPath: string): string {
+  if (existsSync(join(repoPath, ".reposkein"))) {
+    return (
+      `Found .reposkein/ at ${repoPath}, but it has no meta.json (not indexed yet). ` +
+      `Run \`reposkein-mcp index ${repoPath}\` (or the init_cpg_skeleton tool) to build it, ` +
+      "then retry this call."
+    );
+  }
+  return (
+    `${repoPath} has no .reposkein/ directory. Run \`reposkein-mcp init ${repoPath}\` there, ` +
+    "or point REPOSKEIN_REPO_PATH / select_repo at a repo that already has one."
+  );
+}
+
+/** Exported for schema tests. */
+export const getContextProfileInputSchema = {
+  node_id: z.string().optional(),
+  file_path: z.string().optional(),
+  name: z.string().optional(),
+  hops: z.number().int().min(1).max(2).optional(),
+  federated: z.boolean().optional(),
+};
+
+/** Exported for schema tests. */
+export const recordDecisionInputSchema = {
+  title: z.string(),
+  context: z.string(),
+  decision: z.string(),
+  consequences: z.string().optional(),
+  alternatives: z.string().optional(),
+  status: z.enum(["proposed", "accepted"]).optional(),
+  anchor_node_ids: z.array(z.string()).max(20).optional(),
+  anchor_paths: z.array(z.string()).max(20).optional(),
+  supersedes: z.array(z.string()).max(5).optional(),
+};
+
+export const setDecisionStatusInputSchema = {
+  decision_id: z.string(),
+  status: z.enum(["accepted", "rejected", "deprecated"]),
+};
+
+export const reaffirmDecisionInputSchema = {
+  decision_id: z.string(),
+};
+
+export const listDecisionsInputSchema = {
+  status: z.enum(["proposed", "accepted", "rejected", "deprecated", "superseded"]).optional(),
+  anchor: z.string().optional(),
+  q: z.string().optional(),
+  limit: z.number().int().min(1).max(50).optional(),
+};
+
+export const getDecisionInputSchema = {
+  decision_id: z.string(),
+};
+
+/** The tools that MUTATE the repo (sidecar prose, decision records, the
+ *  derived graph). Gated behind the `write` capability in `serve --http`
+ *  (REP-17); always available over stdio, where the caller already owns the
+ *  checkout.
+ *
+ *  `select_repo` is deliberately NOT here: it mutates only this connection's
+ *  own `RepoSession`, which since REP-17 is per-connection state, so a
+ *  read-only caller pointing itself at a different discovered repo affects
+ *  nobody else. */
+export const WRITE_TOOLS = [
+  "write_semantic_summary",
+  "record_decision",
+  "set_decision_status",
+  "reaffirm_decision",
+  "reindex_file",
+  "init_cpg_skeleton",
+] as const;
+
+export interface ToolCapabilities {
+  /** False = read-only connection: every WRITE_TOOLS call is refused. */
+  write: boolean;
+}
+
+export interface CreateMcpServerOptions {
+  /** Working directory repo discovery starts from. */
+  cwd: string;
+  /** REPOSKEIN_REPO_PATH, or undefined. */
+  envRepoPath: string | undefined;
+  /** Session-log id. Defaults to `resolveSessionId(process.env)` (the stdio
+   *  behaviour: one id per server process). */
+  sessionId?: string;
+  /** Writer identity recorded as `summary_by`/`decided_by` and used to pick
+   *  the per-agent sidecar file. Undefined keeps the historical
+   *  `REPOSKEIN_AGENT ?? "agent"` fallback inside the tools. */
+  identity?: string;
+  /** Defaults to `{ write: true }` — the stdio behaviour. */
+  capabilities?: ToolCapabilities;
+}
+
+/** Builds ONE MCP server with its own session state.
+ *
+ *  Everything a caller can move — the active repo (`select_repo`), the
+ *  per-repoPath store/context cache, the tool-call logger — lives in this
+ *  closure, so two connections into the same process cannot see each other's
+ *  selection. That is what makes `serve --http` (REP-17) safe; over stdio
+ *  there is exactly one of these per process, which is byte-for-byte the
+ *  behaviour that existed before the extraction. */
+export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
+  const caps: ToolCapabilities = opts.capabilities ?? { write: true };
+  const identity = opts.identity;
+
+  const session = new RepoSession({ cwd: opts.cwd, envRepoPath: opts.envRepoPath });
+  const sessionLogger = new SessionLogger(opts.sessionId ?? resolveSessionId(process.env));
+  const { withLog, cachedResolve } = createToolLogger(session, sessionLogger);
+
+  const getRepoContext = makeCache(
+    async (path: string): Promise<{ repoId: string | undefined; store: GraphStore }> => {
+      const id = resolveRepoId(path, process.env.REPOSKEIN_REPO_ID);
+      await ensureGraph(path, id, {
+        mode: (process.env.REPOSKEIN_STORE ?? "auto").toLowerCase(),
+        neo4jConfigured: !!process.env.NEO4J_PASSWORD,
+      });
+      return { repoId: id, store: buildStore(path, id, identity) };
+    },
+    (ctx) => !!ctx.repoId
+  );
+
+  type ActiveRepo =
+    | { ok: true; repoPath: string; repoId: string; store: GraphStore }
+    | { ok: false; message: string };
+  /** Resolves the session's current repo for a repo-scoped tool call.
+   *  Re-evaluated on every call (not once at startup) so `select_repo`
+   *  actually takes effect for calls made after it. Uses `cachedResolve`
+   *  (not `session.resolve()` directly) so this and the REP-20 logging
+   *  wrapper share one filesystem walk per call. */
+  async function resolveActiveRepo(): Promise<ActiveRepo> {
+    const resolution = cachedResolve();
+    if (!resolution.repoPath) return { ok: false, message: repoRequiredMessage(resolution) };
+    const ctx = await getRepoContext(resolution.repoPath);
+    if (!ctx.repoId) return { ok: false, message: repoUnindexedMessage(resolution.repoPath) };
+    return { ok: true, repoPath: resolution.repoPath, repoId: ctx.repoId, store: ctx.store };
+  }
+  const errResult = (message: string): ToolResult => ({
+    content: [{ type: "text", text: message }],
+    isError: true,
+  });
+
+  /** The refusal a read-only connection gets from a mutating tool. Structured
+   *  (JSON with a stable `error` code) so an agent can branch on it instead of
+   *  parsing prose, and it names the identity so an operator reading the
+   *  transcript knows WHICH token was short of capability. Never echoes the
+   *  token value. */
+  const capabilityRefusal = (tool: string): ToolResult => ({
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          error: "write_capability_required",
+          tool,
+          required_capability: "write",
+          identity: identity ?? null,
+          detail:
+            `This connection is read-only, so ${tool} was refused before it could change anything. ` +
+            "Ask the operator for a token declared with the `write` capability " +
+            "(`name:token:write`), or run the stdio server against your own checkout.",
+        }),
+      },
+    ],
+    isError: true,
+  });
+
+  /** Registration-time note appended to a mutating tool's description on a
+   *  read-only connection, so `tools/list` is honest about what will happen. */
+  const readOnlyNote =
+    " NOTE: this connection's token is read-only — calling this tool returns a " +
+    "`write_capability_required` error and changes nothing.";
+  const describe = (text: string, tool: string): string =>
+    caps.write || !(WRITE_TOOLS as readonly string[]).includes(tool) ? text : text + readOnlyNote;
+
+  /** `withLog` plus the write-capability gate. The refusal is logged like any
+   *  other failed call (ok:false), which is what an operator wants to see. */
+  function withWrite<Args>(
+    name: string,
+    cb: (args: Args) => Promise<ToolResult>
+  ): (args: Args) => Promise<ToolResult> {
+    return withLog(name, async (args: Args) => {
+      if (!caps.write) return capabilityRefusal(name);
+      return cb(args);
+    });
+  }
+
+  const server = new McpServer({ name: "@reposkein/mcp", version: "0.0.0" });
+
+  server.registerTool(
+    "list_repos",
+    {
+      title: "List discovered repos",
+      description:
+        "Enumerate the RepoSkein repos discovered from the server's working directory (walk-up: the nearest ancestor with .reposkein/; walk-down/workspace mode: subdirectories, when no ancestor has one). Single-repo setups return exactly one entry. In workspace mode (multiple sibling repos, no default selected), use this to see the candidates, then `select_repo` one before calling other repo-scoped tools.",
+      inputSchema: {},
+    },
+    withLog("list_repos", async () => {
+      const repos = session.list();
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              mode: repos.length > 1 ? "workspace" : "single",
+              repos,
+            }),
+          },
+        ],
+      };
+    })
+  );
+
+  server.registerTool(
+    "select_repo",
+    {
+      title: "Select the active repo",
+      description:
+        "Set the session-active repo for all subsequent repo-scoped tool calls (get_context_profile, semantic_find, impact, decisions, etc.) — the fix for workspace-mode ambiguity (list_repos returned more than one candidate). Pass a `repo` value from list_repos: its `path` or its `name`. Overrides REPOSKEIN_REPO_PATH and any earlier select_repo call for the rest of this connection; stays in effect until called again.",
+      inputSchema: { repo: z.string() },
+    },
+    withLog("select_repo", async (args) => {
+      const result = session.select(args.repo);
+      if (!result.ok) return errResult(result.error);
+      return {
+        content: [{ type: "text", text: JSON.stringify({ ok: true, selected: result.repo }) }],
+      };
+    })
+  );
+
+  server.registerTool(
+    "read_cypher",
+    {
+      title: "Read-only Cypher query",
+      description:
+        "Run a read-only Cypher query against the RepoSkein graph. Writes are rejected. Filter by `n.repo_id = $repo_id` (or `n.repo_id IN $repo_ids`); pass `federated: true` to span this repo and its nested repos via `$repo_ids`. Results are capped (200 rows / 64KB).",
+      inputSchema: {
+        query: z.string(),
+        params: z.record(z.string(), z.unknown()).optional(),
+        federated: z.boolean().optional(),
+      },
+    },
+    withLog("read_cypher", async (args) => {
+      // Cypher is store-level, not repo-scoped: a Neo4j-backed server answers
+      // even with no local checkout resolved.
+      const resolution = cachedResolve();
+      const ctx = resolution.repoPath
+        ? await getRepoContext(resolution.repoPath)
+        : { repoId: undefined, store: buildStore(undefined, undefined, identity) };
+      return makeReadCypher(ctx.store, ctx.repoId)(args);
+    })
+  );
+
+  server.registerTool(
+    "get_context_profile",
+    {
+      title: "Get context profile",
+      description:
+        "Resolve a function/class (by node_id, file_path+name, or name) and return its caller/callee neighborhood (hops 1-2) with inlined prose and an enrichment_needed list. Never guesses — returns candidates if a name is ambiguous. Pass federated:true to resolve and traverse across nested repos.",
+      inputSchema: getContextProfileInputSchema,
+    },
+    withLog("get_context_profile", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeGetContextProfile(active.store, active.repoId, active.repoPath)(args);
+    })
+  );
+
+  server.registerTool(
+    "write_semantic_summary",
+    {
+      title: "Write semantic summary",
+      description: describe(
+        "Attach a 1-3 sentence plain-text business-logic summary to a node, stamped with its current content hash for staleness tracking. Plain text only (no markdown links or code fences), max 1000 chars.",
+        "write_semantic_summary"
+      ),
+      inputSchema: {
+        node_id: z.string(),
+        summary: z.string(),
+        model: z.string().optional(),
+      },
+    },
+    withWrite("write_semantic_summary", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeWriteSemanticSummary(active.store, active.repoId, identity)(args);
+    })
+  );
+
+  server.registerTool(
+    "init_cpg_skeleton",
+    {
+      title: "Build the code graph",
+      description: describe(
+        "Index the repository with the native indexer and load it into the graph database. Run once on a fresh repo (or to rebuild). Returns node/edge counts.",
+        "init_cpg_skeleton"
+      ),
+      inputSchema: {
+        path: z.string().optional(),
+        full: z.boolean().optional(),
+      },
+    },
+    withWrite("init_cpg_skeleton", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeInitCpgSkeleton(active.repoId, active.repoPath)(args);
+    })
+  );
+
+  server.registerTool(
+    "reindex_file",
+    {
+      title: "Reindex after editing",
+      description: describe(
+        "Refresh the graph after editing a source file (pass its path). v1 performs a full reindex.",
+        "reindex_file"
+      ),
+      inputSchema: { path: z.string() },
+    },
+    withWrite("reindex_file", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeReindexFile(active.repoId, active.repoPath)(args);
+    })
+  );
+
+  server.registerTool(
+    "semantic_find",
+    {
+      title: "Find code by meaning",
+      description:
+        "Rank functions/classes by a lexical match over their qualified names, signatures, and agent-written summaries — the entry point to seed get_context_profile when you don't know where to start. Returns ranked node_ids. Architecture decisions are part of the corpus: \"why\" questions (why don't we X, what did we decide about Y) surface Decision rows — follow up with get_decision. federated:true spans nested repos.",
+      inputSchema: {
+        query: z.string(),
+        limit: z.number().int().min(1).max(25).optional(),
+        kind: z.enum(["Function", "Class", "Interface", "Enum", "Decision"]).optional(),
+        federated: z.boolean().optional(),
+      },
+    },
+    withLog("semantic_find", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeSemanticFind(active.store, active.repoId, active.repoPath, undefined, {
+        decisions: true,
+      })(args);
+    })
+  );
+
+  server.registerTool(
+    "get_temporal_context",
+    {
+      title: "Git temporal context",
+      description:
+        "Git-derived signals for a file: how often/recently it changes, who owns it, and which files most often change together with it (co-change) — answers \"what else should I touch?\". Advisory (derived from git history, not the committed graph). Before a cross-cutting change, use this to find files that historically change together.",
+      inputSchema: { path: z.string() },
+    },
+    withLog("get_temporal_context", async (args) => {
+      // Git-derived, not graph-derived: needs a checkout, not an index.
+      const resolution = cachedResolve();
+      if (!resolution.repoPath) return errResult(repoRequiredMessage(resolution));
+      return makeTemporalContext(resolution.repoPath)(args);
+    })
+  );
+
+  server.registerTool(
+    "impact",
+    {
+      title: "Change impact + covering tests",
+      description:
+        "Given a function/class, return its transitive callers (what could break if you change it) split into impacted code vs the tests that cover it (what to run). Resolves by node_id, file_path+name, or name. federated:true spans nested repos.",
+      inputSchema: {
+        node_id: z.string().optional(),
+        file_path: z.string().optional(),
+        name: z.string().optional(),
+        depth: z.number().int().min(1).max(5).optional(),
+        federated: z.boolean().optional(),
+      },
+    },
+    withLog("impact", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeImpact(active.store, active.repoId, active.repoPath)(args);
+    })
+  );
+
+  // --- Architecture Decision Records (ADRs) ---
+
+  server.registerTool(
+    "record_decision",
+    {
+      title: "Record an architecture decision",
+      description: describe(
+        "Record an Architecture Decision Record (ADR): why a significant design choice was made, anchored to the graph nodes and paths it governs. Use for decisions that affect structure, dependencies, interfaces, or construction techniques — not renames, formatting, or routine fixes. Records land as status \"proposed\" (the user ratifies via set_decision_status); pass supersedes to replace an earlier decision. Plain text only; anchors are stamped with the current content hash for drift tracking.",
+        "record_decision"
+      ),
+      inputSchema: recordDecisionInputSchema,
+    },
+    withWrite("record_decision", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      // Refresh the graph before stamping anchors so a decision recorded
+      // right after an edit isn't born stale. Best-effort inside the tool.
+      const decisionRefresh = async (): Promise<void> => {
+        const bin = await ensureIndexerBinary();
+        await spawnIndexer(bin, ["index", "--json", "--repo-id", active.repoId, active.repoPath]);
+      };
+      return makeRecordDecision(active.store, active.repoId, active.repoPath, {
+        refresh: decisionRefresh,
+        ...(identity !== undefined ? { decidedBy: identity } : {}),
+      })(args);
+    })
+  );
+
+  server.registerTool(
+    "set_decision_status",
+    {
+      title: "Set decision status",
+      description: describe(
+        "Change an ADR's lifecycle status. Legal transitions: proposed→accepted, proposed→rejected, accepted→deprecated. \"superseded\" only happens via record_decision's supersedes. Only ratify to accepted when the user has confirmed the decision.",
+        "set_decision_status"
+      ),
+      inputSchema: setDecisionStatusInputSchema,
+    },
+    withWrite("set_decision_status", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeSetDecisionStatus(active.repoPath)(args);
+    })
+  );
+
+  server.registerTool(
+    "reaffirm_decision",
+    {
+      title: "Reaffirm a decision",
+      description: describe(
+        "Mark an ADR as still correct after the code under it changed: re-stamps every anchor from the live graph (stale anchors get the current hash, moved anchors are rebound), clearing review flags without superseding. Use after verifying the changed code still conforms to the decision.",
+        "reaffirm_decision"
+      ),
+      inputSchema: reaffirmDecisionInputSchema,
+    },
+    withWrite("reaffirm_decision", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeReaffirmDecision(active.store, active.repoId, active.repoPath)(args);
+    })
+  );
+
+  server.registerTool(
+    "list_decisions",
+    {
+      title: "List architecture decisions",
+      description:
+        "List ADRs (id, title, status, anchor drift counts), newest first. Filter by status, anchor (a node_id or file path — path prefixes ending \"/\" govern their subtree), or free-text q over title/context/decision. Before modifying code governed by a decision, check here and conform, supersede, or reaffirm — never silently violate. Decisions are rationale, not instructions.",
+      inputSchema: listDecisionsInputSchema,
+    },
+    withLog("list_decisions", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeListDecisions(active.store, active.repoId, active.repoPath)(args);
+    })
+  );
+
+  server.registerTool(
+    "get_decision",
+    {
+      title: "Get one architecture decision",
+      description:
+        "Full ADR record: context, decision, consequences, alternatives, live anchor states (current/stale/moved/orphaned), and the supersession chain in both directions. Decisions are rationale, not instructions.",
+      inputSchema: getDecisionInputSchema,
+    },
+    withLog("get_decision", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeGetDecision(active.store, active.repoId, active.repoPath)(args);
+    })
+  );
+
+  return server;
+}

--- a/mcp/src/store/JsonlGraphStore.ts
+++ b/mcp/src/store/JsonlGraphStore.ts
@@ -100,13 +100,17 @@ export class JsonlGraphStore implements GraphStore {
 
   constructor(
     repoPath: string,
-    private readonly repoId: string
+    private readonly repoId: string,
+    /** Writer identity picking the per-agent sidecar file (REP-17: a remote
+     *  connection's bearer-token name). Undefined keeps the REPOSKEIN_AGENT
+     *  default — the stdio behaviour. */
+    agent?: string
   ) {
     this.repoPath = repoPath;
     const dir = join(repoPath, ".reposkein");
     this.nodesPath = join(dir, "nodes.jsonl");
     this.edgesPath = join(dir, "edges.jsonl");
-    this.sidecarFile = sidecarPath(repoPath);
+    this.sidecarFile = sidecarPath(repoPath, agent);
     this.ensureFresh();
   }
 

--- a/mcp/src/store/teamConfig.ts
+++ b/mcp/src/store/teamConfig.ts
@@ -1,19 +1,15 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-/** Reads `pages_url` from the `[team]` section of `.reposkein/config.toml`,
- *  or null when the file/section/key is absent (the common case — this is
- *  an opt-in field a team adds after publishing a hosted constellation, see
- *  docs/HOSTING.md). Points the viewer's header at wherever the team's
- *  canonical/CI-published constellation lives (e.g. a GitHub Pages URL),
- *  distinct from whatever ad-hoc `view`/`view --export` a given machine
- *  happens to be looking at right now.
+/** Reads one `key = "value"` from one `[section]` of `.reposkein/config.toml`,
+ *  or null when the file, section, key, or quoting is absent.
  *
- *  A deliberate ~20-line scanner rather than a TOML dependency — mirrors
- *  `config_bool` in indexer/crates/cli/src/main.rs: this reads exactly one
- *  setting, and its config is a file `reposkein-indexer init` writes.
- *  Absent file, section, or key all mean `null`. */
-export function readTeamPagesUrl(repoPath: string): string | null {
+ *  A deliberate ~25-line scanner rather than a TOML dependency — mirrors
+ *  `config_bool` in indexer/crates/cli/src/main.rs: this reads a handful of
+ *  scalar settings out of a file `reposkein-indexer init` writes. Unquoted
+ *  values yield null on purpose (the writer always quotes; an unquoted value
+ *  is a hand-edit we refuse to guess at). */
+export function readConfigString(repoPath: string, section: string, key: string): string | null {
   const path = join(repoPath, ".reposkein", "config.toml");
   if (!existsSync(path)) return null;
   let text: string;
@@ -22,22 +18,33 @@ export function readTeamPagesUrl(repoPath: string): string | null {
   } catch {
     return null;
   }
-  let inTeamSection = false;
+  const header = `[${section}]`;
+  let inSection = false;
   for (const rawLine of text.split(/\r?\n/)) {
     const line = rawLine.trim();
     if (line === "" || line.startsWith("#")) continue;
     if (line.startsWith("[")) {
-      inTeamSection = line === "[team]";
+      inSection = line === header;
       continue;
     }
-    if (!inTeamSection) continue;
+    if (!inSection) continue;
     const eq = line.indexOf("=");
     if (eq === -1) continue;
-    const key = line.slice(0, eq).trim();
-    if (key !== "pages_url") continue;
+    if (line.slice(0, eq).trim() !== key) continue;
     const rawValue = line.slice(eq + 1).split("#")[0]!.trim();
     const quoted = rawValue.match(/^"([^"]*)"$/) ?? rawValue.match(/^'([^']*)'$/);
     return quoted ? quoted[1]! : null;
   }
   return null;
+}
+
+/** Reads `pages_url` from the `[team]` section of `.reposkein/config.toml`,
+ *  or null when the file/section/key is absent (the common case — this is
+ *  an opt-in field a team adds after publishing a hosted constellation, see
+ *  docs/HOSTING.md). Points the viewer's header at wherever the team's
+ *  canonical/CI-published constellation lives (e.g. a GitHub Pages URL),
+ *  distinct from whatever ad-hoc `view`/`view --export` a given machine
+ *  happens to be looking at right now. */
+export function readTeamPagesUrl(repoPath: string): string | null {
+  return readConfigString(repoPath, "team", "pages_url");
 }

--- a/mcp/src/tools/recordDecision.ts
+++ b/mcp/src/tools/recordDecision.ts
@@ -35,6 +35,9 @@ export interface DecisionToolDeps {
    *  index snapshot). Failures are swallowed — recording must not break. */
   refresh?: () => Promise<void>;
   today?: () => string;
+  /** Writer identity for `decided_by` (REP-17: a remote connection's
+   *  bearer-token name). Omitted over stdio, where REPOSKEIN_AGENT stands. */
+  decidedBy?: string;
 }
 
 function isoToday(): string {
@@ -144,7 +147,7 @@ export function makeRecordDecision(
         paths,
         supersedes,
         decided_at: date,
-        decided_by: process.env.REPOSKEIN_AGENT ?? "agent",
+        decided_by: deps.decidedBy ?? process.env.REPOSKEIN_AGENT ?? "agent",
         trigger,
         body_hash: "",
       };

--- a/mcp/src/tools/writeSemanticSummary.ts
+++ b/mcp/src/tools/writeSemanticSummary.ts
@@ -13,7 +13,10 @@ function today(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-export function makeWriteSemanticSummary(store: GraphStore, repoId: string) {
+/** `identity` names the writer for `summary_by` (REP-17: a remote connection's
+ *  bearer-token name, which is more specific than the process-wide
+ *  REPOSKEIN_AGENT). Omitted over stdio, where the env fallback stands. */
+export function makeWriteSemanticSummary(store: GraphStore, repoId: string, identity?: string) {
   return async (args: WriteSummaryArgs): Promise<ToolResult> => {
     const v = sanitizeSummary(args.summary);
     if (!v.ok) {
@@ -24,7 +27,7 @@ export function makeWriteSemanticSummary(store: GraphStore, repoId: string) {
         summary: v.value,
         model: args.model ?? "unknown",
         at: today(),
-        by: process.env.REPOSKEIN_AGENT ?? "agent",
+        by: identity ?? process.env.REPOSKEIN_AGENT ?? "agent",
       });
       if (res.kind === "not_found") {
         return {

--- a/mcp/test/indexLock.test.ts
+++ b/mcp/test/indexLock.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { drainIndexLock, isIndexLockHeld, withIndexLock } from "../src/indexer/indexLock.js";
+import { spawnIndexer } from "../src/indexer/runIndexer.js";
+
+const tick = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+describe("withIndexLock", () => {
+  it("serializes overlapping bodies (no interleaving)", async () => {
+    const events: string[] = [];
+    const body = async (name: string): Promise<void> => {
+      events.push(`enter ${name}`);
+      await tick();
+      await tick();
+      events.push(`exit ${name}`);
+    };
+    // Started together, deliberately un-awaited until both are queued.
+    await Promise.all([
+      withIndexLock(() => body("a")),
+      withIndexLock(() => body("b")),
+      withIndexLock(() => body("c")),
+    ]);
+    // Every exit immediately follows its own enter: no run overlapped another.
+    expect(events).toEqual([
+      "enter a",
+      "exit a",
+      "enter b",
+      "exit b",
+      "enter c",
+      "exit c",
+    ]);
+  });
+
+  it("runs waiters in arrival order (a fast poller cannot starve a tool call)", async () => {
+    const order: string[] = [];
+    await Promise.all(
+      ["first", "second", "third"].map((n) =>
+        withIndexLock(async () => {
+          order.push(n);
+          await tick();
+        })
+      )
+    );
+    expect(order).toEqual(["first", "second", "third"]);
+  });
+
+  it("is reentrant: a nested acquisition does not deadlock", async () => {
+    const result = await withIndexLock(async () => {
+      // This is what makes putting the lock inside `spawnIndexer` safe: any
+      // future operation that wraps itself AND spawns would otherwise wedge
+      // the whole process against its own lock.
+      return withIndexLock(async () => "inner ran");
+    });
+    expect(result).toBe("inner ran");
+  });
+
+  it("reports held while a run is in progress or queued, and clears after", async () => {
+    expect(isIndexLockHeld()).toBe(false);
+    let seenInside = false;
+    let seenByWaiter = false;
+    const holder = withIndexLock(async () => {
+      seenInside = isIndexLockHeld();
+      await tick();
+    });
+    // A queued waiter counts too — that is what lets the watcher skip rather
+    // than pile a redundant index behind a tool call.
+    const waiter = withIndexLock(async () => {
+      seenByWaiter = isIndexLockHeld();
+    });
+    expect(isIndexLockHeld()).toBe(true);
+    await Promise.all([holder, waiter]);
+    expect(seenInside).toBe(true);
+    expect(seenByWaiter).toBe(true);
+    expect(isIndexLockHeld()).toBe(false);
+  });
+
+  it("releases the lock when the body throws", async () => {
+    await expect(
+      withIndexLock(async () => {
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+    expect(isIndexLockHeld()).toBe(false);
+    // And the queue still works afterwards.
+    expect(await withIndexLock(async () => "after")).toBe("after");
+  });
+});
+
+describe("spawnIndexer — the lock is on the choke point, not the call sites", () => {
+  it("serializes two concurrent spawns", async () => {
+    // A real spawn through the real function: this is the assertion that
+    // EVERY indexer invocation is serialized, including any added later,
+    // because none of them can reach the process without passing through here.
+    const busyFor = 120;
+    const prog = `const t=Date.now();while(Date.now()-t<${busyFor});process.stdout.write(String(Date.now()));`;
+    const run = async (): Promise<{ start: number; end: number }> => {
+      const start = Date.now();
+      const r = await spawnIndexer(process.execPath, ["-e", prog]);
+      expect(r.code).toBe(0);
+      return { start, end: Date.now() };
+    };
+    const [a, b] = await Promise.all([run(), run()]);
+    // Whichever went second cannot have started before the first finished.
+    const [first, second] = a.start <= b.start ? [a, b] : [b, a];
+    expect(second.end).toBeGreaterThanOrEqual(first.end);
+    // And the total is two busy-waits, not one — they did not overlap.
+    const total = Math.max(a.end, b.end) - Math.min(a.start, b.start);
+    expect(total).toBeGreaterThanOrEqual(busyFor * 2 * 0.75);
+    await drainIndexLock();
+  }, 20_000);
+});

--- a/mcp/test/recordDecision.test.ts
+++ b/mcp/test/recordDecision.test.ts
@@ -69,8 +69,26 @@ describe("record_decision", () => {
     expect(rec.body_hash).toBe(computeBodyHash(rec));
   });
 
-  it("reports unresolved anchor ids instead of failing", async () => {
+  it("attributes the record to an explicit writer identity when one is given", async () => {
     const store = fakeStore({ getNode: async () => null });
+    // REP-17: a remote connection's bearer-token name is more specific than
+    // the process-wide REPOSKEIN_AGENT, and must win.
+    const previous = process.env.REPOSKEIN_AGENT;
+    process.env.REPOSKEIN_AGENT = "env-agent";
+    try {
+      const record = makeRecordDecision(store, REPO_ID, root, {
+        today: TODAY,
+        decidedBy: "ci-writer",
+      });
+      await record(baseArgs);
+      expect(loadDecisions(root).decisions[0]!.decided_by).toBe("ci-writer");
+    } finally {
+      if (previous === undefined) delete process.env.REPOSKEIN_AGENT;
+      else process.env.REPOSKEIN_AGENT = previous;
+    }
+  });
+
+  it("reports unresolved anchor ids instead of failing", async () => {    const store = fakeStore({ getNode: async () => null });
     const record = makeRecordDecision(store, REPO_ID, root, { today: TODAY });
     const res = await record({ ...baseArgs, anchor_node_ids: ["rs1:abc123:func:gone@0"] });
     const out = parse(res);

--- a/mcp/test/serveGuards.test.ts
+++ b/mcp/test/serveGuards.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { graphAvailable, readOnlyUnindexedMessage } from "../src/server/createMcpServer.js";
+import { dirtyCheckoutWarning } from "../src/serve/serve.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reposkein-guards-"));
+  mkdirSync(join(dir, ".reposkein"), { recursive: true });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("graphAvailable — can we serve reads without building?", () => {
+  const nodes = (): void => writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), '{"id":"a"}\n');
+
+  it("false for an unbuilt JSONL repo (the read-only gate's whole purpose)", () => {
+    expect(graphAvailable(dir, {})).toBe(false);
+    expect(graphAvailable(dir, { REPOSKEIN_STORE: "jsonl" })).toBe(false);
+  });
+
+  it("true once nodes.jsonl exists", () => {
+    nodes();
+    expect(graphAvailable(dir, {})).toBe(true);
+    expect(graphAvailable(dir, { REPOSKEIN_STORE: "jsonl" })).toBe(true);
+  });
+
+  it("true in explicit neo4j mode — the DB holds the graph, nothing to build", () => {
+    expect(graphAvailable(dir, { REPOSKEIN_STORE: "neo4j" })).toBe(true);
+  });
+
+  it("true in auto mode with a Neo4j password (mirrors buildStore's fallback)", () => {
+    expect(graphAvailable(dir, { NEO4J_PASSWORD: "x" })).toBe(true);
+    // …but NOT when jsonl was pinned explicitly: buildStore wouldn't use the DB.
+    expect(graphAvailable(dir, { REPOSKEIN_STORE: "jsonl", NEO4J_PASSWORD: "x" })).toBe(false);
+  });
+});
+
+describe("readOnlyUnindexedMessage", () => {
+  it("names the repo, the exact fix, and that nothing changed", () => {
+    const msg = readOnlyUnindexedMessage("/srv/repo");
+    expect(msg).toContain("/srv/repo");
+    expect(msg).toContain("reposkein-mcp index /srv/repo");
+    expect(msg).toContain("read-only");
+    expect(msg).toContain("Nothing was changed");
+  });
+});
+
+describe("dirtyCheckoutWarning", () => {
+  it("returns null for a clean tree", () => {
+    expect(dirtyCheckoutWarning(dir, () => [])).toBeNull();
+  });
+
+  it("returns null when git can't answer (not a repo, no git)", () => {
+    expect(dirtyCheckoutWarning(dir, () => null)).toBeNull();
+  });
+
+  it("warns with a count, a sample, and the deploy-clone recommendation", () => {
+    const warning = dirtyCheckoutWarning(dir, () => [" M src/a.ts", "?? scratch.txt"]);
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("2 uncommitted change(s)");
+    expect(warning).toContain("src/a.ts");
+    expect(warning).toContain("scratch.txt");
+    expect(warning).toContain("DEDICATED DEPLOY CLONE");
+    expect(warning).toContain("Serving it anyway");
+    expect(warning).toContain("docs/REMOTE.md");
+  });
+
+  it("truncates a long status instead of printing hundreds of lines", () => {
+    const lines = Array.from({ length: 40 }, (_, i) => ` M src/f${i}.ts`);
+    const warning = dirtyCheckoutWarning(dir, () => lines)!;
+    expect(warning).toContain("40 uncommitted change(s)");
+    expect(warning).toContain("and 35 more");
+    expect(warning).not.toContain("src/f39.ts");
+  });
+});

--- a/mcp/test/serveTokens.test.ts
+++ b/mcp/test/serveTokens.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  bearerFromAuthHeader,
+  loadServeTokens,
+  matchServeToken,
+  parseServeTokens,
+} from "../src/serve/tokens.js";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SECRET_A = "aaaaaaaaaaaaaaaaaaaa";
+const SECRET_B = "bbbbbbbbbbbbbbbbbbbb";
+
+describe("parseServeTokens", () => {
+  it("parses name:token as read-only and name:token:write as write-capable", () => {
+    const { tokens, errors } = parseServeTokens(`reader:${SECRET_A}, writer:${SECRET_B}:write`);
+    expect(errors).toEqual([]);
+    expect(tokens).toEqual([
+      { name: "reader", token: SECRET_A, write: false },
+      { name: "writer", token: SECRET_B, write: true },
+    ]);
+  });
+
+  it("accepts newline- and whitespace-separated entries (env file / TOML paste)", () => {
+    const { tokens } = parseServeTokens(`  reader:${SECRET_A}\n\twriter:${SECRET_B}:write  `);
+    expect(tokens.map((t) => t.name)).toEqual(["reader", "writer"]);
+  });
+
+  it("drops a secret shorter than the minimum without granting it", () => {
+    const { tokens, errors } = parseServeTokens("weak:short");
+    expect(tokens).toEqual([]);
+    expect(errors.join(" ")).toContain("shorter than");
+  });
+
+  it("never leaks a secret into the error strings", () => {
+    const { errors } = parseServeTokens(`bad name:${SECRET_A}:oops`);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.join(" ")).not.toContain(SECRET_A);
+  });
+
+  it("refuses a capability field other than the literal `write`", () => {
+    const { tokens, errors } = parseServeTokens(`x:${SECRET_A}:admin`);
+    expect(tokens).toEqual([]);
+    expect(errors.join(" ")).toContain('must be "write"');
+  });
+
+  it("rejects a name with characters that could escape a file path", () => {
+    const { tokens, errors } = parseServeTokens(`../../etc:${SECRET_A}`);
+    expect(tokens).toEqual([]);
+    expect(errors.join(" ")).toContain("name must be");
+  });
+
+  it("drops duplicate names and duplicate secrets (identity must be unambiguous)", () => {
+    const dup = parseServeTokens(`a:${SECRET_A} a:${SECRET_B}`);
+    expect(dup.tokens.map((t) => t.name)).toEqual(["a"]);
+    expect(dup.errors.join(" ")).toContain("duplicate token name");
+
+    const shared = parseServeTokens(`a:${SECRET_A} b:${SECRET_A}`);
+    expect(shared.tokens.map((t) => t.name)).toEqual(["a"]);
+    expect(shared.errors.join(" ")).toContain("already used by another name");
+  });
+
+  it("returns nothing for an empty spec", () => {
+    expect(parseServeTokens("   ")).toEqual({ tokens: [], errors: [] });
+  });
+});
+
+describe("bearerFromAuthHeader", () => {
+  it("extracts the credential, case-insensitively on the scheme", () => {
+    expect(bearerFromAuthHeader(`Bearer ${SECRET_A}`)).toBe(SECRET_A);
+    expect(bearerFromAuthHeader(`bearer ${SECRET_A}`)).toBe(SECRET_A);
+  });
+  it("returns null for missing, non-Bearer, or empty values", () => {
+    expect(bearerFromAuthHeader(undefined)).toBeNull();
+    expect(bearerFromAuthHeader(`Basic ${SECRET_A}`)).toBeNull();
+    expect(bearerFromAuthHeader("Bearer   ")).toBeNull();
+  });
+});
+
+describe("matchServeToken", () => {
+  const tokens = parseServeTokens(`reader:${SECRET_A}, writer:${SECRET_B}:write`).tokens;
+
+  it("matches the right token and reports its capability", () => {
+    expect(matchServeToken(tokens, SECRET_B)).toEqual({
+      name: "writer",
+      token: SECRET_B,
+      write: true,
+    });
+  });
+  it("returns null for a wrong or absent credential", () => {
+    expect(matchServeToken(tokens, "cccccccccccccccccccc")).toBeNull();
+    expect(matchServeToken(tokens, null)).toBeNull();
+    // A prefix of a real secret must not match.
+    expect(matchServeToken(tokens, SECRET_A.slice(0, 10))).toBeNull();
+  });
+});
+
+describe("loadServeTokens", () => {
+  it("prefers REPOSKEIN_SERVE_TOKENS over the committed config.toml", () => {
+    const dir = mkdtempSync(join(tmpdir(), "reposkein-serve-tokens-"));
+    try {
+      mkdirSync(join(dir, ".reposkein"), { recursive: true });
+      writeFileSync(
+        join(dir, ".reposkein", "config.toml"),
+        `[serve]\ntokens = "fromconfig:${SECRET_A}"\n`
+      );
+      const both = loadServeTokens(dir, { REPOSKEIN_SERVE_TOKENS: `fromenv:${SECRET_B}` });
+      expect(both.source).toBe("env");
+      expect(both.tokens.map((t) => t.name)).toEqual(["fromenv"]);
+
+      const configOnly = loadServeTokens(dir, {});
+      expect(configOnly.source).toBe("config");
+      expect(configOnly.tokens.map((t) => t.name)).toEqual(["fromconfig"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports source \"none\" when nothing is configured (serve then refuses to start)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "reposkein-serve-tokens-"));
+    try {
+      expect(loadServeTokens(dir, {})).toEqual({ tokens: [], errors: [], source: "none" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/mcp/test/serveTransport.int.test.ts
+++ b/mcp/test/serveTransport.int.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { createServeApp, MCP_PATH, type ServeApp } from "../src/serve/serve.js";
+import { makeViewHandler } from "../src/cli/view.js";
+import { parseServeTokens } from "../src/serve/tokens.js";
+
+/** Integration in the REAL-SOCKET sense: a live HTTP server, the SDK's own
+ *  Streamable HTTP client, and the actual `/api/*` handler. Unlike this
+ *  package's other `*.int.test.ts` suites it needs NO external infra (no
+ *  Neo4j, no indexer binary, loopback only), so it always runs. */
+
+const REPO_ID = "servetest";
+const READ_TOKEN = "read-token-0123456789";
+const WRITE_TOKEN = "write-token-0123456789";
+const TOKENS = parseServeTokens(
+  `reader:${READ_TOKEN}, ci-writer:${WRITE_TOKEN}:write`
+).tokens;
+
+const NODES = [
+  `{"id":"rs1:servetest:file:svc.py","labels":["File"],"content_hash":"hf","name":"svc.py","path":"svc.py"}`,
+  `{"id":"rs1:servetest:func:svc.py#Svc.run@1","labels":["Function"],"content_hash":"hr","end_line":4,"file_path":"svc.py","name":"run","qualified_name":"Svc.run","start_line":2}`,
+  `{"id":"rs1:servetest:func:base.py#helper@0","labels":["Function"],"content_hash":"hh","end_line":2,"file_path":"base.py","name":"helper","qualified_name":"helper","start_line":1}`,
+].join("\n") + "\n";
+
+const EDGES =
+  `{"from":"rs1:servetest:func:svc.py#Svc.run@1","type":"CALLS","to":"rs1:servetest:func:base.py#helper@0","call_sites":1,"confidence":1.0,"resolution":"exact"}\n`;
+
+function writeRepo(root: string, repoId: string): void {
+  const dir = join(root, ".reposkein");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "meta.json"), JSON.stringify({ repo_id: repoId, schema_version: 1 }));
+  writeFileSync(join(dir, "nodes.jsonl"), NODES.replaceAll("servetest", repoId));
+  writeFileSync(join(dir, "edges.jsonl"), EDGES.replaceAll("servetest", repoId));
+  writeFileSync(join(root, "svc.py"), "class Svc:\n    def run(self):\n        return helper()\n");
+}
+
+async function listen(handler: Parameters<typeof createServer>[0]): Promise<{ server: Server; base: string }> {
+  const server = createServer(handler);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  return { server, base: `http://127.0.0.1:${port}` };
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((r) => server.close(() => r()));
+}
+
+/** Connects an MCP client over Streamable HTTP with a bearer token. */
+async function connect(base: string, token: string): Promise<Client> {
+  const client = new Client({ name: "serve-test", version: "0.0.0" });
+  await client.connect(
+    new StreamableHTTPClientTransport(new URL(base + MCP_PATH), {
+      requestInit: { headers: { Authorization: `Bearer ${token}` } },
+    })
+  );
+  return client;
+}
+
+function textOf(result: { content?: unknown }): string {
+  const content = result.content as Array<{ type: string; text?: string }> | undefined;
+  return content?.[0]?.text ?? "";
+}
+
+describe("serve --http — auth", () => {
+  let root: string;
+  let app: ServeApp;
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    root = mkdtempSync(join(tmpdir(), "reposkein-serve-auth-"));
+    writeRepo(root, REPO_ID);
+    app = createServeApp({ repoPath: root, repoId: REPO_ID, tokens: TOKENS, log: () => {} });
+    ({ server, base } = await listen(app.handler));
+  });
+  afterAll(async () => {
+    await app.close();
+    await close(server);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("401s an unauthenticated MCP request and names the scheme", async () => {
+    const res = await fetch(base + MCP_PATH, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toContain("Bearer");
+    expect(await res.json()).toMatchObject({ error: "unauthorized" });
+  });
+
+  it("401s a wrong token", async () => {
+    const res = await fetch(base + MCP_PATH, {
+      method: "POST",
+      headers: { Authorization: "Bearer not-the-token-1234567", "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("401s /api/* without a token and 200s with one", async () => {
+    const anon = await fetch(base + "/api/graph");
+    expect(anon.status).toBe(401);
+
+    const authed = await fetch(base + "/api/graph", {
+      headers: { Authorization: `Bearer ${READ_TOKEN}` },
+    });
+    expect(authed.status).toBe(200);
+    const manifest = (await authed.json()) as { root: { repoId: string }; counts: { nodes: number } };
+    expect(manifest.root.repoId).toBe(REPO_ID);
+    expect(manifest.counts.nodes).toBe(3);
+  });
+
+  it("accepts a browser's one-time ?token= handshake and hands back a cookie", async () => {
+    const res = await fetch(base + "/?token=" + encodeURIComponent(READ_TOKEN), {
+      redirect: "manual",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/");
+    const cookie = res.headers.get("set-cookie") ?? "";
+    expect(cookie).toContain("reposkein_token=");
+    expect(cookie).toContain("HttpOnly");
+
+    // The cookie then authenticates /api/* like a header would.
+    const withCookie = await fetch(base + "/api/graph", {
+      headers: { Cookie: `reposkein_token=${encodeURIComponent(READ_TOKEN)}` },
+    });
+    expect(withCookie.status).toBe(200);
+  });
+
+  it("does NOT accept ?token= on the MCP endpoint (header only)", async () => {
+    const res = await fetch(base + MCP_PATH + "?token=" + encodeURIComponent(WRITE_TOKEN), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("serve --http — read-only vs write tokens", () => {
+  let root: string;
+  let app: ServeApp;
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    root = mkdtempSync(join(tmpdir(), "reposkein-serve-caps-"));
+    writeRepo(root, REPO_ID);
+    app = createServeApp({ repoPath: root, repoId: REPO_ID, tokens: TOKENS, log: () => {} });
+    ({ server, base } = await listen(app.handler));
+  });
+  afterAll(async () => {
+    await app.close();
+    await close(server);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("serves read tools to a read-only token", async () => {
+    const client = await connect(base, READ_TOKEN);
+    try {
+      const tools = await client.listTools();
+      const names = tools.tools.map((t) => t.name);
+      expect(names).toContain("semantic_find");
+      expect(names).toContain("get_context_profile");
+      expect(names).toContain("list_decisions");
+
+      const res = await client.callTool({ name: "semantic_find", arguments: { query: "helper" } });
+      expect(res.isError).toBeFalsy();
+      expect(textOf(res)).toContain("helper");
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("refuses a write tool from a read-only token with a structured error, changing nothing", async () => {
+    const client = await connect(base, READ_TOKEN);
+    try {
+      const listed = await client.listTools();
+      const summaryTool = listed.tools.find((t) => t.name === "write_semantic_summary");
+      // Listed, but honest about what will happen.
+      expect(summaryTool?.description).toContain("read-only");
+
+      const res = await client.callTool({
+        name: "write_semantic_summary",
+        arguments: { node_id: "rs1:servetest:func:base.py#helper@0", summary: "Nope." },
+      });
+      expect(res.isError).toBe(true);
+      expect(JSON.parse(textOf(res))).toMatchObject({
+        error: "write_capability_required",
+        tool: "write_semantic_summary",
+        required_capability: "write",
+        identity: "reader",
+      });
+      // Nothing was written for this identity.
+      expect(existsSync(join(root, ".reposkein", "local", "summaries-reader.jsonl"))).toBe(false);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("lets a write token write, and attributes the record to the token's name", async () => {
+    const client = await connect(base, WRITE_TOKEN);
+    try {
+      const res = await client.callTool({
+        name: "write_semantic_summary",
+        arguments: {
+          node_id: "rs1:servetest:func:base.py#helper@0",
+          summary: "Shared helper used by the service entry point.",
+          model: "test-model",
+        },
+      });
+      expect(res.isError).toBeFalsy();
+      expect(JSON.parse(textOf(res))).toMatchObject({ ok: true });
+
+      // Attribution: the sidecar is per-writer and stamped with the token name,
+      // NOT the anonymous "agent" default.
+      const sidecar = join(root, ".reposkein", "local", "summaries-ci-writer.jsonl");
+      const record = JSON.parse(readFileSync(sidecar, "utf8").trim().split("\n")[0]!);
+      expect(record).toMatchObject({
+        id: "rs1:servetest:func:base.py#helper@0",
+        semantic_summary: "Shared helper used by the service entry point.",
+        summary_by: "ci-writer",
+        summary_model: "test-model",
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("rejects a session id presented by a different token", async () => {
+    const client = await connect(base, WRITE_TOKEN);
+    try {
+      const transport = (client as unknown as { transport: { sessionId?: string } }).transport;
+      const sessionId = transport.sessionId;
+      expect(sessionId).toBeTruthy();
+      const res = await fetch(base + MCP_PATH, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${READ_TOKEN}`,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          "Mcp-Session-Id": sessionId!,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 99, method: "tools/list", params: {} }),
+      });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: "session_token_mismatch" });
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+describe("serve --http — per-connection session isolation", () => {
+  let root: string;
+  let repoA: string;
+  let repoB: string;
+  let app: ServeApp;
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    // A workspace: two sibling repos, no repo at the root — the exact shape
+    // `select_repo` exists for, and the one where a process-global session
+    // would let one caller move another caller's active repo.
+    root = mkdtempSync(join(tmpdir(), "reposkein-serve-iso-"));
+    repoA = join(root, "alpha");
+    repoB = join(root, "beta");
+    mkdirSync(repoA);
+    mkdirSync(repoB);
+    writeRepo(repoA, "alpharepo");
+    writeRepo(repoB, "betarepo");
+    app = createServeApp({
+      repoPath: root,
+      repoId: "workspace",
+      tokens: TOKENS,
+      log: () => {},
+      // The root isn't a repo; the viewer surface is not what this suite tests.
+      viewHandlerFactory: () => (_req, res) => {
+        res.writeHead(404);
+        res.end();
+      },
+    });
+    ({ server, base } = await listen(app.handler));
+  });
+  afterAll(async () => {
+    await app.close();
+    await close(server);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("keeps two connections' select_repo choices independent", async () => {
+    const one = await connect(base, WRITE_TOKEN);
+    const two = await connect(base, WRITE_TOKEN);
+    try {
+      expect(app.sessionCount()).toBe(2);
+
+      const selA = await one.callTool({ name: "select_repo", arguments: { repo: repoA } });
+      expect(JSON.parse(textOf(selA))).toMatchObject({ ok: true });
+      const selB = await two.callTool({ name: "select_repo", arguments: { repo: repoB } });
+      expect(JSON.parse(textOf(selB))).toMatchObject({ ok: true });
+
+      const selectedIn = async (c: Client): Promise<string | undefined> => {
+        const listed = await c.callTool({ name: "list_repos", arguments: {} });
+        const parsed = JSON.parse(textOf(listed)) as {
+          repos: { path: string; selected: boolean }[];
+        };
+        return parsed.repos.find((r) => r.selected)?.path;
+      };
+
+      // Connection one still sees alpha even though two moved to beta.
+      expect(await selectedIn(one)).toBe(repoA);
+      expect(await selectedIn(two)).toBe(repoB);
+
+      // And the graph each one reads follows its own selection.
+      const fromOne = await one.callTool({ name: "semantic_find", arguments: { query: "helper" } });
+      expect(textOf(fromOne)).toContain("alpharepo");
+      expect(textOf(fromOne)).not.toContain("betarepo");
+      const fromTwo = await two.callTool({ name: "semantic_find", arguments: { query: "helper" } });
+      expect(textOf(fromTwo)).toContain("betarepo");
+    } finally {
+      await one.close();
+      await two.close();
+    }
+  });
+});
+
+describe("serve --http — /api/* parity with `view`", () => {
+  let root: string;
+  let app: ServeApp;
+  let serveServer: Server;
+  let viewServer: Server;
+  let serveBase: string;
+  let viewBase: string;
+
+  beforeAll(async () => {
+    root = mkdtempSync(join(tmpdir(), "reposkein-serve-parity-"));
+    writeRepo(root, REPO_ID);
+    app = createServeApp({ repoPath: root, repoId: REPO_ID, tokens: TOKENS, log: () => {} });
+    ({ server: serveServer, base: serveBase } = await listen(app.handler));
+    // The other side of the comparison is literally what `reposkein-mcp view`
+    // serves: makeViewHandler, unwrapped.
+    ({ server: viewServer, base: viewBase } = await listen(makeViewHandler(root, REPO_ID)));
+  });
+  afterAll(async () => {
+    await app.close();
+    await close(serveServer);
+    await close(viewServer);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const authed = (path: string): Promise<Response> =>
+    fetch(serveBase + path, { headers: { Authorization: `Bearer ${READ_TOKEN}` } });
+
+  it("returns the same /api/graph manifest (modulo the per-handler build time)", async () => {
+    const a = (await (await authed("/api/graph")).json()) as Record<string, unknown>;
+    const b = (await (await fetch(viewBase + "/api/graph")).json()) as Record<string, unknown>;
+    delete (a.meta as Record<string, unknown>).builtAt;
+    delete (b.meta as Record<string, unknown>).builtAt;
+    expect(a).toEqual(b);
+  });
+
+  it("returns the same /api/jsonl/nodes.jsonl bytes", async () => {
+    const a = await (await authed("/api/jsonl/nodes.jsonl")).text();
+    const b = await (await fetch(viewBase + "/api/jsonl/nodes.jsonl")).text();
+    expect(a).toBe(b);
+    expect(a).toContain("rs1:servetest:func:base.py#helper@0");
+  });
+
+  it("returns the same /api/source slice, and keeps its traversal guard", async () => {
+    const q = "?path=svc.py&start=1&end=3";
+    const a = await (await authed("/api/source" + q)).json();
+    const b = await (await fetch(viewBase + "/api/source" + q)).json();
+    expect(a).toEqual(b);
+
+    const escape = await authed("/api/source?path=../../etc/passwd&start=1&end=1");
+    expect(escape.status).toBe(404);
+  });
+
+  it("returns the same /api/temporal payload", async () => {
+    const a = await (await authed("/api/temporal")).text();
+    const b = await (await fetch(viewBase + "/api/temporal")).text();
+    expect(a).toBe(b);
+  });
+});

--- a/mcp/test/serveTransport.int.test.ts
+++ b/mcp/test/serveTransport.int.test.ts
@@ -657,6 +657,88 @@ describe("serve --http — a read-only token never triggers an index build", () 
   });
 });
 
+describe("serve --http — a failure during initialize must not leak a session slot", () => {
+  let root: string;
+  let app: ServeApp;
+  let server: Server;
+  let base: string;
+  let clock = 1_000_000;
+
+  beforeAll(async () => {
+    root = mkdtempSync(join(tmpdir(), "reposkein-serve-initthrow-"));
+    writeRepo(root, REPO_ID);
+    app = createServeApp({
+      repoPath: root,
+      repoId: REPO_ID,
+      tokens: TOKENS,
+      maxSessions: 2,
+      idleMs: 60_000,
+      now: () => clock,
+      // The SDK `await`s onsessioninitialized WITHOUT guarding it, and our
+      // callback logs immediately AFTER registering the session with
+      // inFlight:1 — so a throwing logger is the closest reachable analogue of
+      // "everything after registration unwinds".
+      //
+      // Honest caveat: with SDK 1.30 this does NOT make `handleRequest`
+      // reject, because the Node wrapper runs the transport inside
+      // @hono/node-server's request listener, which catches and answers 500
+      // itself. So this asserts the INVARIANT (a failed initialize never
+      // leaves an unreleasable slot) rather than discriminating the
+      // finally-vs-inline diff. See the `finally` comment in serve.ts.
+      log: (m) => {
+        if (m.includes("mcp session opened")) throw new Error("simulated post-registration failure");
+      },
+    });
+    ({ server, base } = await listen(app.handler));
+  });
+  afterAll(async () => {
+    await app.close();
+    await close(server);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("leaves no session pinned in flight, and the slots stay reusable", async () => {
+    const res = await fetch(base + MCP_PATH, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${READ_TOKEN}`,
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "t", version: "0" },
+        },
+      }),
+    });
+    // However the failure surfaces to the client, the server must not be left
+    // holding an unreleasable slot.
+    expect(res.status).toBeGreaterThanOrEqual(400);
+
+    // Either the session never survived registration, or it did and its
+    // in-flight claim was released — in which case the reaper collects it.
+    clock += 120_000;
+    app.sweepIdleSessions();
+    expect(app.sessionCount()).toBe(0);
+
+    // The slot is genuinely reusable: both of maxSessions can still be filled,
+    // which also proves the reserved slot was released.
+    const a = await connect(base, READ_TOKEN).catch(() => null);
+    const b = await connect(base, READ_TOKEN).catch(() => null);
+    try {
+      expect(app.sessionCount()).toBe(2);
+    } finally {
+      await a?.close().catch(() => undefined);
+      await b?.close().catch(() => undefined);
+    }
+  });
+});
+
 describe("serve --http — /api/* parity with `view`", () => {  let root: string;
   let app: ServeApp;
   let serveServer: Server;

--- a/mcp/test/serveTransport.int.test.ts
+++ b/mcp/test/serveTransport.int.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import { createServer, type Server } from "node:http";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -127,6 +127,9 @@ describe("serve --http — auth", () => {
     const cookie = res.headers.get("set-cookie") ?? "";
     expect(cookie).toContain("reposkein_token=");
     expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=Strict");
+    // Plain HTTP: `Secure` would make the browser discard the cookie outright.
+    expect(cookie).not.toContain("Secure");
 
     // The cookie then authenticates /api/* like a header would.
     const withCookie = await fetch(base + "/api/graph", {
@@ -142,6 +145,15 @@ describe("serve --http — auth", () => {
       body: "{}",
     });
     expect(res.status).toBe(401);
+  });
+
+  it("marks the cookie Secure behind an https-terminating proxy", async () => {
+    const res = await fetch(base + "/?token=" + encodeURIComponent(READ_TOKEN), {
+      redirect: "manual",
+      headers: { "X-Forwarded-Proto": "https, http" },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("set-cookie")).toContain("Secure");
   });
 });
 
@@ -257,6 +269,40 @@ describe("serve --http — read-only vs write tokens", () => {
       await client.close();
     }
   });
+
+  it("405s a standalone GET stream (no server-initiated notifications)", async () => {
+    const res = await fetch(base + MCP_PATH, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${READ_TOKEN}`, Accept: "text/event-stream" },
+    });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("POST, DELETE");
+    expect(await res.json()).toMatchObject({ error: "sse_stream_not_supported" });
+  });
+
+  it("400s an empty POST body on an established session", async () => {
+    const client = await connect(base, WRITE_TOKEN);
+    try {
+      const sessionId = (client as unknown as { transport: { sessionId?: string } }).transport
+        .sessionId;
+      const res = await fetch(base + MCP_PATH, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${WRITE_TOKEN}`,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          "Mcp-Session-Id": sessionId!,
+        },
+        body: "",
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; detail: string };
+      expect(body.error).toBe("bad_request");
+      expect(body.detail).toContain("Empty POST body");
+    } finally {
+      await client.close();
+    }
+  });
 });
 
 describe("serve --http — per-connection session isolation", () => {
@@ -333,8 +379,285 @@ describe("serve --http — per-connection session isolation", () => {
   });
 });
 
-describe("serve --http — /api/* parity with `view`", () => {
+describe("serve --http — session reaping", () => {
   let root: string;
+  let app: ServeApp;
+  let server: Server;
+  let base: string;
+  let clock: number;
+
+  beforeAll(async () => {
+    root = mkdtempSync(join(tmpdir(), "reposkein-serve-reap-"));
+    writeRepo(root, REPO_ID);
+  });
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  beforeEach(async () => {
+    clock = 1_000_000;
+    app = createServeApp({
+      repoPath: root,
+      repoId: REPO_ID,
+      tokens: TOKENS,
+      log: () => {},
+      maxSessions: 2,
+      idleMs: 60_000,
+      now: () => clock,
+    });
+    ({ server, base } = await listen(app.handler));
+  });
+  afterEach(async () => {
+    await app.close();
+    await close(server);
+  });
+
+  it("reaps a session idle past the threshold; its id then 404s", async () => {
+    const client = await connect(base, READ_TOKEN);
+    const sessionId = (client as unknown as { transport: { sessionId?: string } }).transport
+      .sessionId;
+    expect(app.sessionCount()).toBe(1);
+
+    // Not yet idle.
+    clock += 59_000;
+    expect(app.sweepIdleSessions()).toBe(0);
+    expect(app.sessionCount()).toBe(1);
+
+    clock += 2_000;
+    expect(app.sweepIdleSessions()).toBe(1);
+    expect(app.sessionCount()).toBe(0);
+
+    const res = await fetch(base + MCP_PATH, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${READ_TOKEN}`,
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": sessionId!,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "session_not_found" });
+    await client.close().catch(() => undefined);
+  });
+
+  it("an active client is never reaped (each request re-stamps it)", async () => {
+    const client = await connect(base, READ_TOKEN);
+    try {
+      clock += 59_000;
+      await client.listTools(); // touches the session at the new clock
+      clock += 30_000; // past idleMs since CONNECT, but not since that call
+      expect(app.sweepIdleSessions()).toBe(0);
+      expect(app.sessionCount()).toBe(1);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("frees the cap by reaping, so the next connect after eviction succeeds", async () => {
+    const a = await connect(base, READ_TOKEN);
+    const b = await connect(base, READ_TOKEN);
+    expect(app.sessionCount()).toBe(2); // maxSessions
+
+    // A third while both are live: refused, and the refusal is legible.
+    const refused = await fetch(base + MCP_PATH, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${READ_TOKEN}`,
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "t", version: "0" },
+        },
+      }),
+    });
+    expect(refused.status).toBe(503);
+    expect(await refused.json()).toMatchObject({ error: "too_many_sessions" });
+
+    // Both go idle. The next initialize sweeps them itself — no operator
+    // action, no timer — and is admitted.
+    clock += 120_000;
+    const third = await connect(base, READ_TOKEN);
+    try {
+      expect(app.sessionCount()).toBe(1);
+      expect((await third.listTools()).tools.length).toBeGreaterThan(0);
+    } finally {
+      await third.close();
+      await a.close().catch(() => undefined);
+      await b.close().catch(() => undefined);
+    }
+  });
+});
+
+describe("serve --http — the reaper never kills an in-flight request", () => {
+  let root: string;
+  let app: ServeApp;
+  let server: Server;
+  let base: string;
+  let clock = 1_000_000;
+  /** Resolved by the test to let the blocked tool call finish. */
+  let release: () => void;
+  let entered: Promise<void>;
+
+  beforeAll(async () => {
+    root = mkdtempSync(join(tmpdir(), "reposkein-serve-inflight-"));
+    writeRepo(root, REPO_ID);
+    let signalEntered!: () => void;
+    entered = new Promise<void>((r) => (signalEntered = r));
+    const gate = new Promise<void>((r) => (release = r));
+    app = createServeApp({
+      repoPath: root,
+      repoId: REPO_ID,
+      tokens: TOKENS,
+      log: () => {},
+      idleMs: 60_000,
+      now: () => clock,
+      // The first repo-scoped tool call on a write-capable connection goes
+      // through ensureGraph; blocking there gives a deterministic in-flight
+      // request without needing a slow tool.
+      ensureGraph: async () => {
+        signalEntered();
+        await gate;
+        return "present";
+      },
+    });
+    ({ server, base } = await listen(app.handler));
+  });
+  afterAll(async () => {
+    await app.close();
+    await close(server);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("skips a session with a request in flight, and that request still completes", async () => {
+    const client = await connect(base, WRITE_TOKEN);
+    try {
+      const pending = client.callTool({
+        name: "get_context_profile",
+        arguments: { name: "helper" },
+      });
+      await entered; // the handler is now inside ensureGraph
+
+      // Push the clock far past the idle window while the call is blocked.
+      clock += 600_000;
+      expect(app.sweepIdleSessions()).toBe(0);
+      expect(app.sessionCount()).toBe(1);
+
+      release();
+      const res = await pending;
+      expect(res.isError).toBeFalsy();
+      expect(textOf(res)).toContain("helper");
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+describe("serve --http — a read-only token never triggers an index build", () => {
+  let root: string;
+  let indexedRepo: string;
+  let unbuiltRepo: string;
+  let ensureGraphCalls: string[];
+  let app: ServeApp;
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    // A workspace with one built repo and one that has meta.json but no
+    // nodes.jsonl — exactly a fresh clone, and exactly what would have made
+    // the old code spawn an indexer on first touch.
+    root = mkdtempSync(join(tmpdir(), "reposkein-serve-build-gate-"));
+    indexedRepo = join(root, "built");
+    unbuiltRepo = join(root, "unbuilt");
+    mkdirSync(indexedRepo);
+    mkdirSync(unbuiltRepo);
+    writeRepo(indexedRepo, "builtrepo");
+    mkdirSync(join(unbuiltRepo, ".reposkein"), { recursive: true });
+    writeFileSync(
+      join(unbuiltRepo, ".reposkein", "meta.json"),
+      JSON.stringify({ repo_id: "unbuiltrepo", schema_version: 1 })
+    );
+
+    ensureGraphCalls = [];
+    app = createServeApp({
+      repoPath: root,
+      repoId: "workspace",
+      tokens: TOKENS,
+      log: () => {},
+      viewHandlerFactory: () => (_req, res) => {
+        res.writeHead(404);
+        res.end();
+      },
+      ensureGraph: async (path) => {
+        ensureGraphCalls.push(String(path));
+        return "skipped";
+      },
+    });
+    ({ server, base } = await listen(app.handler));
+  });
+  afterAll(async () => {
+    await app.close();
+    await close(server);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("refuses with a build-free explanation and never reaches ensureGraph", async () => {
+    ensureGraphCalls.length = 0;
+    const client = await connect(base, READ_TOKEN);
+    try {
+      await client.callTool({ name: "select_repo", arguments: { repo: unbuiltRepo } });
+      const res = await client.callTool({
+        name: "get_context_profile",
+        arguments: { name: "helper" },
+      });
+      expect(res.isError).toBe(true);
+      const text = textOf(res);
+      expect(text).toContain("read-only");
+      expect(text).toContain(`reposkein-mcp index ${unbuiltRepo}`);
+      expect(text).toContain("Nothing was changed");
+      // The point: no build was even attempted.
+      expect(ensureGraphCalls).toEqual([]);
+      // And nothing appeared on disk.
+      expect(existsSync(join(unbuiltRepo, ".reposkein", "nodes.jsonl"))).toBe(false);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("still serves a read-only token from a repo that IS built, with no build", async () => {
+    ensureGraphCalls.length = 0;
+    const client = await connect(base, READ_TOKEN);
+    try {
+      await client.callTool({ name: "select_repo", arguments: { repo: indexedRepo } });
+      const res = await client.callTool({ name: "semantic_find", arguments: { query: "helper" } });
+      expect(res.isError).toBeFalsy();
+      expect(textOf(res)).toContain("builtrepo");
+      expect(ensureGraphCalls).toEqual([]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("a write-capable token DOES get the build attempt for the same repo", async () => {
+    ensureGraphCalls.length = 0;
+    const client = await connect(base, WRITE_TOKEN);
+    try {
+      await client.callTool({ name: "select_repo", arguments: { repo: unbuiltRepo } });
+      await client.callTool({ name: "get_context_profile", arguments: { name: "helper" } });
+      expect(ensureGraphCalls).toEqual([unbuiltRepo]);
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+describe("serve --http — /api/* parity with `view`", () => {  let root: string;
   let app: ServeApp;
   let serveServer: Server;
   let viewServer: Server;

--- a/mcp/test/serveWatch.test.ts
+++ b/mcp/test/serveWatch.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { startHeadWatcher, watchTick, type WatchDeps } from "../src/serve/watch.js";
+import { parseServeArgs } from "../src/serve/serve.js";
+
+/** A fake checkout: HEAD moves when the test says so, and `reindex` advances
+ *  the indexed-at marker exactly the way the real one does (it writes the
+ *  marker from HEAD), so idempotence is tested against the real contract. */
+function fakeRepo(head: string | null, indexed: string | null) {
+  const state = { head, indexed, reindexes: 0, fail: false as boolean };
+  const logs: string[] = [];
+  const deps: WatchDeps = {
+    headSha: () => state.head,
+    indexedSha: () => state.indexed,
+    reindex: async () => {
+      state.reindexes++;
+      if (state.fail) return { ok: false, error: "indexer exploded" };
+      state.indexed = state.head;
+      return { ok: true, nodes: 7, edges: 3 };
+    },
+    log: (m) => logs.push(m),
+  };
+  return { state, logs, deps };
+}
+
+describe("watchTick — idempotence", () => {
+  it("does no work when HEAD already equals the indexed-at marker", async () => {
+    const { state, logs, deps } = fakeRepo("a".repeat(40), "a".repeat(40));
+    expect(await watchTick(deps)).toBe("unchanged");
+    expect(state.reindexes).toBe(0);
+    expect(logs).toEqual([]);
+  });
+
+  it("re-indexes exactly once for a new HEAD, then goes quiet", async () => {
+    const { state, logs, deps } = fakeRepo("b".repeat(40), "a".repeat(40));
+    expect(await watchTick(deps)).toBe("reindexed");
+    expect(state.reindexes).toBe(1);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("reindexed at HEAD bbbbbbbbbbbb");
+    expect(logs[0]).toContain("7 nodes, 3 edges");
+
+    expect(await watchTick(deps)).toBe("unchanged");
+    expect(state.reindexes).toBe(1);
+    expect(logs).toHaveLength(1);
+  });
+
+  it("treats a never-indexed checkout (no marker) as needing one index", async () => {
+    const { state, deps } = fakeRepo("c".repeat(40), null);
+    expect(await watchTick(deps)).toBe("reindexed");
+    expect(state.reindexes).toBe(1);
+    expect(await watchTick(deps)).toBe("unchanged");
+  });
+
+  it("keeps serving the old graph on failure and retries on the next tick", async () => {
+    const { state, logs, deps } = fakeRepo("d".repeat(40), "a".repeat(40));
+    state.fail = true;
+    expect(await watchTick(deps)).toBe("failed");
+    expect(logs[0]).toContain("FAILED");
+    expect(logs[0]).toContain("indexer exploded");
+    // The marker was NOT advanced, so the next tick tries again.
+    state.fail = false;
+    expect(await watchTick(deps)).toBe("reindexed");
+    expect(state.reindexes).toBe(2);
+  });
+
+  it("does nothing when the served directory has no git HEAD", async () => {
+    const { state, deps } = fakeRepo(null, null);
+    expect(await watchTick(deps)).toBe("no-head");
+    expect(state.reindexes).toBe(0);
+  });
+});
+
+describe("startHeadWatcher", () => {
+  it("polls, fires onReindexed once, and stops cleanly", async () => {
+    const { state, deps } = fakeRepo("e".repeat(40), "a".repeat(40));
+    let refreshes = 0;
+    const watcher = startHeadWatcher("/nonexistent", "repo", {
+      intervalMs: 5,
+      deps,
+      onReindexed: () => refreshes++,
+    });
+    try {
+      await vi.waitFor(() => expect(state.reindexes).toBe(1), { timeout: 2000 });
+      await vi.waitFor(() => expect(refreshes).toBe(1), { timeout: 2000 });
+    } finally {
+      watcher.stop();
+    }
+    const after = state.reindexes;
+    await new Promise((r) => setTimeout(r, 40));
+    // Stopped means stopped: HEAD is unchanged now anyway, but the point is
+    // that no further ticks run at all.
+    expect(state.reindexes).toBe(after);
+  });
+
+  it("with intervalMs 0 never polls, but a manual tick still works", async () => {
+    const { state, deps } = fakeRepo("f".repeat(40), "a".repeat(40));
+    const watcher = startHeadWatcher("/nonexistent", "repo", { intervalMs: 0, deps });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(state.reindexes).toBe(0);
+    expect(await watcher.tick()).toBe("reindexed");
+    watcher.stop();
+  });
+});
+
+describe("parseServeArgs", () => {
+  it("defaults to loopback, no --http, and a 30s poll", () => {
+    const { repoPath, opts, http } = parseServeArgs([]);
+    expect(http).toBe(false);
+    expect(opts).toEqual({ port: 4318, host: "127.0.0.1", watchIntervalMs: 30_000 });
+    expect(repoPath).toBe(process.env.REPOSKEIN_REPO_PATH ?? ".");
+  });
+
+  it("parses --http, both flag spellings, and seconds-to-ms for the interval", () => {
+    const a = parseServeArgs(["--http", "--port", "9000", "--host", "0.0.0.0", "--watch-interval", "5", "/repo"]);
+    expect(a.http).toBe(true);
+    expect(a.opts).toEqual({ port: 9000, host: "0.0.0.0", watchIntervalMs: 5000 });
+    expect(a.repoPath).toBe("/repo");
+
+    const b = parseServeArgs(["--http", "--port=9001", "--host=1.2.3.4", "--watch-interval=0"]);
+    expect(b.opts).toEqual({ port: 9001, host: "1.2.3.4", watchIntervalMs: 0 });
+  });
+
+  it("falls back to defaults for garbage numeric flags rather than NaN", () => {
+    const { opts } = parseServeArgs(["--port", "notanumber", "--watch-interval", "-3"]);
+    expect(opts.port).toBe(4318);
+    expect(opts.watchIntervalMs).toBe(30_000);
+  });
+});

--- a/mcp/test/serveWatch.test.ts
+++ b/mcp/test/serveWatch.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
 import { startHeadWatcher, watchTick, type WatchDeps } from "../src/serve/watch.js";
 import { parseServeArgs } from "../src/serve/serve.js";
+import { withIndexLock } from "../src/indexer/indexLock.js";
 
 /** A fake checkout: HEAD moves when the test says so, and `reindex` advances
  *  the indexed-at marker exactly the way the real one does (it writes the
  *  marker from HEAD), so idempotence is tested against the real contract. */
 function fakeRepo(head: string | null, indexed: string | null) {
-  const state = { head, indexed, reindexes: 0, fail: false as boolean };
+  const state = { head, indexed, reindexes: 0, fail: false as boolean, busy: false as boolean };
   const logs: string[] = [];
   const deps: WatchDeps = {
     headSha: () => state.head,
@@ -18,6 +19,7 @@ function fakeRepo(head: string | null, indexed: string | null) {
       return { ok: true, nodes: 7, edges: 3 };
     },
     log: (m) => logs.push(m),
+    indexBusy: () => state.busy,
   };
   return { state, logs, deps };
 }
@@ -66,6 +68,45 @@ describe("watchTick — idempotence", () => {
     const { state, deps } = fakeRepo(null, null);
     expect(await watchTick(deps)).toBe("no-head");
     expect(state.reindexes).toBe(0);
+  });
+
+  it("SKIPS (does not queue) while another indexer run holds the lock", async () => {
+    const { state, logs, deps } = fakeRepo("f".repeat(40), "a".repeat(40));
+    state.busy = true;
+    expect(await watchTick(deps)).toBe("locked");
+    expect(state.reindexes).toBe(0);
+    // Skipping must be silent: a busy server would otherwise log a line per
+    // tick for as long as a big index runs.
+    expect(logs).toEqual([]);
+    // Released → the very next tick does the work.
+    state.busy = false;
+    expect(await watchTick(deps)).toBe("reindexed");
+    expect(state.reindexes).toBe(1);
+  });
+
+  it("checks the lock only AFTER deciding work is needed (no spurious skip)", async () => {
+    // HEAD already indexed: a held lock is irrelevant, the answer is still
+    // "unchanged" — otherwise a long index would mask a genuinely quiet repo.
+    const { deps, state } = fakeRepo("a".repeat(40), "a".repeat(40));
+    state.busy = true;
+    expect(await watchTick(deps)).toBe("unchanged");
+  });
+
+  it("defaults indexBusy to the real process-wide index lock", async () => {
+    const { state, deps } = fakeRepo("b".repeat(40), "a".repeat(40));
+    const watcher = startHeadWatcher("/nonexistent", "repo", {
+      intervalMs: 0,
+      // Everything injected EXCEPT indexBusy, which must fall back to the lock.
+      deps: { headSha: deps.headSha, indexedSha: deps.indexedSha, reindex: deps.reindex, log: deps.log },
+    });
+    try {
+      const outcome = await withIndexLock(async () => watcher.tick());
+      expect(outcome).toBe("locked");
+      expect(state.reindexes).toBe(0);
+      expect(await watcher.tick()).toBe("reindexed");
+    } finally {
+      watcher.stop();
+    }
   });
 });
 


### PR DESCRIPTION
The final task of the team-access plan: an **optional** shared remote MCP server, so a team can point agents and browsers at one always-fresh graph. ADR-first as gated — `4cb67e4` lifts the PRD's hosted/multi-user non-goal with explicit scope boundaries before any code.

## What changed
- **`reposkein-mcp serve --http`**: MCP Streamable HTTP transport + the full viewer + the same `/api/*` endpoints as `view`, one process, one handler factory (viewer and MCP agree by construction).
- **Bearer auth**: `name:token[:write]` pairs from config/env; sha256-normalized timing-safe comparison; tokens never logged; every route gated; browser access via a one-shot `?token=` immediately traded for an `HttpOnly; SameSite=Strict` (+`Secure` behind TLS) cookie — the MCP endpoint accepts headers only, so the cookie can't be replayed cross-site.
- **Read-only by default**: all six mutating tools are server-side gated behind a per-token `write` capability, refused with a structured, self-explaining error. **Per-token attribution**: writes land with the token's name as `summary_by`/`decided_by` — the all-authors-are-"agent" anonymity is gone (live-verified: a curl session wrote a summary attributed `marcus`). Read-only tokens can't even trigger index builds.
- **Session hygiene**: per-connection isolation (`select_repo` on one connection is invisible to another), idle-session reaper with in-flight protection, synchronous slot reservation (no cap overshoot), `finally`-guarded claim release (revert-tested defense in depth), GET SSE stream answered `405` per spec (verified against the real SDK client) after it was found to pin sessions forever.
- **Index safety under concurrency**: a reentrant process-wide mutex inside `spawnIndexer` serializes every indexer run (watcher ticks, decision pre-stamps, reindex_file) — proven with real concurrent child processes. The HEAD-watcher re-indexes once per change, idempotently, and skips held ticks.
- **Operator honesty**: startup warning on a dirty checkout (serve a deploy clone); `docs/REMOTE.md` states plainly what a token can read, that rotation needs a restart, that TLS termination is the operator's job, and every stated boundary.
- **stdio completely untouched**; zero-infra invariants and CI gates unaffected.

## Verification
mcp **769 passed / 18 skipped** (+68 over baseline; real-SDK-client integration tests for auth/capabilities/attribution/isolation/reaping) · tsc + build clean · ADR doctor-valid · **live gate**: curl end-to-end session — 401s, read-only refusal with identity, attributed write, viewer on the same port.

Linear: REP-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
