### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ All notable changes to RepoSkein. Format roughly follows
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-21
+
+### Added
+
+- **Astrolabe viewer redesign complete.** Four PRs finish the redesign begun on
+  the React 19 + R3F v9 + Tailwind-tokens foundation (#50) and the ⌘K command
+  palette (#51) shipped in 0.4.0:
+  - **Status bar + mode chips.** One persistent chrome strip replaces
+    scattered viewer chrome, with a never-null breadcrumb and mode chips
+    surfacing the active view at all times. (#53)
+  - **Inspector + summoned layers.** A single Inspector drawer and
+    on-demand summoned layers replace five legacy panels, cutting the
+    viewer's chrome surface without losing any capability. (#54)
+  - **Navigation semantics.** Layered `Esc` (undoes the most local thing
+    first), scoped collapse, view history, anchor-aware hops, and
+    URL-as-view (the URL is always a faithful, shareable snapshot of what's
+    on screen). (#55)
+  - **Polish pass.** A first-run coach mark, responsive chrome down to
+    narrow viewports, and an accessibility floor (focus order, contrast,
+    keyboard reachability) across the redesigned surface. (#56)
+
+  **Note for hosted-constellation users:** the GitHub Pages viewer deploys
+  from the released `@reposkein/mcp` package, not from `main` — this release
+  is what upgrades the deployed viewer app itself.
+
+- **Optional shared remote MCP.** `reposkein-mcp serve --http` serves the MCP
+  Streamable HTTP transport and the viewer/`/api/*` surface from one process
+  against one git checkout, so a team can share a single running instance
+  instead of each agent spawning its own local one. Strictly optional: stdio
+  stays the default, and `serve --http` refuses to start without auth —
+  `name:secret[:write]` bearer tokens via `REPOSKEIN_SERVE_TOKENS` or
+  `config.toml`, timing-safe comparison. Read-only toolset by default;
+  write capability (e.g. `record_decision`) is granted per token, and writes
+  carry the token's identity for attribution. ADR-first: the decision to
+  lift the hosted/multi-user non-goal was recorded and accepted before the
+  feature shipped. (#57)
+
 ## [0.4.0] - 2026-08-21
 
 ### Added

--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -1083,7 +1083,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reposkein-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-indexer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "reposkein-core",
  "tree-sitter",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-csharp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-go"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-java"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-python"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-rust"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-ts"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-neo4j-io"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "neo4rs",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/lang-common", "crates/cli", "crates/lang-python", "crates/lang-ts", "crates/lang-rust", "crates/lang-go", "crates/lang-java", "crates/neo4j-io", "crates/lang-csharp"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/reposkein/reposkein"

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reposkein/mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Deterministic code-graph (GraphRAG) MCP server — give your AI agent callers/callees, change-impact, and semantic search over your repo instead of grep. 7 languages, zero-infra, git-native.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Ships the complete Astrolabe viewer redesign (#50 #51 #53 #54 #55 #56) and the optional remote MCP (#57) — and, critically, upgrades the hosted-constellation viewer app itself: Pages deploys the released package, so the live demo has been showing the v0.4.0-era UI since the redesign merged.

Lockstep verified; indexer builds; core 139/139; mcp 769/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
