### PR TITLE
docs: growth-kit nine-tactic audit — canonical tagline, install callout, tool-description polish (REP-31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 **[🔭 Live demo →](https://reposkein.github.io/reposkein/)** — RepoSkein's own graph, rendered as an interactive 3D constellation in your browser.
 
+**Get running in one line:** `npx @reposkein/mcp init` — full walkthrough in [Installation](#installation).
+
 </div>
 
 ## Introduction

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,7 +4,7 @@
 
 # @reposkein/mcp
 
-**Give your AI coding agent a map of your codebase — instead of letting it grep and guess.**
+**RepoSkein gives your AI coding agent a map of your codebase — so it navigates structure instead of grepping and guessing.**
 
 [![npm](https://img.shields.io/npm/v/@reposkein/mcp?style=for-the-badge&logo=npm&logoColor=EAE7DC&label=npm&labelColor=070A12&color=F2B84B)](https://www.npmjs.com/package/@reposkein/mcp)
 [![downloads](https://img.shields.io/npm/dm/@reposkein/mcp?style=for-the-badge&label=downloads&labelColor=070A12&color=2DD4BF)](https://www.npmjs.com/package/@reposkein/mcp)

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reposkein/mcp",
   "version": "0.5.0",
-  "description": "Deterministic code-graph (GraphRAG) MCP server — give your AI agent callers/callees, change-impact, and semantic search over your repo instead of grep. 7 languages, zero-infra, git-native.",
+  "description": "RepoSkein gives your AI coding agent a map of your codebase — so it navigates structure instead of grepping and guessing.",
   "keywords": [
     "mcp",
     "model-context-protocol",

--- a/mcp/src/server/createMcpServer.ts
+++ b/mcp/src/server/createMcpServer.ts
@@ -434,7 +434,7 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
     {
       title: "Write semantic summary",
       description: describe(
-        "Attach a 1-3 sentence plain-text business-logic summary to a node, stamped with its current content hash for staleness tracking. Plain text only (no markdown links or code fences), max 1000 chars.",
+        "Attach a 1-3 sentence plain-text summary of a node's business logic, so later agents/teammates start from what you learned instead of re-deriving it. Input: node_id and summary (plain text only, no markdown links or code fences, max 1000 chars), plus optional model. Stamps the node's current content hash for staleness tracking and returns { ok, stale_replaced }. Use after get_context_profile/impact reveal what a node actually does.",
         "write_semantic_summary"
       ),
       inputSchema: {
@@ -475,7 +475,7 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
     {
       title: "Reindex after editing",
       description: describe(
-        "Refresh the graph after editing a source file (pass its path). v1 performs a full reindex.",
+        "Refresh the graph after editing a source file. Input: the file's path (relative to the repo root). Runs a full reindex (v1) and returns updated node/edge/file counts. Call this before get_context_profile, impact, or semantic_find so they see your edit, not the stale graph.",
         "reindex_file"
       ),
       inputSchema: { path: z.string() },


### PR DESCRIPTION
Nine-tactic growth-kit audit (`~/mcp-growth-kit/PLAYBOOK.md`) with per-tactic evidence, plus the automatable fixes — deliberately tiny (6 lines):

## Audit verdicts
T1 registries **partial** (npm/Glama/mcpservers evidenced; Smithery + official registry + awesome-mcp are manual) · T2 one-paste install **pass** (hero callout added) · T3 demo video **fail/manual** · T4 tool naming **partial** (13/15 verb_noun; two weak descriptions fixed; renames out of wording-only scope) · T5 hosted endpoint **fail by design** (self-host only — recorded, not hidden) · T6 signup friction **pass** · T7 public numbers **partial** · T8 monetization **pass as decided (dormant)** · T9 downstream.

## Fixes in this PR
- One canonical description sentence, verbatim across `README.md`, `mcp/README.md`, `mcp/package.json`.
- README hero gains the one-line install callout.
- `reindex_file` / `write_semantic_summary` descriptions tightened (wording only; schemas and semantics untouched — 1050 tests green, tsc clean).

## Manual checklist (handed off, in the task report)
Registry submissions (Smithery, official MCP registry, awesome-mcp PR) · 40-second demo shot list built on the tour + palette · three draft honest-numbers bullets for a build-in-public post · REP-27 Ko-fi tier switch.

Sponsorship code, records, and supporter path untouched.

Linear: REP-31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
