### PR TITLE
feat: package RepoSkein as a Claude Code plugin (REP-34)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "reposkein",
+  "description": "Official RepoSkein marketplace — the deterministic code-graph MCP server and its navigation skills, installable as one plugin.",
+  "owner": { "name": "Marcus Nagy Ong", "url": "https://github.com/reposkein" },
+  "plugins": [
+    {
+      "name": "reposkein",
+      "source": { "source": "github", "repo": "reposkein/reposkein" },
+      "displayName": "RepoSkein",
+      "description": "Deterministic code-graph MCP server + navigation skills. Two commands: add this marketplace, install the plugin — the server and skills configure themselves against the current repo.",
+      "keywords": ["mcp", "code-graph", "code-analysis", "adr", "graph-rag"],
+      "category": "integration"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   "plugins": [
     {
       "name": "reposkein",
-      "source": { "source": "github", "repo": "reposkein/reposkein" },
+      "source": "./",
       "displayName": "RepoSkein",
       "description": "Deterministic code-graph MCP server + navigation skills. Two commands: add this marketplace, install the plugin — the server and skills configure themselves against the current repo.",
       "keywords": ["mcp", "code-graph", "code-analysis", "adr", "graph-rag"],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,13 +4,15 @@
   "description": "Deterministic code-graph MCP server: structural navigation, semantic find, impact analysis, and architecture decision records for the current repo. Zero infrastructure — the graph lives in .reposkein/ and the indexer binary is fetched on first run.",
   "author": { "name": "Marcus Nagy Ong" },
   "license": "Apache-2.0",
+  "homepage": "https://reposkein.github.io/reposkein/",
+  "repository": "https://github.com/reposkein/reposkein",
   "keywords": ["mcp", "code-graph", "code-analysis", "adr", "graph-rag"],
   "skills": "./skills/",
   "mcpServers": {
     "reposkein": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@reposkein/mcp"],
+      "args": ["-y", "@reposkein/mcp@0.7.0"],
       "env": {
         "REPOSKEIN_REPO_PATH": "${CLAUDE_PROJECT_DIR}"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "reposkein",
   "displayName": "RepoSkein",
+  "version": "0.7.0",
   "description": "Deterministic code-graph MCP server: structural navigation, semantic find, impact analysis, and architecture decision records for the current repo. Zero infrastructure — the graph lives in .reposkein/ and the indexer binary is fetched on first run.",
   "author": { "name": "Marcus Nagy Ong" },
   "license": "Apache-2.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "reposkein",
+  "displayName": "RepoSkein",
+  "description": "Deterministic code-graph MCP server: structural navigation, semantic find, impact analysis, and architecture decision records for the current repo. Zero infrastructure — the graph lives in .reposkein/ and the indexer binary is fetched on first run.",
+  "author": { "name": "Marcus Nagy Ong" },
+  "license": "Apache-2.0",
+  "keywords": ["mcp", "code-graph", "code-analysis", "adr", "graph-rag"],
+  "skills": "./skills/",
+  "mcpServers": {
+    "reposkein": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@reposkein/mcp"],
+      "env": {
+        "REPOSKEIN_REPO_PATH": "${CLAUDE_PROJECT_DIR}"
+      }
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,10 @@ Keep the viewer's invariants intact: **read-only** (never mutate the committed J
 
 Fork, branch, make focused commits, ensure the gates above pass, and open a PR with a clear description. For new languages or anything touching the resolver/serializer, include the determinism test results in the PR.
 
+## Cutting a release
+
+One release PR bumps `mcp/package.json` (+lock), `indexer/Cargo.toml` (+lock), **and the pinned `@reposkein/mcp@<version>` in `.claude-plugin/plugin.json`** (supply-chain: the plugin never floats `latest`), plus a `CHANGELOG.md` entry. After merge, push the `v<version>` tag — `release.yml` builds binaries and publishes npm, asserting the committed version matches the tag.
+
 By contributing you agree your work is licensed under [Apache-2.0](./LICENSE).
 
 **Support:** [Ko-fi](https://ko-fi.com/mongx) — funds hosted-constellation infra + indexer maintenance.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,23 @@ git clone <repo-url> && cd <repo> && npx @reposkein/mcp init
 
 ## Installation
 
-In the repo you want your agent to understand:
+**Claude Code? Two commands, zero config:**
+
+```
+/plugin marketplace add reposkein/reposkein
+/plugin install reposkein
+```
+
+The plugin registers the MCP server against whatever repo you have open
+(`REPOSKEIN_REPO_PATH` is wired to the project directory) and ships the
+navigation skills as `/reposkein:reposkein-setup` and
+`/reposkein:reposkein-graph-rag` — run the setup skill once per repo to
+build the graph. Optional [embeddings](docs/EMBEDDINGS.md) (Voyage AI or
+any OpenAI-compatible endpoint) work by exporting the `REPOSKEIN_EMBED_*`
+env vars in your shell — the plugin's server inherits them; the default is
+fully local, zero-egress lexical search.
+
+**Any other agent** — in the repo you want it to understand:
 
 ```sh
 npx @reposkein/mcp init


### PR DESCRIPTION
Makes the repo installable as a Claude Code plugin — and its own single-plugin marketplace:

```
/plugin marketplace add reposkein/reposkein
/plugin install reposkein
```

- **`.claude-plugin/plugin.json`** — inline stdio MCP server (`npx -y @reposkein/mcp@0.7.0`, pinned; `REPOSKEIN_REPO_PATH` wired to `${CLAUDE_PROJECT_DIR}` so repo resolution is automatic), existing skills shipped as `/reposkein:reposkein-setup` and `/reposkein:reposkein-graph-rag`, versioned in lockstep with releases.
- **`.claude-plugin/marketplace.json`** — self-sources `./` (no second clone, plugin rides the marketplace commit).
- **README** — two-command install section; embeddings stay opt-in via inherited shell env (`REPOSKEIN_EMBED_*`, Voyage or any OpenAI-compatible endpoint; default local/zero-egress).
- **CONTRIBUTING** — release checklist now includes the plugin pin + version bump.

`claude plugin validate .` passes clean. Security-review findings (unpinned npx, unpinned marketplace source) addressed. Zero-infra invariant untouched — no service, no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)