### PR TITLE
docs: surface the Claude Code plugin at every install front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **[🔭 Live demo →](https://reposkein.github.io/reposkein/)** — RepoSkein's own graph, rendered as an interactive 3D constellation in your browser.
 
-**Get running in one line:** `npx @reposkein/mcp init` — full walkthrough in [Installation](#installation).
+**Get running in one line:** Claude Code: `/plugin marketplace add reposkein/reposkein` · elsewhere: `npx @reposkein/mcp init` — full walkthrough in [Installation](#installation).
 
 </div>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ the [root README's Documentation table](../README.md#documentation).
 
 ## Getting started / joining a team
 
+- **Using Claude Code?** → the [plugin](../README.md#installation): `/plugin marketplace add reposkein/reposkein` then `/plugin install reposkein` — MCP server + skills, wired to the open repo, no config.
 - **Setting up a new repo, workspace, or agent config?** → [`INSTALL.md`](INSTALL.md) — written for agents to execute: a question tree (§1) covering one repo vs workspace, JSONL vs Neo4j, embeddings tier, and which agent CLIs to wire, then step-by-step setup (§2–§7) and troubleshooting (§9).
 - **Joining a repo that already has RepoSkein set up?** → [`INSTALL.md` §0](INSTALL.md#0-joining-an-existing-reposkein-repo) — the one-command `git clone && cd && npx @reposkein/mcp init` path (auto-detects and wires up your agent's config).
 - **Publishing a shareable, always-current view of the graph?** → [`HOSTING.md`](HOSTING.md) — GitHub Pages via `reposkein-mcp init --ci`, or any other static host.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -40,7 +40,7 @@ Agent:  "validate_jwt is called by the login, refresh, and middleware paths;
 
 ### Agent skills
 
-RepoSkein ships two cross-agent [Agent Skills](https://skills.sh) — `npx skills add reposkein/reposkein --all` installs both into Claude Code, Cursor, Codex, and 70+ agents:
+RepoSkein ships two cross-agent [Agent Skills](https://skills.sh). Claude Code users get both automatically with the [plugin](../README.md#installation) (`/plugin install reposkein`, namespaced `/reposkein:…`); everywhere else, `npx skills add reposkein/reposkein --all` installs them into Cursor, Codex, and 70+ agents:
 
 - **`reposkein-setup`** — installs RepoSkein in a repo and verifies it's running (binary → index → MCP reachability). Ask your agent to run it.
 - **`reposkein-graph-rag`** — teaches your agent *when* to use each tool (the loop above), including when to record a decision. `reposkein-mcp init` installs it automatically for Claude Code.


### PR DESCRIPTION
Follow-up to #72 (raced its auto-merge): the top-of-README one-liner, the docs/ front door, and the agent-skills section in TOOLS.md now lead Claude Code users to the two-command plugin path. npx init and skills-CLI paths unchanged for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)