### PR TITLE
docs: Ko-fi support link + FUNDING.yml, palette-themed (REP-26)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: mongx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,3 +83,5 @@ Keep the viewer's invariants intact: **read-only** (never mutate the committed J
 Fork, branch, make focused commits, ensure the gates above pass, and open a PR with a clear description. For new languages or anything touching the resolver/serializer, include the determinism test results in the PR.
 
 By contributing you agree your work is licensed under [Apache-2.0](./LICENSE).
+
+**Support:** [Ko-fi](https://ko-fi.com/mongx) — funds hosted-constellation infra + indexer maintenance.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/reposkein/reposkein/ci.yml?style=for-the-badge&logo=githubactions&logoColor=EAE7DC&label=CI&labelColor=070A12&color=2DD4BF)](https://github.com/reposkein/reposkein/actions/workflows/ci.yml)
 [![release](https://img.shields.io/github/v/release/reposkein/reposkein?style=for-the-badge&logo=github&logoColor=EAE7DC&label=release&labelColor=070A12&color=2DD4BF)](https://github.com/reposkein/reposkein/releases)
 [![License](https://img.shields.io/badge/license-Apache_2.0-F2B84B?style=for-the-badge&labelColor=070A12)](./LICENSE)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-F2B84B?style=for-the-badge&logo=kofi&logoColor=EAE7DC&labelColor=070A12)](https://ko-fi.com/mongx)
 
 <sub>Listed on: [skills.sh](https://skills.sh/reposkein/reposkein) · [Glama](https://glama.ai/mcp/servers/reposkein/reposkein) · [mcpservers.org](https://mcpservers.org/servers/reposkein/reposkein) · [ghcr.io](https://github.com/reposkein/reposkein/pkgs/container/reposkein-embed)</sub>
 
@@ -61,6 +62,8 @@ git clone <repo-url> && cd <repo> && npx @reposkein/mcp init
 ```
 
 `init` detects the committed `.reposkein/meta.json`, reuses its config, and wires up your agent's MCP config automatically. Publish a durable, shareable view of the graph with a [**hosted constellation**](docs/HOSTING.md) (GitHub Pages via `reposkein-mcp init --ci`) — and because summaries are committed to git, they're **shared team memory**: every teammate's agent starts from what previous agents already learned, not from scratch.
+
+**Support:** if RepoSkein is useful, [**Ko-fi**](https://ko-fi.com/mongx) support funds hosted-constellation infrastructure and indexer maintenance — supporters get an ad-free experience once sponsorship tiers ship.
 
 ## Prerequisites
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,3 +34,5 @@ the [root README's Documentation table](../README.md#documentation).
 
 - [`../README.md`](../README.md) — the project front door.
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — dev setup, invariants, adding a language.
+
+**Support:** [Ko-fi](https://ko-fi.com/mongx) — funds hosted-constellation infra + indexer maintenance.

--- a/embed-server/README.md
+++ b/embed-server/README.md
@@ -105,4 +105,6 @@ EMBED_MODEL=voyageai/voyage-4-nano EMBED_DIMS=1024 EMBED_DEVICE=mps \
 (Native install lets torch use Apple **MPS** or an NVIDIA **CUDA** GPU directly;
 omit `EMBED_DEVICE` to auto-detect, or set `cpu` to force CPU.)
 
+**Support:** [Ko-fi](https://ko-fi.com/mongx) — funds hosted-constellation infra + indexer maintenance.
+
 Apache-2.0 (same as RepoSkein). The model's own license is on its HuggingFace card.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -217,6 +217,8 @@ Full documentation, architecture, supported-language details, benchmarks, and th
 
 👉 **https://github.com/reposkein/reposkein**
 
+**Support:** [Ko-fi](https://ko-fi.com/mongx) — funds hosted-constellation infra + indexer maintenance.
+
 ## License
 
 [Apache-2.0](https://github.com/reposkein/reposkein/blob/main/LICENSE).

--- a/viz/README.md
+++ b/viz/README.md
@@ -47,6 +47,8 @@ The viewer honors RepoSkein's [core invariants](https://github.com/reposkein/rep
 - **Zero-infra.** It works directly over the committed JSONL — no Neo4j, no external service. The static export needs no server at all.
 - **Deterministic.** Same graph → same map. The seeded layout is render-time only and is never committed.
 
+**Support:** [Ko-fi](https://ko-fi.com/mongx) — funds hosted-constellation infra + indexer maintenance.
+
 ## License
 
 [Apache-2.0](https://github.com/reposkein/reposkein/blob/main/LICENSE).


### PR DESCRIPTION
Adds the Ko-fi support link (ko-fi.com/mongx) everywhere RepoSkein presents itself: amber-themed badge in the root README primary row, one honest Support sentence (funds hosted-constellation infra + indexer maintenance; supporters get ad-free once sponsorship ships), one-line pointers in mcp/viz/embed-server/docs READMEs + CONTRIBUTING, and `.github/FUNDING.yml` for the native Sponsor button.

Verified: ko-fi.com/mongx resolves in a real browser (curl 403 is Cloudflare site-wide bot-blocking); scripted link check clean; README front-door line budget intact. 14 insertions across 7 files.

Linear: REP-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
