### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to RepoSkein. Format roughly follows
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-23
+
+### Added
+
+- **`reposkein-mcp adr reanchor [--dry-run] [--id <adr-id>]` + `reanchor_decision`
+  MCP tool — repair stale decision anchors.** Mechanical pointer repair after
+  renames/moves: an anchor is rebound only on a confident match (its id
+  resolves under the current repo id, or its recorded content hash matches
+  exactly one live node). Ambiguous and orphaned anchors are reported and left
+  untouched — never guessed — and staleness flags survive the repair
+  (clearing them stays `reaffirm_decision`'s job). Repairs stamp
+  `reanchored_at` and keep the previous anchors in `anchor_history`. Exit
+  codes distinguish clean (0) / partial (1) / error (2); `--dry-run` prints
+  the full plan and writes nothing. `doctor` gains a `decisions_anchors`
+  drift count, and `docs/TOOLS.md` documents the anchor lifecycle
+  (reanchor vs reaffirm vs supersede). (#69)
+
+### Changed
+
+- **Decision `body_hash` is now versioned (v2, `"v2:"`-prefixed) and no longer
+  covers anchor node ids** — anchors are machine-managed metadata, so pointer
+  repair and reaffirmation no longer look like body edits. Records signed
+  under the old scheme verify forever and re-sign to v2 on their next write;
+  no migration needed. Mixed-version note: a `doctor` from ≤0.6.x flags
+  v2-signed records as hand-edited (advisory only) — upgrade teams together.
+  Decision ids containing `/`, `\`, or `..` are now rejected at parse,
+  closing a path-traversal surface for all record writers. (#69)
+
+### Fixed
+
+- **Hermetic `doctor` tests.** `doctor.test.ts` now stubs
+  `REPOSKEIN_INDEXER_BIN`, closing the release-bump CI race where a version
+  bump made doctor's binary-version probe fail in CI. (#68)
+
 ## [0.6.1] - 2026-08-22
 
 ### Security

--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -1083,7 +1083,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reposkein-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-indexer"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-common"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "reposkein-core",
  "tree-sitter",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-csharp"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-go"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-java"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-python"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-rust"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-lang-ts"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "reposkein-core",
  "reposkein-lang-common",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "reposkein-neo4j-io"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "neo4rs",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/lang-common", "crates/cli", "crates/lang-python", "crates/lang-ts", "crates/lang-rust", "crates/lang-go", "crates/lang-java", "crates/neo4j-io", "crates/lang-csharp"]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/reposkein/reposkein"

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reposkein/mcp",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reposkein/mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "RepoSkein gives your AI coding agent a map of your codebase — so it navigates structure instead of grepping and guessing.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Minor release: **#69** — `adr reanchor` + `reanchor_decision` MCP tool (stale-anchor repair), versioned `body_hash` v2 excluding anchors (legacy v1 verifies forever, lazy re-sign), decision-id charset guard, doctor `decisions_anchors` drift check, anchor-lifecycle docs; **#68** — hermetic doctor tests (closes the release-bump CI race — this PR is its first beneficiary).

Mixed-version note (also in CHANGELOG): `doctor` from ≤0.6.x flags v2-signed records as hand-edited (advisory only) — upgrade teams together.

After merge: push tag `v0.7.0` → release.yml builds binaries and publishes `@reposkein/mcp@0.7.0` (workflow asserts committed version matches the tag).

mcp suite at bumped version: 1086 passed / 18 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)