### PR TITLE
feat(mcp): adr reanchor — repair stale decision anchors (REP-24)

### DIFF
--- a/.reposkein/decisions/2026-08-23-version-the-decision-body-hash-exclude-anchors-v2.json
+++ b/.reposkein/decisions/2026-08-23-version-the-decision-body-hash-exclude-anchors-v2.json
@@ -1,0 +1,19 @@
+{
+  "id": "adr:2026-08-23-version-the-decision-body-hash-exclude-anchors-v2",
+  "anchors": [],
+  "body_hash": "v2:78f64ca016ae31b3a977b87e223b6f1a9d1ad609cd404ab85bdcbd528d0d05f3",
+  "consequences": "Anchor rewrites are hash-neutral: reanchor and reaffirm repair pointers without appearing to edit the body. Hand-edits to the anchors array are no longer detected by doctor — accepted, because anchors are machine-managed and repaired by the same flows. Two hash schemes coexist indefinitely; verifyBodyHash dispatches on the prefix.",
+  "context": "computeBodyHash covered anchor_node_ids, so every mechanical anchor re-stamp (reaffirm, and now REP-24 reanchor) re-signed the body hash — contradicting the ruling that anchors are metadata, and making pointer repair look like a body edit. Alternatives: (b) a reanchored overlay array preserving original anchors would force every reader (profile governance, list drift counts, viewer) to apply overlay logic forever; (c) keeping the v1 scheme and re-signing on every repair leaves the contradiction in place.",
+  "decided_at": "2026-08-23",
+  "decided_by": "agent",
+  "decision": "body_hash v2: same allowlist minus anchor_node_ids, value prefixed 'v2:'. Legacy records verify against the retained v1 computation until their next write re-signs them (lazy migration, no sweep). Writers always stamp v2. paths stay in the hash (author-specified governance). reanchored_at and anchor_history are audit metadata outside the hash.",
+  "paths": [
+    "mcp/src/store/"
+  ],
+  "status": "proposed",
+  "supersedes": [],
+  "title": "Version the decision body hash; exclude anchors (v2)",
+  "trigger": {
+    "kind": "manual"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![release](https://img.shields.io/github/v/release/reposkein/reposkein?style=for-the-badge&logo=github&logoColor=EAE7DC&label=release&labelColor=070A12&color=2DD4BF)](https://github.com/reposkein/reposkein/releases)
 [![License](https://img.shields.io/badge/license-Apache_2.0-F2B84B?style=for-the-badge&labelColor=070A12)](./LICENSE)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-F2B84B?style=for-the-badge&logo=kofi&logoColor=EAE7DC&labelColor=070A12)](https://ko-fi.com/mongx)
+[![Lulu MCPs](https://getlulu.dev/api/mcps/badge/mcp-reposkein)](https://getlulu.dev/mcps/mcp-reposkein)
 
 <sub>Listed on: [skills.sh](https://skills.sh/reposkein/reposkein) · [Glama](https://glama.ai/mcp/servers/reposkein/reposkein) · [mcpservers.org](https://mcpservers.org/servers/reposkein/reposkein) · [ghcr.io](https://github.com/reposkein/reposkein/pkgs/container/reposkein-embed)</sub>
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -62,6 +62,7 @@ RepoSkein ships two cross-agent [Agent Skills](https://skills.sh) — `npx skill
 | `record_decision` | record an Architecture Decision Record (ADR) anchored to the graph nodes/paths it governs; lands as `proposed` by default; pass `supersedes` to replace an earlier decision. |
 | `set_decision_status` | change an ADR's lifecycle status: `proposed→accepted`, `proposed→rejected`, `accepted→deprecated` (`superseded` only happens via `record_decision`'s `supersedes`). |
 | `reaffirm_decision` | re-stamp an ADR's anchors after verifying the changed code still conforms, clearing staleness without superseding. |
+| `reanchor_decision` | repair an ADR's anchors after renames/moves — rebinds on confident matches only, reports ambiguous/orphaned anchors untouched. |
 | `list_decisions` | list ADRs (id, title, status, anchor drift counts), filterable by status, anchor, or free-text. |
 | `get_decision` | full ADR record: context, decision, consequences, alternatives, live anchor states, and the supersession chain. |
 
@@ -75,6 +76,7 @@ RepoSkein ships two cross-agent [Agent Skills](https://skills.sh) — `npx skill
 | `reposkein-mcp view [path]` | open the [constellation viewer](VIEWER.md) (`--export <dir>` for a static site). |
 | `reposkein-mcp stats [path]` | session usage report — calls by tool, top queried nodes/files, ADRs/summaries written, session duration, and an estimated context-tokens-saved-vs-grep number. |
 | `reposkein-mcp adr export/import [path] [dir]` | see [Architecture decisions](#architecture-decisions-adrs) below. |
+| `reposkein-mcp adr reanchor [path] [--dry-run] [--id <adr-id>]` | see [Architecture decisions](#architecture-decisions-adrs) below. |
 | `reposkein-mcp serve --http [path]` | **advanced, optional** — one shared server: MCP over Streamable HTTP + the viewer and `/api/*` in one process, bearer-token auth, read-only by default, re-indexing when the served checkout's HEAD moves. Not needed for normal use; stdio is the default transport. See [`REMOTE.md`](REMOTE.md). |
 
 ## Architecture decisions (ADRs)
@@ -84,6 +86,29 @@ Decisions recorded via `record_decision` (and friends, above) live as one commit
 `reposkein-mcp doctor` validates the decision log (parse failures, duplicate ids, tampered `body_hash`, dangling/cyclic supersession) as a non-critical, degrade-don't-block check.
 
 For human review or interop with `adr-tools` / `log4brains` / `Backstage`, `reposkein-mcp adr export [path] [dir]` renders the committed records to Nygard-format markdown under `docs/adr/` (derived — the JSON records stay the system of record). `reposkein-mcp adr import [path] [dir]` reads an existing Nygard/MADR-style markdown ADR log the other direction, creating unanchored records a human can later reaffirm.
+
+### Anchor lifecycle: reanchor vs reaffirm vs supersede
+
+Anchors are stamped at record time and drift as code evolves: `stale` (node
+lives, content changed), `moved` (id dead, content found elsewhere),
+`orphaned` (nothing matches). Three distinct responses:
+
+- **`adr reanchor` / `reanchor_decision`** — mechanical pointer repair, no
+  judgment. Rebinds an anchor when its id resolves under the current repo id
+  or its recorded content hash matches exactly one live node (renames,
+  qualified-name churn). Never guesses: ambiguous and orphaned anchors are
+  reported and left untouched. Staleness survives the repair. Prose and the
+  body hash are never affected; the repair stamps `reanchored_at` and keeps
+  the previous anchors in `anchor_history`.
+- **`reaffirm_decision`** — the semantic judgment "this decision is still
+  correct after the code changed": re-stamps anchor hashes from the live
+  graph, clearing stale flags. Use after actually reviewing the changed code.
+- **`record_decision` with `supersedes`** — the decision itself changed;
+  record the new one and let it supersede the old.
+
+`reposkein-mcp doctor` counts drifted anchors (`decisions_anchors`);
+`adr reanchor --dry-run` prints the full repair plan without writing. Exit
+codes: 0 clean, 1 partial (unresolved anchors remain), 2 error.
 
 ## See also
 

--- a/mcp/src/cli/adr.ts
+++ b/mcp/src/cli/adr.ts
@@ -250,6 +250,6 @@ export function runAdr(sub: string | undefined, repoPath: string, dir?: string):
     );
     return 0;
   }
-  console.error("usage: reposkein-mcp adr <export|import> [repoPath] [dir]");
+  console.error("usage: reposkein-mcp adr <export|import|reanchor> [repoPath] [dir]");
   return 1;
 }

--- a/mcp/src/cli/adrReanchor.ts
+++ b/mcp/src/cli/adrReanchor.ts
@@ -45,6 +45,9 @@ export async function runAdrReanchor(
   const store = buildStore(repoPath, repoId);
   try {
     const repoIds = await anchorRepoIds(store, repoId);
+    // Hoisted so every decision in this run gets the same stamp — a sweep
+    // straddling midnight must not split across two dates.
+    const reanchoredAt = today();
     let rebound = 0;
     let unresolved = 0;
     for (const rec of targets) {
@@ -64,7 +67,7 @@ export async function runAdrReanchor(
         }
       }
       unresolved += plan.unresolved;
-      if (!dryRun) applyReanchor(repoPath, rec, plan, today());
+      if (!dryRun) applyReanchor(repoPath, rec, plan, reanchoredAt);
     }
     console.error(
       `${dryRun ? "[dry-run] " : ""}reanchored ${rebound} anchor${rebound === 1 ? "" : "s"} across ${

--- a/mcp/src/cli/adrReanchor.ts
+++ b/mcp/src/cli/adrReanchor.ts
@@ -1,0 +1,78 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { buildStore } from "../server/createMcpServer.js";
+import { anchorRepoIds, loadDecisions } from "../store/decisions.js";
+import { resolveRepoId } from "../store/repoId.js";
+import { applyReanchor, planReanchor } from "../store/reanchor.js";
+
+/** `reposkein-mcp adr reanchor [path] [--dry-run] [--id <adr-id>]` (REP-24).
+ *  Exit codes: 0 = clean (nothing unresolved), 1 = partial (ambiguous or
+ *  orphaned anchors remain — reported, never guessed), 2 = usage/environment
+ *  error. Deterministic: decisions in id order; the only time field is
+ *  reanchored_at, injected via opts for tests. */
+export async function runAdrReanchor(
+  argv: string[],
+  envRepoPath?: string,
+  opts: { today?: () => string } = {}
+): Promise<number> {
+  const today = opts.today ?? (() => new Date().toISOString().slice(0, 10));
+  const dryRun = argv.includes("--dry-run");
+  const idFlag = argv.indexOf("--id");
+  const onlyId = idFlag >= 0 ? argv[idFlag + 1] : undefined;
+  if (idFlag >= 0 && (!onlyId || onlyId.startsWith("-"))) {
+    console.error("adr reanchor: --id requires a decision id");
+    return 2;
+  }
+  const positional = argv.filter((a, i) => !a.startsWith("-") && argv[i - 1] !== "--id");
+  const repoPath = positional[0] ?? envRepoPath ?? ".";
+
+  const repoId = resolveRepoId(repoPath, process.env.REPOSKEIN_REPO_ID);
+  if (!repoId || !existsSync(join(repoPath, ".reposkein", "nodes.jsonl"))) {
+    console.error("adr reanchor: no graph found — run `reposkein-mcp index` first");
+    return 2;
+  }
+
+  const { decisions, warnings } = loadDecisions(repoPath);
+  for (const w of warnings) console.error(`warning: ${w}`);
+  const targets = onlyId
+    ? decisions.filter((d) => d.id === onlyId)
+    : decisions.filter((d) => d.anchors.length > 0);
+  if (onlyId && targets.length === 0) {
+    console.error(`adr reanchor: unknown decision: ${onlyId}`);
+    return 2;
+  }
+
+  const store = buildStore(repoPath, repoId);
+  try {
+    const repoIds = await anchorRepoIds(store, repoId);
+    let rebound = 0;
+    let unresolved = 0;
+    for (const rec of targets) {
+      const plan = await planReanchor(store, repoIds, rec);
+      for (const a of plan.anchors) {
+        if (a.action === "rebind") {
+          console.error(`${rec.id}: rebind ${a.anchor.node_id} -> ${a.to!.node_id}`);
+          rebound++;
+        } else if (a.action === "ambiguous") {
+          console.error(
+            `${rec.id}: ambiguous ${a.anchor.node_id} (${a.candidates} content-hash matches) — untouched`
+          );
+        } else if (a.action === "orphaned") {
+          console.error(`${rec.id}: orphaned ${a.anchor.node_id} — untouched`);
+        } else if (a.action === "stale") {
+          console.error(`${rec.id}: stale ${a.anchor.node_id} — content changed; reaffirm or supersede`);
+        }
+      }
+      unresolved += plan.unresolved;
+      if (!dryRun) applyReanchor(repoPath, rec, plan, today());
+    }
+    console.error(
+      `${dryRun ? "[dry-run] " : ""}reanchored ${rebound} anchor${rebound === 1 ? "" : "s"} across ${
+        targets.length
+      } decision${targets.length === 1 ? "" : "s"}` + (unresolved ? `; ${unresolved} unresolved` : "")
+    );
+    return unresolved > 0 ? 1 : 0;
+  } finally {
+    await store.close();
+  }
+}

--- a/mcp/src/cli/doctor.ts
+++ b/mcp/src/cli/doctor.ts
@@ -4,7 +4,7 @@ import { ensureIndexerBinary } from "../indexer/fetchBinary.js";
 import { spawnIndexer } from "../indexer/runIndexer.js";
 import { resolveRepoId } from "../store/repoId.js";
 import { resolveRepoPath } from "../store/resolveRepoPath.js";
-import { decisionChecks } from "./doctorDecisions.js";
+import { anchorStateChecks, decisionChecks } from "./doctorDecisions.js";
 import { summaryChecks } from "./doctorSummaries.js";
 import { hooksCheck, graphStaleCheck } from "./doctorFreshness.js";
 
@@ -119,6 +119,10 @@ export async function runChecks(repoPath: string): Promise<DoctorReport> {
 
   // 5) Decision log validation (all non-critical: degrade, don't block).
   checks.push(...decisionChecks(repoPath));
+
+  // 5b) Decision anchor drift against the live graph (non-critical, advisory
+  //     — never added to CI_FAIL_IDS: reanchoring is a repair step, not a gate).
+  checks.push(...(await anchorStateChecks(repoPath, repoId ?? null)));
 
   // 6) Git hooks installed + graph freshness (non-critical here; `doctor
   //    --ci` promotes both to a failing exit code — see CI_FAIL_IDS below).

--- a/mcp/src/cli/doctorDecisions.ts
+++ b/mcp/src/cli/doctorDecisions.ts
@@ -1,6 +1,6 @@
 import {
-  computeBodyHash,
   loadDecisionFiles,
+  verifyBodyHash,
   type DecisionRecord,
 } from "../store/decisions.js";
 import type { Check } from "./doctor.js";
@@ -83,7 +83,7 @@ export function decisionChecks(repoPath: string): Check[] {
   // 3) Bodies unmodified since signing (immutability as invariant, not
   //    convention — reaffirm/supersede re-sign, hand edits don't).
   const tampered = parsed
-    .filter(({ record }) => record.body_hash !== computeBodyHash(record))
+    .filter(({ record }) => !verifyBodyHash(record))
     .map(({ record }) => record.id);
   checks.push(
     warn(

--- a/mcp/src/cli/doctorDecisions.ts
+++ b/mcp/src/cli/doctorDecisions.ts
@@ -1,8 +1,14 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import {
+  anchorRepoIds,
   loadDecisionFiles,
+  loadDecisions,
+  resolveAnchorStates,
   verifyBodyHash,
   type DecisionRecord,
 } from "../store/decisions.js";
+import { JsonlGraphStore } from "../store/JsonlGraphStore.js";
 import type { Check } from "./doctor.js";
 
 /** ~Zimmermann ceiling: past this many active records, recall quality and the
@@ -142,4 +148,39 @@ export function decisionChecks(repoPath: string): Check[] {
   );
 
   return checks;
+}
+
+/** Anchor drift against the live graph (async — opens the JSONL store).
+ *  Skips silently when there is no graph or no anchored decision: doctor
+ *  must work in a repo that has never indexed. Non-critical like every
+ *  decision check. */
+export async function anchorStateChecks(repoPath: string, repoId: string | null): Promise<Check[]> {
+  const { decisions } = loadDecisions(repoPath);
+  const anchored = decisions.filter((d) => d.anchors.length > 0);
+  if (anchored.length === 0) return [];
+  if (!repoId || !existsSync(join(repoPath, ".reposkein", "nodes.jsonl"))) return [];
+  const store = new JsonlGraphStore(repoPath, repoId);
+  try {
+    const repoIds = await anchorRepoIds(store, repoId);
+    let stale = 0, moved = 0, orphaned = 0;
+    for (const rec of anchored) {
+      for (const r of await resolveAnchorStates(store, repoIds, rec.anchors)) {
+        if (r.state === "stale") stale++;
+        else if (r.state === "moved") moved++;
+        else if (r.state === "orphaned") orphaned++;
+      }
+    }
+    const drifted = stale + moved + orphaned;
+    return [
+      warn(
+        "decisions_anchors",
+        "decision anchors current",
+        drifted === 0,
+        drifted === 0 ? "all anchors current" : `${moved} moved, ${stale} stale, ${orphaned} orphaned`,
+        "run `reposkein-mcp adr reanchor` to repair moved anchors; reaffirm or supersede decisions whose stale anchors still conform"
+      ),
+    ];
+  } finally {
+    await store.close();
+  }
 }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -24,6 +24,7 @@ export {
   recordDecisionInputSchema,
   setDecisionStatusInputSchema,
   reaffirmDecisionInputSchema,
+  reanchorDecisionInputSchema,
   listDecisionsInputSchema,
   getDecisionInputSchema,
   createMcpServer,

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -4,6 +4,7 @@ import { runInit, runIndex } from "./cli/init.js";
 import { parseAgentsFlag } from "./cli/agentAdapters.js";
 import { runDoctor, resolveDoctorRepoPath } from "./cli/doctor.js";
 import { runAdr } from "./cli/adr.js";
+import { runAdrReanchor } from "./cli/adrReanchor.js";
 import { runView, runExport, parseViewArgs } from "./cli/view.js";
 import { runStats } from "./cli/stats.js";
 import { runSupport } from "./cli/support.js";
@@ -39,7 +40,7 @@ Usage:
   reposkein-mcp init [path]     set up a repo (indexer, git hooks, skill, graph); --no-index skips the initial index, --ci also writes a GitHub Pages publish workflow (see docs/HOSTING.md). On a repo joined from a committed .reposkein/meta.json, also auto-writes local agent MCP config (--agents claude,opencode,cursor to override detection, --dry-run to preview)
   reposkein-mcp index [path]    (re)build the committed graph
   reposkein-mcp doctor [path]   health check (indexer binary, index, repo id, hooks, graph freshness); --json for machine output, --ci additionally fails on stale graph / missing hooks / unsplit legacy summaries
-  reposkein-mcp adr <sub> ...   decision-log utilities
+  reposkein-mcp adr <sub> ...   decision-log utilities (export|import|reanchor)
   reposkein-mcp stats [path]    session usage report (calls, tokens saved vs grep)
   reposkein-mcp support <token> install a supporter token (verified locally, stored at ~/.config/reposkein/supporter.jwt, mode 600); pass \`-\` to read it from stdin instead of argv (keeps it out of shell history and \`ps\`); --status to show tier/expiry, --remove to delete it. Offline: no network call, ever
   reposkein-mcp view [path]     open the constellation viewer (--export <dir> for a static site)
@@ -129,10 +130,16 @@ if (invokedAsBin()) {
   } else if (sub === "adr") {
     const rest = process.argv.slice(3);
     const adrSub = rest[0];
-    const positional = rest.slice(1).filter((a) => !a.startsWith("-"));
-    const path = positional[0] ?? process.env.REPOSKEIN_REPO_PATH ?? ".";
-    const dir = positional[1];
-    process.exit(runAdr(adrSub, path, dir));
+    if (adrSub === "reanchor") {
+      runAdrReanchor(rest.slice(1), process.env.REPOSKEIN_REPO_PATH)
+        .then((code) => process.exit(code))
+        .catch((err) => { console.error(err); process.exit(1); });
+    } else {
+      const positional = rest.slice(1).filter((a) => !a.startsWith("-"));
+      const path = positional[0] ?? process.env.REPOSKEIN_REPO_PATH ?? ".";
+      const dir = positional[1];
+      process.exit(runAdr(adrSub, path, dir));
+    }
   } else if (sub === "view") {
     const { repoPath, opts, exportDir, exportOpts } = parseViewArgs(process.argv.slice(3));
     const resolvedViewRepoId = resolveRepoId(repoPath, process.env.REPOSKEIN_REPO_ID);

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -133,7 +133,7 @@ if (invokedAsBin()) {
     if (adrSub === "reanchor") {
       runAdrReanchor(rest.slice(1), process.env.REPOSKEIN_REPO_PATH)
         .then((code) => process.exit(code))
-        .catch((err) => { console.error(err); process.exit(1); });
+        .catch((err) => { console.error(err); process.exit(2); });
     } else {
       const positional = rest.slice(1).filter((a) => !a.startsWith("-"));
       const path = positional[0] ?? process.env.REPOSKEIN_REPO_PATH ?? ".";

--- a/mcp/src/server/createMcpServer.ts
+++ b/mcp/src/server/createMcpServer.ts
@@ -17,6 +17,7 @@ import { makeImpact } from "../tools/impact.js";
 import { makeRecordDecision } from "../tools/recordDecision.js";
 import { makeSetDecisionStatus } from "../tools/setDecisionStatus.js";
 import { makeReaffirmDecision } from "../tools/reaffirmDecision.js";
+import { makeReanchorDecision } from "../tools/reanchorDecision.js";
 import { makeListDecisions } from "../tools/listDecisions.js";
 import { makeGetDecision } from "../tools/getDecision.js";
 import { resolveRepoId } from "../store/repoId.js";
@@ -165,6 +166,11 @@ export const reaffirmDecisionInputSchema = {
   decision_id: z.string(),
 };
 
+export const reanchorDecisionInputSchema = {
+  decision_id: z.string().optional(),
+  dry_run: z.boolean().optional(),
+};
+
 export const listDecisionsInputSchema = {
   status: z.enum(["proposed", "accepted", "rejected", "deprecated", "superseded"]).optional(),
   anchor: z.string().optional(),
@@ -190,6 +196,7 @@ export const WRITE_TOOLS = [
   "record_decision",
   "set_decision_status",
   "reaffirm_decision",
+  "reanchor_decision",
   "reindex_file",
   "init_cpg_skeleton",
 ] as const;
@@ -605,6 +612,23 @@ export function createMcpServer(opts: CreateMcpServerOptions): McpServer {
       const active = await resolveActiveRepo();
       if (!active.ok) return errResult(active.message);
       return makeReaffirmDecision(active.store, active.repoId, active.repoPath)(args);
+    })
+  );
+
+  server.registerTool(
+    "reanchor_decision",
+    {
+      title: "Reanchor a decision",
+      description: describe(
+        "Repair an ADR's anchors after renames/moves: re-resolves each anchor against the current graph and rebinds on confident matches only (live id under another repo_id, or a UNIQUE content-hash match). Ambiguous/orphaned anchors are reported untouched — never guessed. Staleness is preserved; use reaffirm_decision to clear it after review. dry_run previews the full plan without writing. Omit decision_id to sweep every anchored decision.",
+        "reanchor_decision"
+      ),
+      inputSchema: reanchorDecisionInputSchema,
+    },
+    withWrite("reanchor_decision", async (args) => {
+      const active = await resolveActiveRepo();
+      if (!active.ok) return errResult(active.message);
+      return makeReanchorDecision(active.store, active.repoId, active.repoPath)(args);
     })
   );
 

--- a/mcp/src/store/decisions.ts
+++ b/mcp/src/store/decisions.ts
@@ -298,6 +298,11 @@ function parseAnchorArray(v: unknown): DecisionAnchor[] {
 
 function parseDecision(obj: Record<string, unknown>): DecisionRecord | null {
   if (typeof obj.id !== "string" || !obj.id.startsWith("adr:")) return null;
+  // The id is path-derived (decisionFileName/writeDecision join it under
+  // decisions dir) — reject a remainder with a separator or a `..` segment
+  // so no writer can ever be made to escape that directory.
+  const idRest = obj.id.slice("adr:".length);
+  if (/[/\\]/.test(idRest) || idRest.split(/[/\\]/).includes("..")) return null;
   if (typeof obj.title !== "string" || typeof obj.context !== "string") return null;
   if (typeof obj.decision !== "string" || typeof obj.decided_at !== "string") return null;
   const status = obj.status;

--- a/mcp/src/store/decisions.ts
+++ b/mcp/src/store/decisions.ts
@@ -42,6 +42,11 @@ export interface DecisionAnchor {
   hash: string | null;
 }
 
+export interface AnchorHistoryEntry {
+  reanchored_at: string;
+  anchors: DecisionAnchor[];
+}
+
 export type DecisionTriggerKind = "manual" | "graph_delta" | "drift";
 
 export interface DecisionRecord {
@@ -63,6 +68,12 @@ export interface DecisionRecord {
   /** Hash of the immutable body fields (see computeBodyHash). Lets doctor
    *  detect hand-edited bodies. */
   body_hash: string;
+  /** Date of the most recent anchor repair (`adr reanchor`). Audit metadata,
+   *  outside body_hash. */
+  reanchored_at?: string;
+  /** Pre-repair anchor arrays, one entry per reanchor that changed anything.
+   *  Audit metadata, outside body_hash. */
+  anchor_history?: AnchorHistoryEntry[];
 }
 
 /** Anchor lifecycle at read time. Never deletes: the worst state is a flag. */
@@ -174,10 +185,32 @@ export function takenDecisionIds(repoPath: string): Set<string> {
   return taken;
 }
 
-/** SHA-256 over the immutable body. Excludes status/superseded_by (lifecycle)
- *  and anchor hash values (re-stamped by reaffirm) — but covers WHICH nodes
- *  and paths the decision governs, and every prose field. */
+/** SHA-256 over the immutable body, `"v2:"`-prefixed. Excludes lifecycle
+ *  (status/superseded_by), audit metadata (reanchored_at/anchor_history) and —
+ *  since v2 — the anchors entirely: anchors are machine-managed pointers,
+ *  re-stamped by reaffirm and repaired by reanchor, so binding them into the
+ *  body made every mechanical repair look like an edit. Covers prose, paths,
+ *  supersedes and attribution. */
 export function computeBodyHash(rec: Omit<DecisionRecord, "body_hash">): string {
+  const body = {
+    alternatives: rec.alternatives ?? "",
+    consequences: rec.consequences ?? "",
+    context: rec.context,
+    decided_at: rec.decided_at,
+    decided_by: rec.decided_by,
+    decision: rec.decision,
+    paths: rec.paths,
+    supersedes: rec.supersedes,
+    title: rec.title,
+    trigger: rec.trigger.kind,
+  };
+  return "v2:" + createHash("sha256").update(JSON.stringify(body)).digest("hex");
+}
+
+/** The pre-v2 hash (included anchor_node_ids, bare hex). Verification only:
+ *  records signed before the v2 scheme verify against this until their next
+ *  write re-signs them. */
+export function computeBodyHashV1(rec: Omit<DecisionRecord, "body_hash">): string {
   const body = {
     alternatives: rec.alternatives ?? "",
     anchor_node_ids: rec.anchors.map((a) => a.node_id),
@@ -192,6 +225,13 @@ export function computeBodyHash(rec: Omit<DecisionRecord, "body_hash">): string 
     trigger: rec.trigger.kind,
   };
   return createHash("sha256").update(JSON.stringify(body)).digest("hex");
+}
+
+/** True when body_hash matches the record under whichever scheme signed it. */
+export function verifyBodyHash(rec: DecisionRecord): boolean {
+  return rec.body_hash.startsWith("v2:")
+    ? rec.body_hash === computeBodyHash(rec)
+    : rec.body_hash === computeBodyHashV1(rec);
 }
 
 /** File name for a decision id (`adr:` prefix stripped). */
@@ -235,15 +275,13 @@ export function writeDecision(repoPath: string, rec: DecisionRecord): void {
   renameSync(tmp, file);
 }
 
-function parseDecision(obj: Record<string, unknown>): DecisionRecord | null {
-  if (typeof obj.id !== "string" || !obj.id.startsWith("adr:")) return null;
-  if (typeof obj.title !== "string" || typeof obj.context !== "string") return null;
-  if (typeof obj.decision !== "string" || typeof obj.decided_at !== "string") return null;
-  const status = obj.status;
-  if (typeof status !== "string" || !STATUSES.includes(status as DecisionStatus)) return null;
-  const anchorsRaw = Array.isArray(obj.anchors) ? obj.anchors : [];
+/** Parses an anchors array tolerantly: a malformed entry (not an object, or
+ *  missing node_id) is dropped, never fatal — shared by `anchors` and each
+ *  `anchor_history` entry. */
+function parseAnchorArray(v: unknown): DecisionAnchor[] {
   const anchors: DecisionAnchor[] = [];
-  for (const a of anchorsRaw) {
+  if (!Array.isArray(v)) return anchors;
+  for (const a of v) {
     if (a === null || typeof a !== "object") continue;
     const o = a as Record<string, unknown>;
     if (typeof o.node_id !== "string") continue;
@@ -255,6 +293,16 @@ function parseDecision(obj: Record<string, unknown>): DecisionRecord | null {
       hash: typeof o.hash === "string" ? o.hash : null,
     });
   }
+  return anchors;
+}
+
+function parseDecision(obj: Record<string, unknown>): DecisionRecord | null {
+  if (typeof obj.id !== "string" || !obj.id.startsWith("adr:")) return null;
+  if (typeof obj.title !== "string" || typeof obj.context !== "string") return null;
+  if (typeof obj.decision !== "string" || typeof obj.decided_at !== "string") return null;
+  const status = obj.status;
+  if (typeof status !== "string" || !STATUSES.includes(status as DecisionStatus)) return null;
+  const anchors = parseAnchorArray(obj.anchors);
   const strArray = (v: unknown): string[] =>
     Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
   const triggerKind =
@@ -286,6 +334,17 @@ function parseDecision(obj: Record<string, unknown>): DecisionRecord | null {
   if (typeof obj.consequences === "string") rec.consequences = obj.consequences;
   if (typeof obj.alternatives === "string") rec.alternatives = obj.alternatives;
   if (typeof obj.superseded_by === "string") rec.superseded_by = obj.superseded_by;
+  if (typeof obj.reanchored_at === "string") rec.reanchored_at = obj.reanchored_at;
+  if (Array.isArray(obj.anchor_history)) {
+    const history: AnchorHistoryEntry[] = [];
+    for (const h of obj.anchor_history) {
+      if (h === null || typeof h !== "object") continue;
+      const ho = h as Record<string, unknown>;
+      if (typeof ho.reanchored_at !== "string" || !Array.isArray(ho.anchors)) continue;
+      history.push({ reanchored_at: ho.reanchored_at, anchors: parseAnchorArray(ho.anchors) });
+    }
+    if (history.length > 0) rec.anchor_history = history;
+  }
   return rec;
 }
 

--- a/mcp/src/store/reanchor.ts
+++ b/mcp/src/store/reanchor.ts
@@ -1,0 +1,129 @@
+import type { GraphStore } from "./GraphStore.js";
+import type { TargetRow } from "../profile/types.js";
+import {
+  computeBodyHash,
+  nodeIdSuffix,
+  writeDecision,
+  type AnchorHistoryEntry,
+  type DecisionAnchor,
+  type DecisionRecord,
+} from "./decisions.js";
+
+/** Anchor repair for `adr reanchor` / `reanchor_decision` (REP-24).
+ *
+ *  Reanchor is MECHANICAL pointer repair, distinct from reaffirm's semantic
+ *  judgment: it rebinds an anchor only on a confident match — the id resolves
+ *  under a live repo_id (suffix retry), or the recorded content hash matches
+ *  exactly one live node — and preserves staleness (a suffix rebind keeps the
+ *  recorded hash, so a stale flag survives the repair; clearing it is
+ *  reaffirm_decision's job). Ambiguous and orphaned anchors are reported,
+ *  never guessed. plan is pure; apply writes only when something rebinds, so
+ *  a second run on the same graph is a byte-level no-op. */
+
+export type ReanchorAction = "keep" | "rebind" | "stale" | "orphaned" | "ambiguous";
+
+export interface AnchorPlanEntry {
+  anchor: DecisionAnchor;
+  action: ReanchorAction;
+  /** Present iff action === "rebind". */
+  to?: DecisionAnchor;
+  /** Content-hash match count when ambiguous. */
+  candidates?: number;
+}
+
+export interface ReanchorPlan {
+  decision_id: string;
+  anchors: AnchorPlanEntry[];
+  changed: boolean;
+  unresolved: number;
+}
+
+function liveAnchor(live: TargetRow, fallbackKind: string, hash: string | null): DecisionAnchor {
+  return {
+    node_id: live.id,
+    path: live.file_path,
+    name: live.qualified_name || live.name,
+    kind: live.labels[0] ?? fallbackKind,
+    hash,
+  };
+}
+
+export async function planReanchor(
+  store: GraphStore,
+  repoIds: string[],
+  rec: DecisionRecord
+): Promise<ReanchorPlan> {
+  const anchors: AnchorPlanEntry[] = [];
+  for (const anchor of rec.anchors) {
+    let live: TargetRow | null = await store.getNode(repoIds, anchor.node_id);
+    if (!live) {
+      const suffix = nodeIdSuffix(anchor.node_id);
+      if (suffix) {
+        for (const repoId of repoIds) {
+          const candidate = `rs1:${repoId}${suffix}`;
+          if (candidate === anchor.node_id) continue;
+          live = await store.getNode(repoIds, candidate);
+          if (live) break;
+        }
+      }
+    }
+    if (live) {
+      if (live.id !== anchor.node_id) {
+        // Suffix repair: rebind the pointer, keep the recorded hash so a
+        // stale flag survives (reaffirm clears it, not reanchor).
+        anchors.push({ anchor, action: "rebind", to: liveAnchor(live, anchor.kind, anchor.hash) });
+      } else if (anchor.hash !== null && live.content_hash !== null && anchor.hash !== live.content_hash) {
+        anchors.push({ anchor, action: "stale" });
+      } else {
+        anchors.push({ anchor, action: "keep" });
+      }
+      continue;
+    }
+    if (anchor.hash && store.findByContentHash) {
+      const matches = await store.findByContentHash(repoIds, anchor.hash);
+      if (matches.length === 1) {
+        anchors.push({ anchor, action: "rebind", to: liveAnchor(matches[0]!, anchor.kind, anchor.hash) });
+        continue;
+      }
+      if (matches.length > 1) {
+        anchors.push({ anchor, action: "ambiguous", candidates: matches.length });
+        continue;
+      }
+    }
+    anchors.push({ anchor, action: "orphaned" });
+  }
+  return {
+    decision_id: rec.id,
+    anchors,
+    changed: anchors.some((a) => a.action === "rebind"),
+    unresolved: anchors.filter((a) => a.action === "orphaned" || a.action === "ambiguous").length,
+  };
+}
+
+/** Applies a plan's rebinds. Returns the written record, or null when the
+ *  plan changes nothing (in which case NOTHING is written — idempotence is
+ *  the determinism gate). Body prose is never touched; the v2 body hash is
+ *  anchor-independent, so re-signing here only upgrades pre-v2 records. */
+export function applyReanchor(
+  repoPath: string,
+  rec: DecisionRecord,
+  plan: ReanchorPlan,
+  reanchoredAt: string
+): DecisionRecord | null {
+  if (!plan.changed) return null;
+  const anchors = plan.anchors.map((a) => (a.action === "rebind" ? a.to! : a.anchor));
+  const history: AnchorHistoryEntry[] = [
+    ...(rec.anchor_history ?? []),
+    { reanchored_at: reanchoredAt, anchors: rec.anchors },
+  ];
+  const updated: DecisionRecord = {
+    ...rec,
+    anchors,
+    reanchored_at: reanchoredAt,
+    anchor_history: history,
+    body_hash: "",
+  };
+  updated.body_hash = computeBodyHash(updated);
+  writeDecision(repoPath, updated);
+  return updated;
+}

--- a/mcp/src/tools/reaffirmDecision.ts
+++ b/mcp/src/tools/reaffirmDecision.ts
@@ -19,8 +19,10 @@ const err = (text: string): ToolResult => ({ content: [{ type: "text", text }], 
 /** "This decision is still correct": re-stamps every anchor from the live
  *  graph — stale anchors get the current hash, moved anchors are rebound to
  *  their recovered node — clearing review flags without supersede spam. The
- *  prose body never changes; body_hash is re-signed because rebinding an
- *  anchor updates the governed node list it covers. */
+ *  prose body never changes, and since v2 the body_hash doesn't either:
+ *  anchors are excluded from it, so re-stamping is a no-op on the hash. The
+ *  re-sign stays because it's a lazy v1→v2 upgrade path — a pre-v2 record
+ *  re-signed here moves onto the anchor-independent scheme. */
 export function makeReaffirmDecision(store: GraphStore, repoId: string, repoPath: string) {
   return async (args: ReaffirmDecisionArgs): Promise<ToolResult> => {
     try {

--- a/mcp/src/tools/reanchorDecision.ts
+++ b/mcp/src/tools/reanchorDecision.ts
@@ -1,0 +1,60 @@
+import type { GraphStore } from "../store/GraphStore.js";
+import type { ToolResult } from "./readCypher.js";
+import { anchorRepoIds, loadDecisions } from "../store/decisions.js";
+import { applyReanchor, planReanchor, type ReanchorPlan } from "../store/reanchor.js";
+
+export interface ReanchorDecisionArgs {
+  decision_id?: string;
+  dry_run?: boolean;
+}
+
+const err = (text: string): ToolResult => ({ content: [{ type: "text", text }], isError: true });
+
+function planReport(plan: ReanchorPlan): Record<string, unknown> {
+  return {
+    decision_id: plan.decision_id,
+    changed: plan.changed,
+    unresolved: plan.unresolved,
+    anchors: plan.anchors.map((a) => ({
+      node_id: a.anchor.node_id,
+      action: a.action,
+      ...(a.to ? { to_node_id: a.to.node_id } : {}),
+      ...(a.candidates !== undefined ? { candidates: a.candidates } : {}),
+    })),
+  };
+}
+
+/** Mechanical anchor repair (REP-24): rebinds anchors whose node moved or
+ *  whose id churned, on confident matches only. Prose and (v2) body hash are
+ *  untouched; staleness flags survive — reaffirm_decision clears those. */
+export function makeReanchorDecision(
+  store: GraphStore,
+  repoId: string,
+  repoPath: string,
+  opts: { today?: () => string } = {}
+) {
+  const today = opts.today ?? (() => new Date().toISOString().slice(0, 10));
+  return async (args: ReanchorDecisionArgs): Promise<ToolResult> => {
+    try {
+      const { decisions } = loadDecisions(repoPath);
+      const targets = args.decision_id
+        ? decisions.filter((d) => d.id === args.decision_id)
+        : decisions.filter((d) => d.anchors.length > 0);
+      if (args.decision_id && targets.length === 0) return err(`unknown decision: ${args.decision_id}`);
+      const repoIds = await anchorRepoIds(store, repoId);
+      const results: Record<string, unknown>[] = [];
+      for (const rec of targets) {
+        const plan = await planReanchor(store, repoIds, rec);
+        if (!args.dry_run) applyReanchor(repoPath, rec, plan, today());
+        results.push(planReport(plan));
+      }
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ ok: true, dry_run: args.dry_run === true, results }) },
+        ],
+      };
+    } catch (e) {
+      return err((e as Error).message);
+    }
+  };
+}

--- a/mcp/src/tools/reanchorDecision.ts
+++ b/mcp/src/tools/reanchorDecision.ts
@@ -42,10 +42,13 @@ export function makeReanchorDecision(
         : decisions.filter((d) => d.anchors.length > 0);
       if (args.decision_id && targets.length === 0) return err(`unknown decision: ${args.decision_id}`);
       const repoIds = await anchorRepoIds(store, repoId);
+      // Hoisted so every decision in this call gets the same stamp — a sweep
+      // straddling midnight must not split across two dates.
+      const reanchoredAt = today();
       const results: Record<string, unknown>[] = [];
       for (const rec of targets) {
         const plan = await planReanchor(store, repoIds, rec);
-        if (!args.dry_run) applyReanchor(repoPath, rec, plan, today());
+        if (!args.dry_run) applyReanchor(repoPath, rec, plan, reanchoredAt);
         results.push(planReport(plan));
       }
       return {

--- a/mcp/test/adrReanchor.test.ts
+++ b/mcp/test/adrReanchor.test.ts
@@ -208,4 +208,33 @@ describe("adr reanchor CLI", () => {
 
     expect(code).toBe(2);
   });
+
+  // D4 (REP-24 final review, finding 1): a throwing store must not surface as
+  // exit 1 ("partial") — that collides with the unresolved-anchors contract.
+  // The CLI itself has no try/catch around buildStore/planReanchor, so a
+  // throwing store rejects the returned promise; it's src/index.ts's
+  // `adr reanchor` dispatch .catch that must map that rejection to exit 2.
+  // This test proves the rejection actually happens (the half of the
+  // contract this module owns) — REPOSKEIN_STORE=neo4j with no NEO4J env
+  // resolves to UnconfiguredStore, whose getNode() throws inside
+  // planReanchor.
+  it("rejects when the store throws (e.g. misconfigured neo4j backend), so the CLI dispatcher can exit 2", async () => {
+    seedGraph(dir, [funcNodeLine("src/new.py", "h1")]);
+    seedDecision(dir, "adr:2026-08-01-rename", {
+      node_id: `rs1:${REPO_ID}:func:src/old.py#f@0`,
+      path: "src/old.py",
+      name: "f",
+      kind: "Function",
+      hash: "h1",
+    });
+
+    const prevStore = process.env.REPOSKEIN_STORE;
+    process.env.REPOSKEIN_STORE = "neo4j";
+    try {
+      await expect(runAdrReanchor([dir], undefined, { today })).rejects.toThrow();
+    } finally {
+      if (prevStore === undefined) delete process.env.REPOSKEIN_STORE;
+      else process.env.REPOSKEIN_STORE = prevStore;
+    }
+  });
 });

--- a/mcp/test/adrReanchor.test.ts
+++ b/mcp/test/adrReanchor.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runAdrReanchor } from "../src/cli/adrReanchor.js";
+import {
+  computeBodyHash,
+  decisionFileName,
+  decisionsDir,
+  loadDecisions,
+  writeDecision,
+  type DecisionAnchor,
+  type DecisionRecord,
+} from "../src/store/decisions.js";
+
+/** `reposkein-mcp adr reanchor` CLI end-to-end (REP-24), against a REAL
+ *  JsonlGraphStore (buildStore picks it up from `.reposkein/nodes.jsonl`) and
+ *  real decision files on disk — no fakeStore here, planReanchor/applyReanchor
+ *  already have unit coverage in test/reanchor.test.ts. */
+
+const REPO_ID = "adr-reanchor-cli-test";
+
+/** Writes `.reposkein/meta.json` (so resolveRepoId/buildStore resolve a real
+ *  repo id) + `.reposkein/nodes.jsonl` (row shape per
+ *  test/jsonlGraphStore.test.ts). */
+function seedGraph(dir: string, nodeLines: string[]): void {
+  const reposkein = join(dir, ".reposkein");
+  mkdirSync(reposkein, { recursive: true });
+  writeFileSync(join(reposkein, "meta.json"), JSON.stringify({ repo_id: REPO_ID }));
+  writeFileSync(join(reposkein, "nodes.jsonl"), nodeLines.map((l) => l + "\n").join(""));
+}
+
+/** A single Function node row named `f` at `path`. */
+function funcNodeLine(path: string, hash: string): string {
+  return JSON.stringify({
+    id: `rs1:${REPO_ID}:func:${path}#f@0`,
+    labels: ["Function"],
+    content_hash: hash,
+    name: "f",
+    qualified_name: "f",
+    file_path: path,
+    start_line: 1,
+    end_line: 2,
+  });
+}
+
+/** Writes a decision record with one anchor and returns it. */
+function seedDecision(dir: string, id: string, anchor: DecisionAnchor): DecisionRecord {
+  const rec: DecisionRecord = {
+    id,
+    title: `Title ${id}`,
+    status: "accepted",
+    context: "ctx",
+    decision: "We decided.",
+    anchors: [anchor],
+    paths: [],
+    supersedes: [],
+    decided_at: "2026-08-01",
+    decided_by: "agent",
+    trigger: { kind: "manual" },
+    body_hash: "",
+  };
+  rec.body_hash = computeBodyHash(rec);
+  writeDecision(dir, rec);
+  return rec;
+}
+
+function recFilePath(dir: string, id: string): string {
+  return join(decisionsDir(dir), decisionFileName(id));
+}
+
+const today = () => "2026-08-23";
+
+describe("adr reanchor CLI", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "adr-reanchor-cli-"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("repairs a renamed node and exits 0", async () => {
+    seedGraph(dir, [funcNodeLine("src/new.py", "h1")]);
+    seedDecision(dir, "adr:2026-08-01-rename", {
+      node_id: `rs1:${REPO_ID}:func:src/old.py#f@0`,
+      path: "src/old.py",
+      name: "f",
+      kind: "Function",
+      hash: "h1",
+    });
+
+    const code = await runAdrReanchor([dir], undefined, { today });
+
+    expect(code).toBe(0);
+    const rec = loadDecisions(dir).decisions[0]!;
+    expect(rec.anchors[0]!.node_id).toBe(`rs1:${REPO_ID}:func:src/new.py#f@0`);
+    expect(rec.anchors[0]!.path).toBe("src/new.py");
+    expect(rec.reanchored_at).toBe("2026-08-23");
+  });
+
+  it("--dry-run is side-effect-free and still exits 0", async () => {
+    seedGraph(dir, [funcNodeLine("src/new.py", "h1")]);
+    const id = "adr:2026-08-01-rename";
+    seedDecision(dir, id, {
+      node_id: `rs1:${REPO_ID}:func:src/old.py#f@0`,
+      path: "src/old.py",
+      name: "f",
+      kind: "Function",
+      hash: "h1",
+    });
+    const recFile = recFilePath(dir, id);
+    const before = readFileSync(recFile, "utf8");
+
+    const code = await runAdrReanchor([dir, "--dry-run"], undefined, { today });
+
+    expect(code).toBe(0);
+    expect(readFileSync(recFile, "utf8")).toBe(before);
+    // loadDecisions confirms the record on disk truly never moved (no
+    // reanchored_at stamped), not just that a copy in memory was untouched.
+    expect(loadDecisions(dir).decisions[0]!.reanchored_at).toBeUndefined();
+  });
+
+  it("exits 1 when unresolved anchors remain, leaving them untouched", async () => {
+    seedGraph(dir, [funcNodeLine("src/live.py", "hlive")]);
+    const id = "adr:2026-08-01-orphan";
+    seedDecision(dir, id, {
+      node_id: `rs1:${REPO_ID}:func:src/gone.py#f@0`,
+      path: "src/gone.py",
+      name: "f",
+      kind: "Function",
+      hash: "hnomatch",
+    });
+    const recFile = recFilePath(dir, id);
+    const before = readFileSync(recFile, "utf8");
+
+    const code = await runAdrReanchor([dir], undefined, { today });
+
+    expect(code).toBe(1);
+    expect(readFileSync(recFile, "utf8")).toBe(before);
+  });
+
+  it("--id limits scope and exits 2 on an unknown id", async () => {
+    seedGraph(dir, [funcNodeLine("src/new.py", "h1")]);
+    seedDecision(dir, "adr:2026-08-01-rename", {
+      node_id: `rs1:${REPO_ID}:func:src/old.py#f@0`,
+      path: "src/old.py",
+      name: "f",
+      kind: "Function",
+      hash: "h1",
+    });
+
+    const code = await runAdrReanchor([dir, "--id", "adr:nope"], undefined, { today });
+
+    expect(code).toBe(2);
+  });
+
+  it("--id with no following value exits 2", async () => {
+    seedGraph(dir, [funcNodeLine("src/new.py", "h1")]);
+
+    const code = await runAdrReanchor([dir, "--id"], undefined, { today });
+
+    expect(code).toBe(2);
+  });
+
+  it("--id scoped to one decision reanchors only that one, leaving a sibling untouched", async () => {
+    seedGraph(dir, [funcNodeLine("src/new.py", "h1")]);
+    const targetId = "adr:2026-08-01-rename";
+    const siblingId = "adr:2026-08-01-orphan";
+    seedDecision(dir, targetId, {
+      node_id: `rs1:${REPO_ID}:func:src/old.py#f@0`,
+      path: "src/old.py",
+      name: "f",
+      kind: "Function",
+      hash: "h1",
+    });
+    seedDecision(dir, siblingId, {
+      node_id: `rs1:${REPO_ID}:func:src/gone.py#f@0`,
+      path: "src/gone.py",
+      name: "f",
+      kind: "Function",
+      hash: "hnomatch",
+    });
+    const siblingFile = recFilePath(dir, siblingId);
+    const siblingBefore = readFileSync(siblingFile, "utf8");
+
+    const code = await runAdrReanchor([dir, "--id", targetId], undefined, { today });
+
+    expect(code).toBe(0);
+    const { decisions } = loadDecisions(dir);
+    expect(decisions.find((d) => d.id === targetId)!.anchors[0]!.path).toBe("src/new.py");
+    expect(readFileSync(siblingFile, "utf8")).toBe(siblingBefore);
+  });
+
+  it("exits 2 when no graph exists", async () => {
+    seedDecision(dir, "adr:2026-08-01-nograph", {
+      node_id: `rs1:${REPO_ID}:func:src/x.py#f@0`,
+      path: "src/x.py",
+      name: "f",
+      kind: "Function",
+      hash: "h1",
+    });
+
+    const code = await runAdrReanchor([dir], undefined, { today });
+
+    expect(code).toBe(2);
+  });
+});

--- a/mcp/test/adsGating.test.ts
+++ b/mcp/test/adsGating.test.ts
@@ -239,6 +239,7 @@ describe("ads placement policy", () => {
       "record_decision",
       "set_decision_status",
       "reaffirm_decision",
+      "reanchor_decision",
       "reindex_file",
       "init_cpg_skeleton",
     ]) {

--- a/mcp/test/decisionSchemas.test.ts
+++ b/mcp/test/decisionSchemas.test.ts
@@ -4,6 +4,7 @@ import {
   getDecisionInputSchema,
   listDecisionsInputSchema,
   reaffirmDecisionInputSchema,
+  reanchorDecisionInputSchema,
   recordDecisionInputSchema,
   setDecisionStatusInputSchema,
 } from "../src/index.js";
@@ -28,6 +29,7 @@ const SCHEMAS = {
   record_decision: recordDecisionInputSchema,
   set_decision_status: setDecisionStatusInputSchema,
   reaffirm_decision: reaffirmDecisionInputSchema,
+  reanchor_decision: reanchorDecisionInputSchema,
   list_decisions: listDecisionsInputSchema,
   get_decision: getDecisionInputSchema,
 };

--- a/mcp/test/decisionsStore.test.ts
+++ b/mcp/test/decisionsStore.test.ts
@@ -6,10 +6,12 @@ import { fakeStore } from "./fakeStore.js";
 import type { TargetRow } from "../src/profile/types.js";
 import {
   computeBodyHash,
+  computeBodyHashV1,
   decisionsDir,
   loadDecisions,
   mintDecisionId,
   resolveAnchorStates,
+  verifyBodyHash,
   writeDecision,
   type DecisionRecord,
 } from "../src/store/decisions.js";
@@ -210,6 +212,58 @@ describe("decisions store", () => {
       const states = await resolveAnchorStates(store, ["otherrepo"], anchors);
       expect(states[0]!.state).toBe("current");
       expect(states[0]!.resolved_node_id).toBe(live.id);
+    });
+  });
+
+  describe("body_hash v2", () => {
+    it("computeBodyHash stamps a v2: prefix and ignores anchor node ids", () => {
+      const a = record({ body_hash: "" });
+      const b = record({ body_hash: "", anchors: [] });
+      expect(computeBodyHash(a).startsWith("v2:")).toBe(true);
+      expect(computeBodyHash(a)).toBe(computeBodyHash(b)); // anchors out of the hash
+    });
+
+    it("v2 hash still covers prose and paths", () => {
+      const a = record({ body_hash: "" });
+      expect(computeBodyHash(a)).not.toBe(computeBodyHash(record({ body_hash: "", decision: "changed" })));
+      expect(computeBodyHash(a)).not.toBe(computeBodyHash(record({ body_hash: "", paths: ["other/"] })));
+    });
+
+    it("verifyBodyHash accepts legacy v1-signed records and rejects tampered ones", () => {
+      const legacy = record({ body_hash: "" });
+      legacy.body_hash = computeBodyHashV1(legacy);
+      expect(legacy.body_hash.startsWith("v2:")).toBe(false);
+      expect(verifyBodyHash(legacy)).toBe(true);
+      expect(verifyBodyHash({ ...legacy, decision: "edited" })).toBe(false);
+      const modern = record({ body_hash: "" });
+      modern.body_hash = computeBodyHash(modern);
+      expect(verifyBodyHash(modern)).toBe(true);
+      expect(verifyBodyHash({ ...modern, context: "edited" })).toBe(false);
+    });
+
+    it("v2 hash is independent of reanchored_at and anchor_history", () => {
+      const a = record({ body_hash: "" });
+      const b: DecisionRecord = {
+        ...record({ body_hash: "" }),
+        reanchored_at: "2026-08-23",
+        anchor_history: [{ reanchored_at: "2026-08-23", anchors: a.anchors }],
+      };
+      expect(computeBodyHash(a)).toBe(computeBodyHash(b));
+    });
+
+    it("reanchored_at and anchor_history round-trip through write/load", () => {
+      const rec: DecisionRecord = {
+        ...record({ body_hash: "" }),
+        reanchored_at: "2026-08-23",
+        anchor_history: [{ reanchored_at: "2026-08-23", anchors: record({}).anchors }],
+      };
+      rec.body_hash = computeBodyHash(rec);
+      writeDecision(root, rec);
+      const loaded = loadDecisions(root).decisions.find((d) => d.id === rec.id)!;
+      expect(loaded.reanchored_at).toBe("2026-08-23");
+      expect(loaded.anchor_history).toHaveLength(1);
+      expect(loaded.anchor_history![0]!.anchors[0]!.node_id).toBe(record({}).anchors[0]!.node_id);
+      expect(verifyBodyHash(loaded)).toBe(true);
     });
   });
 });

--- a/mcp/test/decisionsStore.test.ts
+++ b/mcp/test/decisionsStore.test.ts
@@ -140,6 +140,26 @@ describe("decisions store", () => {
     expect(warnings).toHaveLength(2);
   });
 
+  it("treats a path-escaping id as malformed (never parsed, never rewritten)", () => {
+    // The id is path-derived (decisionFileName/writeDecision join it under
+    // decisions dir); an id like `adr:../../evil` must not survive parsing —
+    // any writer (reaffirm, set_decision_status, reanchor) could otherwise be
+    // made to write outside .reposkein/decisions/.
+    mkdirSync(decisionsDir(root), { recursive: true });
+    const write = (name: string, id: string) =>
+      writeFileSync(join(decisionsDir(root), name), JSON.stringify({ ...record(), id }) + "\n");
+    write("evil1.json", "adr:../../evil");
+    write("evil2.json", "adr:a/b");
+    write("evil3.json", "adr:a\\b");
+    write("ok.json", record().id);
+
+    const { decisions, warnings } = loadDecisions(root);
+
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]!.id).toBe(record().id);
+    expect(warnings).toHaveLength(3);
+  });
+
   it("keeps the higher-precedence status when two files carry the same id", () => {
     // Merge damage: same id in two files. superseded > deprecated > rejected > accepted > proposed.
     const a = record({ status: "accepted" });

--- a/mcp/test/doctor.test.ts
+++ b/mcp/test/doctor.test.ts
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runChecks, resolveDoctorRepoPath, runDoctor, ciFailingChecks } from "../src/cli/doctor.js";
-import { decisionChecks } from "../src/cli/doctorDecisions.js";
+import { decisionChecks, anchorStateChecks } from "../src/cli/doctorDecisions.js";
 import { computeBodyHash, writeDecision, decisionsDir, type DecisionRecord } from "../src/store/decisions.js";
 import { writeIndexedAtMarker } from "../src/store/indexedAt.js";
 
@@ -183,6 +183,119 @@ describe("doctor decision checks", () => {
     const budget = decisionChecks(dir).find((c) => c.id === "decisions_budget")!;
     expect(budget.ok).toBe(false);
     expect(budget.detail).toMatch(/101/);
+  });
+});
+
+describe("anchorStateChecks", () => {
+  it("returns [] with no graph or no anchored decisions", async () => {
+    // No graph at all, but an anchored decision exists.
+    seedDecision("adr:2026-08-01-a", {
+      anchors: [{ node_id: "rs1:repoa:func:svc.py#f@0", path: "svc.py", name: "f", kind: "Function", hash: "h1" }],
+    });
+    expect(await anchorStateChecks(dir, "repoa")).toEqual([]);
+
+    // Graph present, but every decision's anchors array is empty.
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(
+      join(dir, ".reposkein", "nodes.jsonl"),
+      `{"id":"rs1:repoa:func:svc.py#f@0","labels":["Function"],"content_hash":"h1","file_path":"svc.py","name":"f","qualified_name":"f"}\n`
+    );
+    rmSync(join(decisionsDir(dir), "2026-08-01-a.json"));
+    seedDecision("adr:2026-08-02-b"); // no overrides -> anchors: []
+    expect(await anchorStateChecks(dir, "repoa")).toEqual([]);
+  });
+
+  it("returns [] when repoId is null even though anchors + graph exist", async () => {
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(
+      join(dir, ".reposkein", "nodes.jsonl"),
+      `{"id":"rs1:repoa:func:svc.py#f@0","labels":["Function"],"content_hash":"h1","file_path":"svc.py","name":"f","qualified_name":"f"}\n`
+    );
+    seedDecision("adr:2026-08-01-a", {
+      anchors: [{ node_id: "rs1:repoa:func:svc.py#f@0", path: "svc.py", name: "f", kind: "Function", hash: "h1" }],
+    });
+    expect(await anchorStateChecks(dir, null)).toEqual([]);
+  });
+
+  it("ok when every anchor is current", async () => {
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    writeFileSync(
+      join(dir, ".reposkein", "nodes.jsonl"),
+      `{"id":"rs1:repoa:func:svc.py#current@0","labels":["Function"],"content_hash":"hash-current","file_path":"svc.py","name":"current","qualified_name":"current"}\n`
+    );
+    seedDecision("adr:2026-08-01-a", {
+      anchors: [
+        {
+          node_id: "rs1:repoa:func:svc.py#current@0",
+          path: "svc.py",
+          name: "current",
+          kind: "Function",
+          hash: "hash-current",
+        },
+      ],
+    });
+    const checks = await anchorStateChecks(dir, "repoa");
+    const c = checks.find((x) => x.id === "decisions_anchors")!;
+    expect(c.ok).toBe(true);
+    expect(c.critical).toBe(false);
+    expect(c.detail).toBe("all anchors current");
+    expect(c.fix).toBeUndefined();
+  });
+
+  it("flags moved/stale/orphaned with counts and a reanchor fix", async () => {
+    mkdirSync(join(dir, ".reposkein"), { recursive: true });
+    // Three live nodes: one backs a "current" anchor unchanged, one backs a
+    // "stale" anchor (same id, content changed), and one backs a "moved"
+    // anchor under a DIFFERENT id but the SAME content_hash (the only signal
+    // that survives a rename). No node backs the "orphaned" anchor at all.
+    writeFileSync(
+      join(dir, ".reposkein", "nodes.jsonl"),
+      [
+        `{"id":"rs1:repoa:func:svc.py#current@0","labels":["Function"],"content_hash":"hash-current","file_path":"svc.py","name":"current","qualified_name":"current"}`,
+        `{"id":"rs1:repoa:func:svc.py#stale@0","labels":["Function"],"content_hash":"hash-stale-new","file_path":"svc.py","name":"stale","qualified_name":"stale"}`,
+        `{"id":"rs1:repoa:func:svc.py#movedTarget@0","labels":["Function"],"content_hash":"hash-moved","file_path":"svc.py","name":"movedTarget","qualified_name":"movedTarget"}`,
+      ].join("\n") + "\n"
+    );
+    seedDecision("adr:2026-08-01-a", {
+      anchors: [
+        {
+          node_id: "rs1:repoa:func:svc.py#current@0",
+          path: "svc.py",
+          name: "current",
+          kind: "Function",
+          hash: "hash-current",
+        },
+        {
+          node_id: "rs1:repoa:func:svc.py#stale@0",
+          path: "svc.py",
+          name: "stale",
+          kind: "Function",
+          hash: "hash-stale-old",
+        },
+        {
+          node_id: "rs1:repoa:func:svc.py#movedOld@0",
+          path: "svc.py",
+          name: "movedOld",
+          kind: "Function",
+          hash: "hash-moved",
+        },
+        {
+          node_id: "rs1:repoa:func:svc.py#gone@0",
+          path: "svc.py",
+          name: "gone",
+          kind: "Function",
+          hash: "hash-orphan-nomatch",
+        },
+      ],
+    });
+    const checks = await anchorStateChecks(dir, "repoa");
+    expect(checks).toHaveLength(1);
+    const c = checks.find((x) => x.id === "decisions_anchors")!;
+    expect(c.ok).toBe(false);
+    expect(c.critical).toBe(false);
+    expect(c.detail).toMatch(/moved/);
+    expect(c.detail).toBe("1 moved, 1 stale, 1 orphaned");
+    expect(c.fix).toMatch(/adr reanchor/);
   });
 });
 

--- a/mcp/test/reanchor.test.ts
+++ b/mcp/test/reanchor.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fakeStore } from "./fakeStore.js";
+import type { TargetRow } from "../src/profile/types.js";
+import {
+  computeBodyHash,
+  loadDecisions,
+  verifyBodyHash,
+  writeDecision,
+  type DecisionRecord,
+} from "../src/store/decisions.js";
+import { applyReanchor, planReanchor } from "../src/store/reanchor.js";
+
+const REPO = "r1";
+const node = (id: string, over: Partial<TargetRow> = {}): TargetRow => ({
+  id,
+  repo_id: REPO,
+  name: "f",
+  qualified_name: "mod.f",
+  file_path: "src/new.py",
+  start_line: 1,
+  end_line: 2,
+  semantic_summary: null,
+  summary_of_hash: null,
+  content_hash: "h1",
+  labels: ["Function"],
+  ...over,
+});
+
+const rec = (over: Partial<DecisionRecord> = {}): DecisionRecord => {
+  const base: DecisionRecord = {
+    id: "adr:2026-08-01-x",
+    title: "X",
+    status: "accepted",
+    context: "ctx",
+    decision: "dec",
+    anchors: [
+      { node_id: `rs1:${REPO}:func:src/old.py#f@0`, path: "src/old.py", name: "mod.f", kind: "Function", hash: "h1" },
+    ],
+    paths: [],
+    supersedes: [],
+    decided_at: "2026-08-01",
+    decided_by: "agent",
+    trigger: { kind: "manual" },
+    body_hash: "",
+    ...over,
+  };
+  base.body_hash = computeBodyHash(base);
+  return base;
+};
+
+describe("planReanchor", () => {
+  it("keeps a live, unchanged anchor", async () => {
+    const store = fakeStore({
+      getNode: async (_ids, id) =>
+        id === `rs1:${REPO}:func:src/old.py#f@0` ? node(id, { file_path: "src/old.py" }) : null,
+    });
+    const plan = await planReanchor(store, [REPO], rec());
+    expect(plan.anchors[0]!.action).toBe("keep");
+    expect(plan.changed).toBe(false);
+    expect(plan.unresolved).toBe(0);
+  });
+
+  it("marks stale (id live, content changed) and does not rebind it", async () => {
+    const store = fakeStore({
+      getNode: async (_ids, id) =>
+        id === `rs1:${REPO}:func:src/old.py#f@0` ? node(id, { content_hash: "h2" }) : null,
+    });
+    const plan = await planReanchor(store, [REPO], rec());
+    expect(plan.anchors[0]!.action).toBe("stale");
+    expect(plan.changed).toBe(false);
+  });
+
+  it("rebinds via repo_id-suffix match, preserving the recorded hash", async () => {
+    const r = rec({
+      anchors: [{ node_id: "rs1:oldrepo:func:src/old.py#f@0", path: "src/old.py", name: "mod.f", kind: "Function", hash: "hstale" }],
+    });
+    const liveId = `rs1:${REPO}:func:src/old.py#f@0`;
+    const store = fakeStore({
+      getNode: async (_ids, id) => (id === liveId ? node(liveId, { content_hash: "hnew" }) : null),
+      findByContentHash: async () => [node(liveId)],
+    });
+    const plan = await planReanchor(store, [REPO], r);
+    expect(plan.anchors[0]!.action).toBe("rebind");
+    expect(plan.anchors[0]!.to!.node_id).toBe(liveId);
+    // pointer repaired, staleness preserved for reaffirm to judge:
+    expect(plan.anchors[0]!.to!.hash).toBe("hstale");
+    expect(plan.changed).toBe(true);
+  });
+
+  it("rebinds a dead id via a UNIQUE content-hash match", async () => {
+    const liveId = `rs1:${REPO}:func:src/new.py#f@0`;
+    const store = fakeStore({
+      getNode: async () => null,
+      findByContentHash: async (_ids, hash) => (hash === "h1" ? [node(liveId)] : []),
+    });
+    const plan = await planReanchor(store, [REPO], rec());
+    const e = plan.anchors[0]!;
+    expect(e.action).toBe("rebind");
+    expect(e.to).toEqual({ node_id: liveId, path: "src/new.py", name: "mod.f", kind: "Function", hash: "h1" });
+  });
+
+  it("reports ambiguous on multiple content-hash matches, never guessing", async () => {
+    const store = fakeStore({
+      getNode: async () => null,
+      findByContentHash: async () => [node("rs1:r1:func:a#f@0"), node("rs1:r1:func:b#f@0")],
+    });
+    const plan = await planReanchor(store, [REPO], rec());
+    expect(plan.anchors[0]!.action).toBe("ambiguous");
+    expect(plan.anchors[0]!.candidates).toBe(2);
+    expect(plan.changed).toBe(false);
+    expect(plan.unresolved).toBe(1);
+  });
+
+  it("reports orphaned when nothing matches (and when the store lacks findByContentHash)", async () => {
+    const plan = await planReanchor(fakeStore({ getNode: async () => null, findByContentHash: async () => [] }), [REPO], rec());
+    expect(plan.anchors[0]!.action).toBe("orphaned");
+    const noHashLookup = await planReanchor(fakeStore({ getNode: async () => null }), [REPO], rec());
+    expect(noHashLookup.anchors[0]!.action).toBe("orphaned");
+    expect(noHashLookup.unresolved).toBe(1);
+  });
+});
+
+describe("applyReanchor", () => {
+  let dir: string;
+  beforeEach(() => (dir = mkdtempSync(join(tmpdir(), "reanchor-"))));
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const rebindStore = (liveId: string) =>
+    fakeStore({ getNode: async () => null, findByContentHash: async () => [node(liveId)] });
+
+  it("writes rebinds, stamps reanchored_at + anchor_history, re-signs v2, and never touches prose", async () => {
+    const original = rec();
+    writeDecision(dir, original);
+    const plan = await planReanchor(rebindStore(`rs1:${REPO}:func:src/new.py#f@0`), [REPO], original);
+    const updated = applyReanchor(dir, original, plan, "2026-08-23")!;
+    const loaded = loadDecisions(dir).decisions[0]!;
+    expect(loaded.anchors[0]!.node_id).toBe(`rs1:${REPO}:func:src/new.py#f@0`);
+    expect(loaded.reanchored_at).toBe("2026-08-23");
+    expect(loaded.anchor_history).toEqual([{ reanchored_at: "2026-08-23", anchors: original.anchors }]);
+    expect(loaded.body_hash.startsWith("v2:")).toBe(true);
+    expect(verifyBodyHash(loaded)).toBe(true);
+    // prose/body untouched — v2 hash core equality is the byte-level proof:
+    expect(computeBodyHash(loaded)).toBe(computeBodyHash(original));
+    expect(updated.decision).toBe(original.decision);
+  });
+
+  it("is a no-op (returns null, writes nothing) when the plan has no rebinds", async () => {
+    const original = rec();
+    writeDecision(dir, original);
+    const plan = await planReanchor(fakeStore({ getNode: async () => null, findByContentHash: async () => [] }), [REPO], original);
+    expect(applyReanchor(dir, original, plan, "2026-08-23")).toBeNull();
+    const loaded = loadDecisions(dir).decisions[0]!;
+    expect(loaded.reanchored_at).toBeUndefined();
+    expect(loaded.body_hash).toBe(original.body_hash);
+  });
+
+  it("second reanchor after a repair is a no-op (idempotent/deterministic)", async () => {
+    const original = rec();
+    writeDecision(dir, original);
+    const liveId = `rs1:${REPO}:func:src/new.py#f@0`;
+    const store = fakeStore({
+      getNode: async (_ids, id) => (id === liveId ? node(liveId) : null),
+      findByContentHash: async () => [node(liveId)],
+    });
+    const first = applyReanchor(dir, original, await planReanchor(store, [REPO], original), "2026-08-23")!;
+    const second = await planReanchor(store, [REPO], first);
+    expect(second.changed).toBe(false);
+    expect(applyReanchor(dir, first, second, "2026-08-24")).toBeNull();
+  });
+});

--- a/mcp/test/reanchorScenario.test.ts
+++ b/mcp/test/reanchorScenario.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  computeBodyHash,
+  decisionFileName,
+  decisionsDir,
+  loadDecisions,
+  verifyBodyHash,
+  writeDecision,
+  type DecisionAnchor,
+  type DecisionRecord,
+} from "../src/store/decisions.js";
+import { runAdrReanchor } from "../src/cli/adrReanchor.js";
+import { makeReanchorDecision } from "../src/tools/reanchorDecision.js";
+import { anchorStateChecks } from "../src/cli/doctorDecisions.js";
+import { JsonlGraphStore } from "../src/store/JsonlGraphStore.js";
+
+const REPO = "scenario";
+const TODAY = () => "2026-08-23";
+
+const nodesV1 = [
+  `{"id":"rs1:${REPO}:func:src/auth.py#check_token@0","labels":["Function"],"content_hash":"cht","file_path":"src/auth.py","name":"check_token","qualified_name":"check_token","start_line":1,"end_line":9}`,
+  `{"id":"rs1:${REPO}:func:src/auth.py#login@0","labels":["Function"],"content_hash":"chl","file_path":"src/auth.py","name":"login","qualified_name":"login","start_line":10,"end_line":20}`,
+].join("\n") + "\n";
+// The rename: file moved src/auth.py -> src/security/auth.py, ids/paths churn,
+// content hashes survive (pure rename) except login also changed content.
+const nodesV2 = [
+  `{"id":"rs1:${REPO}:func:src/security/auth.py#check_token@0","labels":["Function"],"content_hash":"cht","file_path":"src/security/auth.py","name":"check_token","qualified_name":"check_token","start_line":1,"end_line":9}`,
+  `{"id":"rs1:${REPO}:func:src/security/auth.py#login@0","labels":["Function"],"content_hash":"chl2","file_path":"src/security/auth.py","name":"login","qualified_name":"login","start_line":10,"end_line":21}`,
+].join("\n") + "\n";
+
+/** Seeds `.reposkein/{meta.json,nodes.jsonl,edges.jsonl}` so resolveRepoId(dir)
+ *  === REPO (meta.json's repo_id field, per src/store/repoId.ts) and buildStore
+ *  finds a real graph — mirrors test/adrReanchor.test.ts's seedGraph. */
+function seedFixture(dir: string, nodes: string): void {
+  const reposkein = join(dir, ".reposkein");
+  mkdirSync(reposkein, { recursive: true });
+  writeFileSync(join(reposkein, "meta.json"), JSON.stringify({ repo_id: REPO }));
+  writeFileSync(join(reposkein, "nodes.jsonl"), nodes);
+  writeFileSync(join(reposkein, "edges.jsonl"), "");
+}
+
+function recFile(dir: string, id: string): string {
+  return join(decisionsDir(dir), decisionFileName(id));
+}
+
+const CHECK_TOKEN_ID = "adr:2026-08-01-check-token-guard";
+const LOGIN_ID = "adr:2026-08-01-login-flow";
+
+function baseRecord(id: string, title: string, anchor: DecisionAnchor, path: string): DecisionRecord {
+  const rec: DecisionRecord = {
+    id,
+    title,
+    status: "accepted",
+    context: `Context for ${title}.`,
+    decision: `We decided about ${title}.`,
+    anchors: [anchor],
+    paths: [path],
+    supersedes: [],
+    decided_at: "2026-08-01",
+    decided_by: "agent",
+    trigger: { kind: "manual" },
+    body_hash: "",
+  };
+  rec.body_hash = computeBodyHash(rec);
+  return rec;
+}
+
+/** Writes both scenario decisions against `dir`'s current graph state and
+ *  returns them. Deterministic content -> deterministic body_hash, so the
+ *  same call against two fixtures (dir, dir2) produces byte-identical files. */
+function seedDecisions(dir: string): { checkToken: DecisionRecord; login: DecisionRecord } {
+  const checkToken = baseRecord(
+    CHECK_TOKEN_ID,
+    "Guard check_token against replay",
+    {
+      node_id: `rs1:${REPO}:func:src/auth.py#check_token@0`,
+      path: "src/auth.py",
+      name: "check_token",
+      kind: "Function",
+      hash: "cht",
+    },
+    "src/auth.py"
+  );
+  const login = baseRecord(
+    LOGIN_ID,
+    "Rate-limit the login flow",
+    {
+      node_id: `rs1:${REPO}:func:src/auth.py#login@0`,
+      path: "src/auth.py",
+      name: "login",
+      kind: "Function",
+      hash: "chl",
+    },
+    "src/auth.py"
+  );
+  writeDecision(dir, checkToken);
+  writeDecision(dir, login);
+  return { checkToken, login };
+}
+
+describe("REP-24 origin scenario: rename -> reanchor -> repaired", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mktempScenarioDir();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function mktempScenarioDir(): string {
+    const d = mkdtempSync(join(tmpdir(), "reanchor-scenario-"));
+    seedFixture(d, nodesV1);
+    return d;
+  }
+
+  it("repairs renamed anchors in one command; prose byte-identical; partial reported; idempotent", async () => {
+    // 1. record two decisions anchored on check_token (pure rename -> repairable)
+    //    and login (rename + content change -> orphaned, unrepairable), via
+    //    writeDecision with hashes cht / chl and body_hash = computeBodyHash(rec).
+    const { checkToken, login } = seedDecisions(dir);
+    const checkTokenFile = recFile(dir, checkToken.id);
+    const loginFile = recFile(dir, login.id);
+    const checkTokenInitialBytes = readFileSync(checkTokenFile, "utf8");
+    const loginInitialBytes = readFileSync(loginFile, "utf8");
+
+    // 2. simulate the rename: overwrite nodes.jsonl with nodesV2.
+    writeFileSync(join(dir, ".reposkein", "nodes.jsonl"), nodesV2);
+
+    // 3. dry-run first: exit 1 (login unresolved), files byte-identical before/after.
+    const dryRunCode = await runAdrReanchor([dir, "--dry-run"], undefined, { today: TODAY });
+    expect(dryRunCode).toBe(1);
+    expect(readFileSync(checkTokenFile, "utf8")).toBe(checkTokenInitialBytes);
+    expect(readFileSync(loginFile, "utf8")).toBe(loginInitialBytes);
+
+    // 4. real run: exit 1 (partial — login still unresolved).
+    const realRunCode = await runAdrReanchor([dir], undefined, { today: TODAY });
+    expect(realRunCode).toBe(1);
+
+    //    - check_token decision: anchor now rs1:…:func:src/security/auth.py#check_token@0,
+    //      path src/security/auth.py, reanchored_at stamped, anchor_history has the
+    //      old anchor, verifyBodyHash true, and computeBodyHash(after) === computeBodyHash(before)
+    //      (anchor-independent v2 hash — the "bodies byte-identical" gate), plus direct
+    //      field equality on title/context/decision/paths/decided_at/decided_by.
+    const afterFirstRun = loadDecisions(dir).decisions;
+    const checkTokenAfter = afterFirstRun.find((d) => d.id === checkToken.id)!;
+    expect(checkTokenAfter.anchors).toHaveLength(1);
+    expect(checkTokenAfter.anchors[0]!.node_id).toBe(
+      `rs1:${REPO}:func:src/security/auth.py#check_token@0`
+    );
+    expect(checkTokenAfter.anchors[0]!.path).toBe("src/security/auth.py");
+    expect(checkTokenAfter.reanchored_at).toBe("2026-08-23");
+    expect(checkTokenAfter.anchor_history).toBeDefined();
+    expect(checkTokenAfter.anchor_history).toHaveLength(1);
+    expect(checkTokenAfter.anchor_history![0]!.anchors).toEqual(checkToken.anchors);
+    expect(verifyBodyHash(checkTokenAfter)).toBe(true);
+    expect(computeBodyHash(checkTokenAfter)).toBe(computeBodyHash(checkToken));
+    expect(checkTokenAfter.title).toBe(checkToken.title);
+    expect(checkTokenAfter.context).toBe(checkToken.context);
+    expect(checkTokenAfter.decision).toBe(checkToken.decision);
+    expect(checkTokenAfter.paths).toEqual(checkToken.paths);
+    expect(checkTokenAfter.decided_at).toBe(checkToken.decided_at);
+    expect(checkTokenAfter.decided_by).toBe(checkToken.decided_by);
+
+    //    - login decision: file bytes IDENTICAL to before the run (orphaned -> untouched).
+    expect(readFileSync(loginFile, "utf8")).toBe(loginInitialBytes);
+    const loginAfter = afterFirstRun.find((d) => d.id === login.id)!;
+    expect(loginAfter.reanchored_at).toBeUndefined();
+    expect(loginAfter.anchors).toEqual(login.anchors);
+
+    // 5. doctor: anchorStateChecks now reports ok:false only for login's orphan.
+    const checks = await anchorStateChecks(dir, REPO);
+    const anchorCheck = checks.find((c) => c.id === "decisions_anchors")!;
+    expect(anchorCheck).toBeDefined();
+    expect(anchorCheck.ok).toBe(false);
+    expect(anchorCheck.detail).toBe("0 moved, 0 stale, 1 orphaned");
+
+    // 6. determinism/idempotence: run again -> exit 1 again, ALL decision files
+    //    byte-identical to after step 4 (no history growth, no reanchored_at bump).
+    const checkTokenAfterFirstRunBytes = readFileSync(checkTokenFile, "utf8");
+    const loginAfterFirstRunBytes = readFileSync(loginFile, "utf8");
+    const secondRunCode = await runAdrReanchor([dir], undefined, { today: TODAY });
+    expect(secondRunCode).toBe(1);
+    expect(readFileSync(checkTokenFile, "utf8")).toBe(checkTokenAfterFirstRunBytes);
+    expect(readFileSync(loginFile, "utf8")).toBe(loginAfterFirstRunBytes);
+    const afterSecondRun = loadDecisions(dir).decisions;
+    const checkTokenAfterSecondRun = afterSecondRun.find((d) => d.id === checkToken.id)!;
+    expect(checkTokenAfterSecondRun.anchor_history).toHaveLength(1);
+    expect(checkTokenAfterSecondRun.reanchored_at).toBe(checkTokenAfter.reanchored_at);
+
+    // 7. MCP parity: fresh copy of the fixture, same repair via
+    //    makeReanchorDecision(new JsonlGraphStore(dir2, REPO), REPO, dir2,
+    //    { today: () => "2026-08-23" })({}) — same end state as the CLI run.
+    const dir2 = mkdtempSync(join(tmpdir(), "reanchor-scenario-mcp-"));
+    try {
+      seedFixture(dir2, nodesV1);
+      seedDecisions(dir2);
+      writeFileSync(join(dir2, ".reposkein", "nodes.jsonl"), nodesV2);
+
+      const store2 = new JsonlGraphStore(dir2, REPO);
+      const reanchor = makeReanchorDecision(store2, REPO, dir2, { today: TODAY });
+      const res = await reanchor({});
+      expect(res.isError).toBeUndefined();
+      await store2.close();
+
+      const mcpDecisions = loadDecisions(dir2).decisions;
+      const mcpCheckToken = mcpDecisions.find((d) => d.id === checkToken.id)!;
+      const mcpLogin = mcpDecisions.find((d) => d.id === login.id)!;
+
+      expect(mcpCheckToken.anchors).toEqual(checkTokenAfter.anchors);
+      expect(mcpCheckToken.reanchored_at).toBe(checkTokenAfter.reanchored_at);
+      expect(mcpCheckToken.anchor_history).toEqual(checkTokenAfter.anchor_history);
+      expect(mcpLogin.anchors).toEqual(loginAfter.anchors);
+      expect(mcpLogin.reanchored_at).toBe(loginAfter.reanchored_at);
+    } finally {
+      rmSync(dir2, { recursive: true, force: true });
+    }
+  });
+});

--- a/mcp/test/recordDecision.test.ts
+++ b/mcp/test/recordDecision.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { decisionsDir } from "../src/store/decisions.js";
+import { decisionsDir, decisionFileName } from "../src/store/decisions.js";
 import { pendingDeltaPath } from "../src/indexer/decisionsAffected.js";
 import { fakeStore } from "./fakeStore.js";
 import type { TargetRow } from "../src/profile/types.js";
@@ -10,6 +10,7 @@ import { loadDecisions, writeDecision, computeBodyHash, type DecisionRecord } fr
 import { makeRecordDecision } from "../src/tools/recordDecision.js";
 import { makeSetDecisionStatus } from "../src/tools/setDecisionStatus.js";
 import { makeReaffirmDecision } from "../src/tools/reaffirmDecision.js";
+import { makeReanchorDecision } from "../src/tools/reanchorDecision.js";
 
 const REPO_ID = "abc123";
 const NODE_ID = `rs1:${REPO_ID}:func:svc.py#Svc.run@1`;
@@ -365,6 +366,96 @@ describe("reaffirm_decision", () => {
     const store = fakeStore({});
     const reaffirm = makeReaffirmDecision(store, REPO_ID, root);
     const res = await reaffirm({ decision_id: "adr:2026-01-01-nope" });
+    expect(res.isError).toBe(true);
+  });
+});
+
+describe("reanchor_decision", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "reposkein-reanchor-"));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("dry_run reports the plan and writes nothing", async () => {
+    const deadId = `rs1:${REPO_ID}:func:old.py#Svc.run@1`;
+    const rec: DecisionRecord = {
+      id: "adr:2026-08-20-use-x",
+      title: "Use X",
+      status: "accepted",
+      context: "ctx",
+      decision: "We will use X.",
+      anchors: [{ node_id: deadId, path: "old.py", name: "Svc.run", kind: "Function", hash: "h1" }],
+      paths: [],
+      supersedes: [],
+      decided_at: "2026-08-20",
+      decided_by: "agent",
+      trigger: { kind: "manual" },
+      body_hash: "",
+    };
+    rec.body_hash = computeBodyHash(rec);
+    writeDecision(root, rec);
+    const store = fakeStore({
+      getNode: async () => null,
+      findByContentHash: async (_r, hash) => (hash === "h1" ? [liveNode("h1", NODE_ID)] : []),
+    });
+    const before = readFileSync(join(decisionsDir(root), decisionFileName(rec.id)), "utf8");
+    const reanchor = makeReanchorDecision(store, REPO_ID, root, { today: () => "2026-08-23" });
+    const res = await reanchor({ decision_id: rec.id, dry_run: true });
+    expect(res.isError).toBeUndefined();
+    const payload = parse(res) as { dry_run: boolean; results: { anchors: { action: string; to_node_id?: string }[] }[] };
+    expect(payload.dry_run).toBe(true);
+    expect(payload.results[0]!.anchors[0]!.action).toBe("rebind");
+    expect(payload.results[0]!.anchors[0]!.to_node_id).toBe(NODE_ID);
+    expect(readFileSync(join(decisionsDir(root), decisionFileName(rec.id)), "utf8")).toBe(before);
+  });
+
+  it("applies rebinds and reports unresolved anchors without touching them", async () => {
+    const deadId = `rs1:${REPO_ID}:func:old.py#Svc.run@1`;
+    const orphanId = `rs1:${REPO_ID}:func:gone.py#Svc.gone@1`;
+    const rec: DecisionRecord = {
+      id: "adr:2026-08-20-use-x",
+      title: "Use X",
+      status: "accepted",
+      context: "ctx",
+      decision: "We will use X.",
+      anchors: [
+        { node_id: deadId, path: "old.py", name: "Svc.run", kind: "Function", hash: "h1" },
+        { node_id: orphanId, path: "gone.py", name: "Svc.gone", kind: "Function", hash: "h2" },
+      ],
+      paths: [],
+      supersedes: [],
+      decided_at: "2026-08-20",
+      decided_by: "agent",
+      trigger: { kind: "manual" },
+      body_hash: "",
+    };
+    rec.body_hash = computeBodyHash(rec);
+    writeDecision(root, rec);
+    const store = fakeStore({
+      getNode: async () => null,
+      findByContentHash: async (_r, hash) => (hash === "h1" ? [liveNode("h1", NODE_ID)] : []),
+    });
+    const reanchor = makeReanchorDecision(store, REPO_ID, root, { today: () => "2026-08-23" });
+    const res = await reanchor({ decision_id: rec.id });
+    expect(res.isError).toBeUndefined();
+    const payload = parse(res) as {
+      dry_run: boolean;
+      results: { changed: boolean; unresolved: number; anchors: { node_id: string; action: string }[] }[];
+    };
+    expect(payload.dry_run).toBe(false);
+    expect(payload.results[0]!.changed).toBe(true);
+    expect(payload.results[0]!.unresolved).toBe(1);
+    const after = loadDecisions(root).decisions[0]!;
+    expect(after.anchors[0]!.node_id).toBe(NODE_ID);
+    expect(after.anchors[1]).toEqual(rec.anchors[1]);
+    expect(after.reanchored_at).toBe("2026-08-23");
+  });
+
+  it("errors on an unknown decision_id", async () => {
+    const store = fakeStore({});
+    const reanchor = makeReanchorDecision(store, REPO_ID, root);
+    const res = await reanchor({ decision_id: "adr:nope" });
     expect(res.isError).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Implements REP-24: `reposkein-mcp adr reanchor [--dry-run] [--id <adr-id>]` + MCP write tool `reanchor_decision` — repairs stale decision anchors against the current graph after renames/moves, without touching decision prose. Origin: a consuming repo's agent hit 17 stale-anchored records with no repair path short of supersede-spam.

## The central design decision (recorded as a proposed ADR)

`computeBodyHash` previously covered `anchor_node_ids`, so every mechanical anchor re-stamp (reaffirm, and now reanchor) re-signed the body hash — contradicting "anchors are metadata". This PR ships **body_hash v2**: same allowlist minus anchors, values prefixed `v2:`. Legacy v1 records verify forever via the retained v1 computation (`verifyBodyHash` dispatches on prefix); writers stamp v2 lazily on their next write — no migration sweep. `paths` stays in the hash. Recorded as `adr:2026-08-23-version-the-decision-body-hash-exclude-anchors-v2` (**status: proposed** — awaiting human ratification).

## Semantics: reanchor vs reaffirm vs supersede

- **reanchor** — mechanical pointer repair, no judgment: rebinds on a live id under the current repo_id (suffix match) or a **unique** content-hash match. Ambiguous (>1 match) / orphaned anchors are reported, never guessed, never modified. Staleness flags survive the repair. Stamps `reanchored_at` + previous anchors into `anchor_history` (both outside the hash).
- **reaffirm** — semantic "still correct": restamps hashes, clears stale flags.
- **supersede** — the decision changed.

Docs: new "Anchor lifecycle" section in `docs/TOOLS.md`.

## Also in this PR

- CLI exit codes: 0 clean / 1 partial (unresolved remain) / 2 usage-or-environment error.
- `--dry-run`: full plan, byte-level side-effect-free (tested).
- Doctor check `decisions_anchors`: counts moved/stale/orphaned anchors (advisory, not CI-failing).
- Determinism: injected `reanchored_at` is the only time field; second run on the same graph is a byte-level no-op (tested).
- Origin-scenario integration test: rename → reanchor → repaired; prose byte-identical; idempotent; CLI/MCP parity.
- Hardening from final review: decision ids containing `/`, `\`, or `..` are rejected at parse (closes a pre-existing path-traversal surface for all record writers); store errors exit 2, not 1; `today()` hoisted out of sweep loops.
- Unrelated rider (user-requested): verified Lulu MCPs badge in README (80b11b7).

## Testing

- mcp suite: **1086 passed / 18 skipped** (baseline 1054), `tsc --noEmit` clean.
- Smoke on this repo: `adr reanchor .. --dry-run` correctly reports real drift (legacy-repo-id orphans, stale anchors), makes zero guesses, exits 1, writes nothing.
- All committed decision records (v1-signed included) verify under the dual-scheme.

## Follow-ups (will file)

- Doctor labels 2+-match anchors "moved" while reanchor refuses them as ambiguous — fix text wedge.
- Extract shared suffix-retry helper (`resolveAnchorStates` / `planReanchor` duplication).
- Consider filtering the sweep to active statuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
