### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to RepoSkein. Format roughly follows
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-22
+
+### Security
+
+- **Linear-time `Authorization` header parsing in `serve --http`.** The
+  bearer-token parse used a regex vulnerable to polynomial ReDoS on
+  attacker-controlled input; replaced with plain string operations
+  (prefix check, single separator, slice+trim), same accepted inputs.
+  (CodeQL #5)
+- **Capped `REPOSKEIN_AGENT` before slug regexes.** The env var is now
+  truncated to 256 chars before any trim regex runs, closing a polynomial
+  ReDoS on an uncapped value. (CodeQL #4)
+
 ## [0.6.0] - 2026-08-22
 
 ### Added

--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -1083,7 +1083,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reposkein-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-indexer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reposkein-core",
  "tree-sitter",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-csharp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-go"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-java"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-python"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-rust"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-ts"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-neo4j-io"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "neo4rs",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/lang-common", "crates/cli", "crates/lang-python", "crates/lang-ts", "crates/lang-rust", "crates/lang-go", "crates/lang-java", "crates/neo4j-io", "crates/lang-csharp"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/reposkein/reposkein"

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reposkein/mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "RepoSkein gives your AI coding agent a map of your codebase — so it navigates structure instead of grepping and guessing.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Security patch: ships the CodeQL ReDoS fixes (#66) — linear-time Authorization-header parsing in serve --http and capped REPOSKEIN_AGENT slugging. Lockstep verified; core 139/139; mcp 1054/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)