### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ All notable changes to RepoSkein. Format roughly follows
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-22
+
+### Added
+
+- **`reposkein-mcp support` — offline supporter entitlement.** A new CLI
+  subcommand (`support <token>`, `support -` to read a token from stdin,
+  `support --status`, `support --remove`) installs, inspects, and removes a
+  Ko-fi "Skein" member's supporter token. The token is a minimal Ed25519
+  envelope (`rsk1.<payload>.<signature>`) verified entirely offline against
+  a public key compiled into the package — no licence server, no
+  activation call, no heartbeat, no revocation check, and no network call
+  now or ever. Being a supporter turns ads off; that's the only effect.
+  (#62)
+- **Ko-fi support links + `FUNDING.yml`.** A visible, honest way to support
+  the project's maintenance. (#59)
+- **Ko-fi fulfillment worker.** A small, optional Cloudflare Worker under
+  `workers/` that verifies Ko-fi's webhook and mints a supporter token on a
+  Skein membership payment, delivered via a one-time claim link a human
+  relays through Ko-fi's own supporter DM (Ko-fi's webhook can't message
+  the payer directly). This is RepoSkein's own infrastructure — no
+  user-facing feature depends on it, and a token already issued keeps
+  verifying offline whether or not this worker is deployed. (#62, #64)
+- **Disclosed sponsored-slot infrastructure — off by default, dormant.**
+  Wiring for an opt-in, fail-open sponsored slot on the MCP tool-result
+  envelope (`_meta["reposkein/sponsored"]` only, never mixed into
+  `content`), gated behind a kill switch, explicit opt-in, credentials, and
+  a non-supporter check, with `semantic_find` and every mutating tool
+  permanently excluded. Shipped disclosed and currently **dormant by
+  decision**: the governing ADR authorizes a future viewer-chip placement,
+  not this MCP-result surface, so this infrastructure stays off until a
+  separate decision ratifies it. Nothing about this release turns ads on
+  for anyone. (#60, #61)
+- **Canonical tagline + tool-description polish.** One agent-facing
+  description sentence reused verbatim across `README.md`, `mcp/README.md`,
+  and `mcp/package.json`; a paste-able install line surfaced in the README
+  hero; and tightened `reindex_file` / `write_semantic_summary` tool
+  descriptions (wording only — schemas and behavior unchanged). (#63)
+
 ## [0.5.0] - 2026-08-21
 
 ### Added

--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -1083,7 +1083,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reposkein-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-indexer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-common"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "reposkein-core",
  "tree-sitter",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-csharp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-go"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-java"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-python"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-rust"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-ts"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-neo4j-io"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "neo4rs",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/lang-common", "crates/cli", "crates/lang-python", "crates/lang-ts", "crates/lang-rust", "crates/lang-go", "crates/lang-java", "crates/neo4j-io", "crates/lang-csharp"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/reposkein/reposkein"

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reposkein/mcp",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "RepoSkein gives your AI coding agent a map of your codebase — so it navigates structure instead of grepping and guessing.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Ships the funding epic (#59–#64): `reposkein-mcp support` offline supporter entitlement, Ko-fi links + FUNDING.yml, the fulfillment worker, and the dormant opt-in sponsorship infrastructure. Lockstep verified; core 139/139; mcp 1050/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)